### PR TITLE
Update MW reference to recognize memories properly

### DIFF
--- a/synthDC/.synopsys_dc.setup
+++ b/synthDC/.synopsys_dc.setup
@@ -23,7 +23,7 @@ if {$tech == "sky130"} {
     set s10lib $pdk/TSMCHOME/digital/Front_End/timing_power_noise/NLDM/tcbn28hpcplusbwp30p140_180a
     lappend search_path $s10lib
 } elseif {$tech == "tsmc28psyn"} {
-    set TLU /import/yukari1/pdk/TSMC/TLU+
+    set TLU /home/jstine/TLU+
     set pdk /proj/models/tsmc28/libraries/28nmtsmc/tcbn28hpcplusbwp30p140_190a/
     set osupdk /import/yukari1/pdk/TSMC/28/CMOS/HPC+/stclib/9-track/tcbn28hpcplusbwp30p140-set/tcbn28hpcplusbwp30p140_190a_FE/    
     set s10lib $pdk/TSMCHOME/digital/Front_End/timing_power_noise/NLDM/tcbn28hpcplusbwp30p140_180a
@@ -32,7 +32,7 @@ if {$tech == "sky130"} {
     set mw_logic1_net VDD
     set mw_logic0_net VSS
     set CAPTABLE $TLU/1p8m/
-    set MW_REFERENCE_LIBRARY /import/yukari1/pdk/TSMC/MW
+    set MW_REFERENCE_LIBRARY /home/jstine/MW
     set MW_TECH_FILE tcbn28hpcplusbwp30p140
     set MIN_TLU_FILE $CAPTABLE/crn28hpc+_1p08m+ut-alrdl_5x1z1u_rcbest.tluplus
     set MAX_TLU_FILE $CAPTABLE/crn28hpc+_1p08m+ut-alrdl_5x1z1u_rcworst.tluplus
@@ -73,7 +73,10 @@ if {($tech == "tsmc28psyn") || ($tech == "tsmc28psyn")} {
     lappend target_library $memory/ts1n28hpcpsvtb64x44m4sw_180a/NLDM/ts1n28hpcpsvtb64x44m4sw_tt0p9v25c.db
     lappend target_library $memory/tsdn28hpcpa1024x68m4mw_130a/NLDM/tsdn28hpcpa1024x68m4mw_tt0p9v25c.db
     lappend target_library $memory/tsdn28hpcpa64x32m4mw_130a/NLDM/tsdn28hpcpa64x32m4mw_tt0p9v25c.db
-
+    lappend mw_reference_library $MW_REFERENCE_LIBRARY/ts1n28hpcpsvtb64x44m4sw
+    lappend mw_reference_library $MW_REFERENCE_LIBRARY/ts1n28hpcpsvtb64x128m4sw
+    lappend mw_reference_library $MW_REFERENCE_LIBRARY/tsdn28hpcpa1024x68m4mw
+    lappend mw_reference_library $MW_REFERENCE_LIBRARY/tsdn28hpcpa64x32m4mw
 }
 
 # Set Link Library


### PR DESCRIPTION
Fix MilkyWay reference for memories in .synopsys_dc.setup.  Previously, this was not picking the memories up correctly - this will add so that it finds all the necessary tf correctly.