### PR TITLE
fixed typo in LZC

### DIFF
--- a/src/generic/lzc.sv
+++ b/src/generic/lzc.sv
@@ -33,6 +33,6 @@ module lzc #(parameter WIDTH = 1) (
   always_comb begin
     i = 0;
     while (~num[WIDTH-1-i] & (i < WIDTH)) i = i+1;  // search for leading one
-    ZeroCnt = i[$clog2(WIDTH)-1:0];
+    ZeroCnt = i[$clog2(WIDTH+1)-1:0];
   end
 endmodule


### PR DESCRIPTION
I think that the output signal of the LZC should be ceil(log_2(WIDTH+1)) bits wide instead of ceil(log_2(WIDTH)) bits. This would fix a signal width mismatch and a bug where the LZC would fail to count up to WIDTH leading zeros.