### PR TITLE
Synthesis

### DIFF
--- a/src/generic/mem/ram1p1rwbe_64x22.sv
+++ b/src/generic/mem/ram1p1rwbe_64x22.sv
@@ -36,7 +36,9 @@ module ram1p1rwbe_64x22(
 
    // replace "generic64x22RAM" with "TS1N..64X22.." module from your memory vendor
    // use part of a larger RAM to avoid generating more flavors of RAM
-  TS1N28HPCPSVTB64X44M4SW sramIP(.CLK, .CEB, .WEB, .A, .D(D[21:0]), .BWEB(BWEB[21:0]), .Q(Q[21:0]));
+  logic [43:0] Qfull;
+  TS1N28HPCPSVTB64X44M4SW sramIP(.CLK, .CEB, .WEB, .A, .D({22'b0, D[21:0]}), .BWEB({22'b0, BWEB[21:0]}), .Q(Qfull));
+  assign Q = Qfull[21:0];
    // genericRAM #(64, 22) sramIP (.CLK, .CEB, .WEB, .A, .D, .BWEB, .Q);
 
 endmodule

--- a/src/generic/mem/ram2p1r1wbe_1024x36.sv
+++ b/src/generic/mem/ram2p1r1wbe_1024x36.sv
@@ -45,8 +45,11 @@ module ram2p1r1wbe_1024x36(
    //generic1024x36RAM sramIP (.CLKA, .CLKB, .CEBA, .CEBB, .WEBA, .WEBB, 
    //			     .AA, .AB, .DA, .DB, .BWEBA, .BWEBB, .QA, .QB);
    // use part of a larger RAM to avoid generating more flavors of RAM
+  logic [67:0] QAfull, QBfull;
   TSDN28HPCPA1024X68M4MW sramIP(.CLKA, .CLKB, .CEBA, .CEBB, .WEBA, .WEBB, 
-			   .AA, .AB, .DA(DA[35:0]), .DB(DB[35:0]), 
-         .BWEBA(BWEBA[35:0]), .BWEBB(BWEBB[35:0]), .QA(QA[35:0]), .QB(QB[35:0]));
+			   .AA, .AB, .DA({32'b0, DA[35:0]}), .DB({32'b0, DB[35:0]}), 
+         .BWEBA({32'b0, BWEBA[35:0]}), .BWEBB({32'b0, BWEBB[35:0]}), .QA(QAfull), .QB(QBfull));
+  assign QA = QAfull[35:0];
+  assign QB = QBfull[35:0];
 
 endmodule

--- a/synthDC/.synopsys_dc.setup
+++ b/synthDC/.synopsys_dc.setup
@@ -66,7 +66,7 @@ set cache_read   $cache_write
 lappend search_path ./scripts
 lappend search_path ./hdl
 lappend search_path ./mapped
-if {($tech == "tsmc28psyn") || ($tech == "tsmc28psyn")} {
+if {($tech == "tsmc28psyn")} {
     set memory /home/jstine/WallyMem/rv64gc/
     set osumemory /import/yukari1/pdk/TSMC/WallyMem/rv64gc/    
     lappend target_library $memory/ts1n28hpcpsvtb64x128m4sw_180a/NLDM/ts1n28hpcpsvtb64x128m4sw_tt0p9v25c.db

--- a/synthDC/Makefile
+++ b/synthDC/Makefile
@@ -21,7 +21,6 @@ export MAXCORES ?= 1
 export MAXOPT ?= 0
 export DRIVE ?= FLOP
 export USESRAM ?= 0
-export USETOPO ?= 0
 
 time := $(shell date +%F-%H-%M)
 hash := $(shell git rev-parse --short HEAD)
@@ -50,18 +49,6 @@ DIRS = $(DIRS32) $(DIRS64)
 
 configs: $(CONFIG)
 $(CONFIG):
-ifeq ($(USETOPO), 0))
-ifeq ($(TECH), tsmc28psyn))
-	@echo "Bad configuration: you cannot use physical synthesis without tsmc28psyn and usetopo (i.e., -topo)"
-	exit 1
-endif
-endif
-ifeq ($(USETOPO), 1))
-ifneq ($(TECH), tsmc28psyn))
-	@echo "Bad configuration: you cannot use usetopo (i.e., -topo) without tsmc28psyn"
-	exit 1
-endif
-endif
 	@echo $(CONFIG)
 	cp -r $(OLDCONFIGDIR)/shared/*.vh $(CONFIGDIR)
 	cp -r $(OLDCONFIGDIR)/$(CONFIG)/* $(CONFIGDIR)
@@ -138,11 +125,10 @@ mkdirecs:
 synth: mkdirecs configs rundc clean
 
 rundc:
-ifeq ($(USETOPO), 0)
-	dc_shell-xg-t -64bit -f scripts/$(NAME).tcl | tee $(OUTPUTDIR)/$(NAME).out
-else
-	
+ifeq ($(TECH), tsmc28psyn)
 	dc_shell-xg-t -64bit -topographical_mode -f scripts/$(NAME).tcl | tee $(OUTPUTDIR)/$(NAME).out
+else
+	dc_shell-xg-t -64bit -f scripts/$(NAME).tcl | tee $(OUTPUTDIR)/$(NAME).out	
 endif
 
 

--- a/synthDC/wallySynth.py
+++ b/synthDC/wallySynth.py
@@ -5,9 +5,9 @@ import subprocess
 from multiprocessing import Pool
 import argparse
 
-def runSynth(config, mod, tech, freq, maxopt, usesram, usetopo):
+def runSynth(config, mod, tech, freq, maxopt, usesram):
     global pool
-    command = "make synth DESIGN=wallypipelinedcore CONFIG={} MOD={} TECH={} DRIVE=FLOP FREQ={} MAXOPT={} USESRAM={} USETOPO={} MAXCORES=1".format(config, mod, tech, freq, maxopt, usesram, usetopo)
+    command = "make synth DESIGN=wallypipelinedcore CONFIG={} MOD={} TECH={} DRIVE=FLOP FREQ={} MAXOPT={} USESRAM={} MAXCORES=1".format(config, mod, tech, freq, maxopt, usesram)
     pool.map(mask, [command])
 
 def mask(command):
@@ -34,34 +34,32 @@ if __name__ == '__main__':
     parser.add_argument("-e", "--tech", choices=techs, help = "Technology")
     parser.add_argument("-o", "--maxopt", action='store_true', help = "Turn on MAXOPT")
     parser.add_argument("-r", "--usesram", action='store_true', help = "Use SRAM modules")
-    parser.add_argument("-topo", "--usetopo", action='store_true', help = "Run physical synthesis")	
 
     args = parser.parse_args()
 
     tech = args.tech if args.tech else 'sky90'
     maxopt = int(args.maxopt)
     usesram = int(args.usesram)
-    usetopo = int(args.usetopo)	
     mod = 'orig'
 
     if args.freqsweep:
         sc = args.freqsweep
         config = args.version if args.version else 'rv32e'
         for freq in [round(sc+sc*x/100) for x in freqVaryPct]: # rv32e freq sweep
-            runSynth(config, mod, tech, freq, maxopt, usesram, usetopo)
+            runSynth(config, mod, tech, freq, maxopt, usesram)
     elif args.configsweep:
         defaultfreq = 1500 if tech == 'sky90' else 5000
         freq = args.targetfreq if args.targetfreq else defaultfreq
         for config in ['rv32i', 'rv64gc', 'rv64i', 'rv32gc', 'rv32imc', 'rv32e']: #configs
-            runSynth(config, mod, tech, freq, maxopt, usesram, usetopo)
+            runSynth(config, mod, tech, freq, maxopt, usesram)
     elif args.featuresweep:
         defaultfreq = 500 if tech == 'sky90' else 1500
         freq = args.targetfreq if args.targetfreq else defaultfreq
         config = args.version if args.version else 'rv64gc'
         for mod in ['noFPU', 'noMulDiv', 'noPriv', 'PMP0', 'orig']: 
-            runSynth(config, mod, tech, freq, maxopt, usesram, usetopo)
+            runSynth(config, mod, tech, freq, maxopt, usesram)
     else:
         defaultfreq = 500 if tech == 'sky90' else 1500
         freq = args.targetfreq if args.targetfreq else defaultfreq
         config = args.version if args.version else 'rv64gc'
-        runSynth(config, mod, tech, freq, maxopt, usesram, usetopo)
+        runSynth(config, mod, tech, freq, maxopt, usesram)

--- a/tests/wally-riscv-arch-test/riscv-test-suite/rv32i_m/privilege/src/WALLY-mmu-sv32-01.S
+++ b/tests/wally-riscv-arch-test/riscv-test-suite/rv32i_m/privilege/src/WALLY-mmu-sv32-01.S
@@ -52,9 +52,9 @@ test_cases:
 # 
 # ---------------------------------------------------------------------------------------------
 
-# =========== test 12.3.1.1 Page Table Translation ===========
+# =========== test 8.3.1.1 Page Table Translation ===========
 
-# test 12.3.1.1.1 write page tables / entries to phyiscal memory
+# test 8.3.1.1.1 write page tables / entries to phyiscal memory
 # sv32 Page table (See Figure 12.12***):
 # Level 1 page table, situated at 0x8000D000
 .4byte 0x8000D000, 0x20004C01, write32_test  # points to level 0 page table A
@@ -78,19 +78,19 @@ test_cases:
 .4byte 0x8000F000, 0x200000CF, write32_test # Vaddr 0x0 Paddr 0x80000000: aligned megapage
 .4byte 0x8000F800, 0x200000CF, write32_test # Vaddr 0x80000000 Paddr 0x80000000: aligned megapage (program and data memory)
 
-# test 12.3.1.1.2 write values to Paddrs in each page
-# each of these values is used for 12.3.1.1.3 and some other tests, specified in the comments.
+# test 8.3.1.1.2 write values to Paddrs in each page
+# each of these values is used for 8.3.1.1.3 and some other tests, specified in the comments.
 # when a test is supposed to fault, nothing is written into where it'll be reading/executing since it should fault before getting there.
-.4byte 0x800AAAA8, 0xBEEF0055, write32_test # 12.3.1.1.4 megapage
-.4byte 0x800FFAC0, 0xBEEF0033, write32_test # 12.3.1.3.2 
-.4byte 0x800E3130, 0xBEEF0077, write32_test # 12.3.1.3.2
-.4byte 0x808017E0, 0xBEEF0099, write32_test # 12.3.1.1.4 kilopage
-.4byte 0x80805EA0, 0xBEEF0440, write32_test # 12.3.1.3.3
-.4byte 0x80803AA0, 0xBEEF0BB0, write32_test # 12.3.1.3.7
+.4byte 0x800AAAA8, 0xBEEF0055, write32_test # 8.3.1.1.4 megapage
+.4byte 0x800FFAC0, 0xBEEF0033, write32_test # 8.3.1.3.2 
+.4byte 0x800E3130, 0xBEEF0077, write32_test # 8.3.1.3.2
+.4byte 0x808017E0, 0xBEEF0099, write32_test # 8.3.1.1.4 kilopage
+.4byte 0x80805EA0, 0xBEEF0440, write32_test # 8.3.1.3.3
+.4byte 0x80803AA0, 0xBEEF0BB0, write32_test # 8.3.1.3.7
 .4byte 0x8000FFA0, 0x11100393, write32_test # write executable code for "li x7, 0x111; ret" to executable region.
-.4byte 0x8000FFA4, 0x00008067, write32_test # Used for 12.3.1.3.1, 12.3.1.3.2
+.4byte 0x8000FFA4, 0x00008067, write32_test # Used for 8.3.1.3.1, 8.3.1.3.2
 
-# test 12.3.1.1.3 read values back from Paddrs without translation (this also verifies the previous test)
+# test 8.3.1.1.3 read values back from Paddrs without translation (this also verifies the previous test)
 .4byte 0x0, 0x0, goto_baremetal # satp.MODE = baremetal / no translation.
 .4byte 0x0, 0x0, goto_s_mode # change to S mode, 0xb written to output
 .4byte 0x800AAAA8, 0xBEEF0055, read32_test
@@ -102,38 +102,38 @@ test_cases:
 .4byte 0x8000FFA0, 0x11100393, read32_test
 .4byte 0x8000FFA4, 0x00008067, read32_test
 
-# test 12.3.1.1.4 check translation works in sv48, read the same values from previous tests, this time with Vaddrs
+# test 8.3.1.1.4 check translation works in sv48, read the same values from previous tests, this time with Vaddrs
 .4byte 0x8000D, 0x0, goto_sv32 # satp.MODE = sv32, Nothing written to output
 .4byte 0x4AAAA8, 0xBEEF0055, read32_test    # megapage at Vaddr 0x400000, Paddr 0x80000000
 .4byte 0xBFF7E0, 0xBEEF0099, read32_test    # kilopage at Vaddr 0xBFF000, Paddr 0x80201000
 
-# =========== test 12.3.1.2 page fault tests ===========
+# =========== test 8.3.1.2 page fault tests ===========
 
-# test 12.3.1.2.1 load page fault if upper bits of Vaddr are not the same
+# test 8.3.1.2.1 load page fault if upper bits of Vaddr are not the same
 # Not tested in rv32/sv32
 
-# test 12.3.1.2.2 load page fault when reading an address where the valid flag is zero
+# test 8.3.1.2.2 load page fault when reading an address where the valid flag is zero
 .4byte 0x6000, 0x0, read32_test
 
-# test 12.3.1.2.3 store page fault if PTE has W and ~R flags set
+# test 8.3.1.2.3 store page fault if PTE has W and ~R flags set
 .4byte 0x2000, 0x0, write32_test
 
-# test 12.3.1.2.4 Fault if last level PTE is a pointer
+# test 8.3.1.2.4 Fault if last level PTE is a pointer
 .4byte 0x0200, 0x0, read32_test
 
-# test 12.3.1.2.5 load page fault on misaligned pages
+# test 8.3.1.2.5 load page fault on misaligned pages
 .4byte 0xC00000, 0x0, read32_test   # misaligned megapage
 
-# =========== test 12.3.1.3 PTE Protection flags ===========
+# =========== test 8.3.1.3 PTE Protection flags ===========
 
-# test 12.3.1.3.1 User flag == 0
-# *** reads on pages with U=0 already tested in 12.3.1.1.4
+# test 8.3.1.3.1 User flag == 0
+# *** reads on pages with U=0 already tested in 8.3.1.1.4
 .4byte 0x40FFA0, 0x111, executable_test           # fetch success when U=0, priv=S
 .4byte 0x80400000, 0x1, goto_u_mode             # go to U mode, return to VPN 0x80400000 where PTE.U = 1. 0x9 written to output
 .4byte 0xBFFC80, 0xBEEF0550, read32_test    # load page fault when U=0, priv=U
 .4byte 0x40FFA0, 0xbad, executable_test           # instr page fault when U=0, priv=U
 
-# test 12.3.1.3.2 User flag == 1
+# test 8.3.1.3.2 User flag == 1
 .4byte 0x804FFAC0, 0xBEEF0033, read32_test  # read success when U=1, priv=U
 .4byte 0x80000000, 0x1, goto_s_mode             # go back to S mode, return to VPN 0x80000000 where PTE.U = 0. 0x8 written to output
 .4byte 0x0, 0x3, write_mxr_sum                # set sstatus.[MXR, SUM] = 11
@@ -142,58 +142,58 @@ test_cases:
 .4byte 0x0, 0x2, write_mxr_sum                # set sstatus.[MXR, SUM] = 10.
 .4byte 0x804FFAC0, 0xBEEF0033, read32_test  # load page fault when U-1, priv=S, sstatus.SUM=0
 
-# test 12.3.1.3.3 Read flag
-# *** reads on pages with R=1 already tested in 12.3.1.1.4
+# test 8.3.1.3.3 Read flag
+# *** reads on pages with R=1 already tested in 8.3.1.1.4
 .4byte 0x0, 0x1, write_mxr_sum            # set sstatus.[MXR, SUM] = 01.
 .4byte 0x5EA0, 0xBEEF0440, read32_test  # load page fault when R=0, sstatus.MXR=0
 .4byte 0x0, 0x3, write_mxr_sum            # set sstatus.[MXR, SUM] = 11.
 .4byte 0x5EA0, 0xBEEF0440, read32_test  # read success when R=0, MXR=1, X=1
 
-# test 12.3.1.3.4 Write flag
+# test 8.3.1.3.4 Write flag
 .4byte 0xBFF290, 0xBEEF0110, write32_test    # write success when W=1
 .4byte 0xBFF290, 0xBEEF0110, read32_test    # check write success by reading
 .4byte 0x5B78, 0xBEEF0CC0, write32_test      # store page fault when W=0
 
-# test 12.3.1.3.5 eXecute flag
-# *** fetches on pages with X = 1 already tested in 12.3.1.3.1
+# test 8.3.1.3.5 eXecute flag
+# *** fetches on pages with X = 1 already tested in 8.3.1.3.1
 .4byte 0xBFFDE0, 0xbad, executable_test             # instr page fault when X=0 
 
-# test 12.3.1.3.6 Accessed flag == 0
+# test 8.3.1.3.6 Accessed flag == 0
 .4byte 0x3020, 0xBEEF0770, write32_test # store page fault when A=0
 .4byte 0x3808, 0xBEEF0990, read32_test # load page fault when A=0
 
-# test 12.3.1.3.7 Dirty flag == 0
+# test 8.3.1.3.7 Dirty flag == 0
 .4byte 0x4658, 0xBEEF0AA0, write32_test # store page fault when D=0
 .4byte 0x4AA0, 0xBEEF0BB0, read32_test # read success when D=0
 
-# =========== test 12.3.1.4 SATP Register ===========
+# =========== test 8.3.1.4 SATP Register ===========
 
-# test 12.3.1.4.1 SATP ASID and PPN fields (test having two page tables with different ASID)
+# test 8.3.1.4.1 SATP ASID and PPN fields (test having two page tables with different ASID)
 // *** .4byte 0xFFFFFFFFFFFFF888, 0x0220DEADBEEF0099, write32_test # write identical value to global PTE to make sure it's still in the TLB
 .4byte 0x8000F, 0x11, goto_sv32 # go to SV39 on a second, very minimal page table
 .4byte 0xE3130, 0xBEEF0077, read32_test # Read success of old written value from a new page table mapping 
 
-# test 12.3.1.4.2 Test Global mapping
+# test 8.3.1.4.2 Test Global mapping
 // ***.4byte 0x7FFFFFF888, 0x0220DEADBEEF0099, read32_test # read success of global PTE undefined in current mapping.
 
 
-# =========== test 12.3.1.5 STATUS Registers ===========
+# =========== test 8.3.1.5 STATUS Registers ===========
 
-# test 12.3.1.5.1 mstatus.mprv translation
+# test 8.3.1.5.1 mstatus.mprv translation
 # *** mstatus.mprv = 0 tested on every one of the translated reads and writes before this.
 .4byte 0x8000D, 0x0, goto_sv32 // go back to old, extensive page table
 .4byte 0x80000000, 0x1, goto_m_mode // go to m mode to be able to write mstatus
 .4byte 0x1, 0x1, read_write_mprv // write 1 to mstatus.mprv and set mstatus.mpp to be 01=S
 .4byte 0xBFF7E0, 0xBEEF0099, read32_test // read test succeeds with translation even though we're in M mode since MPP=S and MPRV=1
 
-# test 12.3.1.5.2 mstatus.mprv clearing
+# test 8.3.1.5.2 mstatus.mprv clearing
 # mstatus.mprv is already 1 from the last test so going to S mode should clear it with the mret
 .4byte 0x80000000, 0x1, goto_s_mode // This should zero out the mprv bit but now to read and write mstatus, we have to 
 .4byte 0x80000000, 0x1, goto_m_mode // go back to m mode to allow us to reread mstatus.
 .4byte 0x0, 0x0, read_write_mprv // read what should be a zeroed out mprv value and then force it back to zero.
 
-# test 12.3.1.5.3 sstatus.mxr read
-# this bitfield already tested in 12.3.1.3.3
+# test 8.3.1.5.3 sstatus.mxr read
+# this bitfield already tested in 8.3.1.3.3
 
 # terminate tests
 .4byte 0x0, 0x0, terminate_test # brings us back into machine mode with a final ecall, writing 0x9 to the output.

--- a/tests/wally-riscv-arch-test/riscv-test-suite/rv64i_m/privilege/src/WALLY-mmu-sv39-01.S
+++ b/tests/wally-riscv-arch-test/riscv-test-suite/rv64i_m/privilege/src/WALLY-mmu-sv39-01.S
@@ -52,9 +52,9 @@ test_cases:
 # 
 # ---------------------------------------------------------------------------------------------
 
-# =========== test 12.3.1.1 Page Table Translation ===========
+# =========== test 8.3.1.1 Page Table Translation ===========
 
-# test 12.3.1.1.1 write page tables / entries to phyiscal memory
+# test 8.3.1.1.1 write page tables / entries to phyiscal memory
 # sv39 page table (See Figure 12.12***):
 # Level 2 page table, situated at 0x8000D000
 .8byte 0x000000008000D000, 0x0000000020004C01, write64_test# points to level 1 page table A
@@ -89,20 +89,20 @@ test_cases:
 .8byte 0x8FFFF000, 0x200000CF, write64_test# Vaddr 0x0, Paddr 0x80000000 aligned gigapage
 .8byte 0x8FFFF010, 0x200000CF, write64_test# Vaddr 0x8000_0000, Paddr 0x80000000: aligned gigapage (program and data memory so we can execute without jumping around)
 
-# test 12.3.1.1.2 write values to Paddrs in each page
-# each of these values is used for 12.3.1.1.3 and some other tests, specified in the comments.
+# test 8.3.1.1.2 write values to Paddrs in each page
+# each of these values is used for 8.3.1.1.3 and some other tests, specified in the comments.
 # when a test is supposed to fault, nothing is written into where it'll be reading/executing since it shuold fault before getting there.
-.8byte 0x80200AB0, 0x0000DEADBEEF0000, write64_test# 12.3.1.1.4 and 12.3.1.4.1
-.8byte 0x800FFAB8, 0x0880DEADBEEF0055, write64_test# 12.3.1.1.4
-.8byte 0x80200AC0, 0x0990DEADBEEF0033, write64_test# 12.3.1.3.2
-.8byte 0x80203130, 0x0110DEADBEEF0077, write64_test# 12.3.1.3.2
-.8byte 0x80099000, 0x0000806711100393, write64_test# 12.3.1.3.1 and 12.3.1.3.2 write executable code for "li x7, 0x111; ret"
-.8byte 0x80205AA0, 0x0000806711100393, write64_test# 12.3.1.3.5 write same executable code
-.8byte 0x80201888, 0x0220DEADBEEF0099, write64_test# 12.3.1.1.4
-.8byte 0x84212348, 0x0330DEADBEEF0440, write64_test# 12.3.1.3.3
-.8byte 0x80203AA0, 0x0440DEADBEEF0BB0, write64_test# 12.3.1.3.7
+.8byte 0x80200AB0, 0x0000DEADBEEF0000, write64_test# 8.3.1.1.4 and 8.3.1.4.1
+.8byte 0x800FFAB8, 0x0880DEADBEEF0055, write64_test# 8.3.1.1.4
+.8byte 0x80200AC0, 0x0990DEADBEEF0033, write64_test# 8.3.1.3.2
+.8byte 0x80203130, 0x0110DEADBEEF0077, write64_test# 8.3.1.3.2
+.8byte 0x80099000, 0x0000806711100393, write64_test# 8.3.1.3.1 and 8.3.1.3.2 write executable code for "li x7, 0x111; ret"
+.8byte 0x80205AA0, 0x0000806711100393, write64_test# 8.3.1.3.5 write same executable code
+.8byte 0x80201888, 0x0220DEADBEEF0099, write64_test# 8.3.1.1.4
+.8byte 0x84212348, 0x0330DEADBEEF0440, write64_test# 8.3.1.3.3
+.8byte 0x80203AA0, 0x0440DEADBEEF0BB0, write64_test# 8.3.1.3.7
 
-# test 12.3.1.1.3 read values back from Paddrs without translation (this also verifies the previous test)
+# test 8.3.1.1.3 read values back from Paddrs without translation (this also verifies the previous test)
 .8byte 0x0, 0x0, goto_baremetal# satp.MODE = baremetal / no translation.
 .8byte 0x0, 0x0, goto_s_mode # change to S mode, 0xb written to output
 .8byte 0x80200AB0, 0x0000DEADBEEF0000, read64_test
@@ -113,42 +113,42 @@ test_cases:
 .8byte 0x84212348, 0x0330DEADBEEF0440, read64_test
 .8byte 0x80203AA0, 0x0440DEADBEEF0BB0, read64_test
 
-# test 12.3.1.1.4 check translation works in sv39, read the same values from previous tests, this time with Vaddrs
+# test 8.3.1.1.4 check translation works in sv39, read the same values from previous tests, this time with Vaddrs
 .8byte 0x8000D, 0x0, goto_sv39 # satp.MODE = sv39, with base page table PPN = 0x8000D and ASID = 0. current VPN: gigapage at 0x80000000.
 .8byte 0x80200AB0, 0x0000DEADBEEF0000, read64_test         # gigapage at Vaddr 0x80000000, Paddr 0x80000000
 .8byte 0x400FFAB8, 0x0880DEADBEEF0055, read64_test         # megapage at Vaddr 0x40400000, Paddr 0x80000000
 .8byte 0xFFFFFFFFFFFFF888, 0x0220DEADBEEF0099, read64_test # kilopage at Vaddr 0xFFFFFFFFFFFFF000, Paddr 0x80201000
 
-# =========== test 12.3.1.2 page fault tests ===========
+# =========== test 8.3.1.2 page fault tests ===========
 
-# test 12.3.1.2.1 load page fault if upper bits of Vaddr are not the same
+# test 8.3.1.2.1 load page fault if upper bits of Vaddr are not the same
 .8byte 0x0010000080000AB0, 0x0, read64_test# gigapage at Vaddr 0x80000000, Paddr 0x80000000, bad 1 in upper bits
 .8byte 0xFF0FFFFFFFFFF888, 0x0, read64_test# kilopage at Vaddr 0xFFFFFFFFFFFFF000, Paddr 0x80201000, bad 0000 in upper bits
 
-# test 12.3.1.2.2 load page fault when reading an address where the valid flag is zero
+# test 8.3.1.2.2 load page fault when reading an address where the valid flag is zero
 .8byte 0x6000, 0x0, read64_test
 
-# test 12.3.1.2.3 store page fault if PTE has W and ~R flags set
+# test 8.3.1.2.3 store page fault if PTE has W and ~R flags set
 .8byte 0x2000, 0x0, write64_test
 
-# test 12.3.1.2.4 Fault if last level PTE is a pointer
+# test 8.3.1.2.4 Fault if last level PTE is a pointer
 .8byte 0x0020, 0x0, read64_test
 
-# test 12.3.1.2.5 load page fault on misaligned pages
+# test 8.3.1.2.5 load page fault on misaligned pages
 .8byte 0xC0000000, 0x0, read64_test# misaligned gigapage
 .8byte 0x40200000, 0x0, read64_test# misaligned megapage
 
-# =========== test 12.3.1.3 PTE Protection flags ===========
+# =========== test 8.3.1.3 PTE Protection flags ===========
 
 
-# test 12.3.1.3.1 User flag == 0
-# *** reads on pages with U=0 already tested in 12.3.1.1.4
+# test 8.3.1.3.1 User flag == 0
+# *** reads on pages with U=0 already tested in 8.3.1.1.4
 .8byte 0x40099000, 0x111, executable_test                       # execute success when U=0, priv=S
 .8byte 0x40400000, 0x2, goto_u_mode                         # go to U mode, return to megapage at 0x40400000 where U = 1. 0x9 written to output
 .8byte 0xFFFFFFFFFFFFFC80, 0x0880DEADBEEF0550, read64_test # load page fault when U=0, priv=U
 .8byte 0x40099000, 0xbad, executable_test                       # execute fault when U=0, priv=U
 
-# test 12.3.1.3.2 User flag == 1
+# test 8.3.1.3.2 User flag == 1
 .8byte 0x1AC0, 0x0990DEADBEEF0033, read64_test # read success when U=1, priv=U
 .8byte 0x80000000, 0x1, goto_s_mode                   # go back to S mode, return to gigapage at 0x80000000 where U = 0. 0x8 written to output
 .8byte 0x0, 0x3, write_mxr_sum                    # set sstatus.[MXR, SUM] = 11
@@ -157,58 +157,58 @@ test_cases:
 .8byte 0x0, 0x2, write_mxr_sum                    # set sstatus.[MXR, SUM] = 10.
 .8byte 0x1AC0, 0x0990DEADBEEF0033, read64_test # load page fault when U-1, priv=S, sstatus.SUM=0
 
-# test 12.3.1.3.3 Read flag
-# *** reads on pages with R=1 already tested in 12.3.1.1.4
+# test 8.3.1.3.3 Read flag
+# *** reads on pages with R=1 already tested in 8.3.1.1.4
 .8byte 0x0, 0x1, write_mxr_sum                        # set sstatus.[MXR, SUM] = 01.
 .8byte 0x40612348, 0x0330DEADBEEF0440, read64_test # load page fault when R=0, sstatus.MXR=0
 .8byte 0x0, 0x3, write_mxr_sum                        # set sstatus.[MXR, SUM] = 11.
 .8byte 0x40612348, 0x0330DEADBEEF0440, read64_test # read success when MXR=1, X=1
 
-# test 12.3.1.3.4 Write flag
+# test 8.3.1.3.4 Write flag
 .8byte 0x80AAAAA0, 0x0440DEADBEEF0110, write64_test# write success when W=1
 .8byte 0x80AAAAA0, 0x0440DEADBEEF0110, read64_test# check write success by reading the same address
 .8byte 0x40000000, 0x0220DEADBEEF0BB0, write64_test# store page fault when W=0
 
-# test 12.3.1.3.5 eXecute flag
-# *** fetches on pages with X = 1 already tested in 12.3.1.3.1
+# test 8.3.1.3.5 eXecute flag
+# *** fetches on pages with X = 1 already tested in 8.3.1.3.1
 .8byte 0x5AA0, 0x1, executable_test                 # instr page fault when X=0
 
-# test 12.3.1.3.6 Accessed flag == 0
+# test 8.3.1.3.6 Accessed flag == 0
 .8byte 0x36D0, 0x0990DEADBEEF0770, write64_test# store page fault when A=0
 .8byte 0x3AB8, 0x0990DEADBEEF0990, read64_test# load page fault when A=0
 
-# test 12.3.1.3.7 Dirty flag == 0
+# test 8.3.1.3.7 Dirty flag == 0
 .8byte 0x4658, 0x0440DEADBEEF0AA0, write64_test# store page fault when D=0
 .8byte 0x4AA0, 0x0440DEADBEEF0BB0, read64_test# read success when D=0
 
-# =========== test 12.3.1.4 SATP Register ===========
+# =========== test 8.3.1.4 SATP Register ===========
 
-# test 12.3.1.4.1 SATP ASID and PPN fields (test having two page tables with different ASID)
+# test 8.3.1.4.1 SATP ASID and PPN fields (test having two page tables with different ASID)
 // *** .8byte 0xFFFFFFFFFFFFF888, 0x0220DEADBEEF0099, write64_test # write identical value to global PTE to make sure it's still in the TLB
 .8byte 0x8FFFF, 0x11, goto_sv39 # go to SV39 on a second, very minimal page table
 .8byte 0x200AB0, 0x0000DEADBEEF0000, read64_test # Read success of old written value from a new page table mapping 
 
-# test 12.3.1.4.2 Test Global mapping
+# test 8.3.1.4.2 Test Global mapping
 // ***.8byte 0x7FFFFFF888, 0x0220DEADBEEF0099, read64_test # read success of global PTE undefined in current mapping.
 
 
-# =========== test 12.3.1.5 STATUS Registers ===========
+# =========== test 8.3.1.5 STATUS Registers ===========
 
-# test 12.3.1.5.1 mstatus.mprv translation
+# test 8.3.1.5.1 mstatus.mprv translation
 # *** mstatus.mprv = 0 tested on every one of the translated reads and writes before this.
 .8byte 0x8000D, 0x0, goto_sv39 // go back to old, extensive page table
 .8byte 0x80000000, 0x1, goto_m_mode // go to m mode to be able to write mstatus
 .8byte 0x1, 0x1, read_write_mprv // write 1 to mstatus.mprv and set mstatus.mpp to be 01=S
 .8byte 0xFFFFFFFFFFFFF888, 0x0220DEADBEEF0099, read64_test // read test succeeds with translation even though we're in M mode since MPP=S and MPRV=1
 
-# test 12.3.1.5.2 mstatus.mprv clearing
+# test 8.3.1.5.2 mstatus.mprv clearing
 # mstatus.mprv is already 1 from the last test so going to S mode should clear it with the mret
 .8byte 0x80000000, 0x1, goto_s_mode // This should zero out the mprv bit but now to read and write mstatus, we have to 
 .8byte 0x80000000, 0x1, goto_m_mode // go back to m mode to allow us to reread mstatus.
 .8byte 0x0, 0x0, read_write_mprv // read what should be a zeroed out mprv value and then force it back to zero.
 
-# test 12.3.1.5.3 sstatus.mxr read
-# this bitfield already tested in 12.3.1.3.3
+# test 8.3.1.5.3 sstatus.mxr read
+# this bitfield already tested in 8.3.1.3.3
 
 # terminate tests
 .8byte 0x0, 0x0, terminate_test # brings us back into machine mode with a final ecall, writing 0x9 to the output.

--- a/tests/wally-riscv-arch-test/riscv-test-suite/rv64i_m/privilege/src/WALLY-mmu-sv48-01.S
+++ b/tests/wally-riscv-arch-test/riscv-test-suite/rv64i_m/privilege/src/WALLY-mmu-sv48-01.S
@@ -54,9 +54,9 @@ test_cases:
 # ---------------------------------------------------------------------------------------------
 
 
-# =========== test 12.3.1.1 Page Table Translation ===========
+# =========== test 8.3.1.1 Page Table Translation ===========
 
-# test 12.3.1.1.1 write page tables / entries to phyiscal memory
+# test 8.3.1.1.1 write page tables / entries to phyiscal memory
 # sv48 page table (See Figure 12.12***):
 # Level 3 page table, situated at 0x8000D000
 .8byte 0x000000008000D000, 0x0000000020004C01, write64_test # points to level 2 page table A
@@ -101,22 +101,22 @@ test_cases:
 .8byte 0x8002F010, 0x200000CF, write64_test # Vaddr 0x80000000, Paddr 0x80000000: aligned gigapage (data and instr memory)
 
 
-# test 12.3.1.1.2 write values to Paddrs in each page
-# each of these values is used for 12.3.1.1.3 and some other tests, specified in the comments.
+# test 8.3.1.1.2 write values to Paddrs in each page
+# each of these values is used for 8.3.1.1.3 and some other tests, specified in the comments.
 # when a test is supposed to fault, nothing is written into where it'll be reading/executing since it should fault before getting there.
-.8byte 0x82777778, 0x0EE0DEADBEEF0CC0, write64_test # 12.3.1.1.4 terapage
-.8byte 0x85BC0AB0, 0x0000DEADBEEF0000, write64_test # 12.3.1.1.4 gigapage
-.8byte 0x800F0AB8, 0x0880DEADBEEF0055, write64_test # 12.3.1.1.4 megapage
-.8byte 0x80201888, 0x0220DEADBEEF0099, write64_test # 12.3.1.1.4 kilopage
-.8byte 0x80099000, 0x0000806711100393, write64_test # 12.3.1.3.1 write executable code for "li x7, 0x111; ret"
-.8byte 0x80200400, 0x0000806711100393, write64_test # 12.3.1.3.2 write same executable code 
-.8byte 0x80200AC0, 0x0990DEADBEEF0033, write64_test # 12.3.1.3.2 
-.8byte 0x80200130, 0x0110DEADBEEF0077, write64_test # 12.3.1.3.2
-.8byte 0x85212348, 0x0330DEADBEEF0440, write64_test # 12.3.1.3.3
-.8byte 0x88888000, 0x0000806711100393, write64_test # 12.3.1.3.5 write same executable code
-.8byte 0x80203AA0, 0x0440DEADBEEF0BB0, write64_test # 12.3.1.3.7
+.8byte 0x82777778, 0x0EE0DEADBEEF0CC0, write64_test # 8.3.1.1.4 terapage
+.8byte 0x85BC0AB0, 0x0000DEADBEEF0000, write64_test # 8.3.1.1.4 gigapage
+.8byte 0x800F0AB8, 0x0880DEADBEEF0055, write64_test # 8.3.1.1.4 megapage
+.8byte 0x80201888, 0x0220DEADBEEF0099, write64_test # 8.3.1.1.4 kilopage
+.8byte 0x80099000, 0x0000806711100393, write64_test # 8.3.1.3.1 write executable code for "li x7, 0x111; ret"
+.8byte 0x80200400, 0x0000806711100393, write64_test # 8.3.1.3.2 write same executable code 
+.8byte 0x80200AC0, 0x0990DEADBEEF0033, write64_test # 8.3.1.3.2 
+.8byte 0x80200130, 0x0110DEADBEEF0077, write64_test # 8.3.1.3.2
+.8byte 0x85212348, 0x0330DEADBEEF0440, write64_test # 8.3.1.3.3
+.8byte 0x88888000, 0x0000806711100393, write64_test # 8.3.1.3.5 write same executable code
+.8byte 0x80203AA0, 0x0440DEADBEEF0BB0, write64_test # 8.3.1.3.7
 
-# test 12.3.1.1.3 read values back from Paddrs without translation (this also verifies the previous test)
+# test 8.3.1.1.3 read values back from Paddrs without translation (this also verifies the previous test)
 .8byte 0x0, 0x0, goto_baremetal # satp.MODE = baremetal / no translation.
 .8byte 0x0, 0x0, goto_s_mode # change to S mode, 0xb written to output
 .8byte 0x82777778, 0x0EE0DEADBEEF0CC0, read64_test
@@ -128,43 +128,43 @@ test_cases:
 .8byte 0x85212348, 0x0330DEADBEEF0440, read64_test
 .8byte 0x80203AA0, 0x0440DEADBEEF0BB0, read64_test
 
-# test 12.3.1.1.4 check translation works in sv48, read the same values from previous tests, this time with Vaddrs
+# test 8.3.1.1.4 check translation works in sv48, read the same values from previous tests, this time with Vaddrs
 .8byte 0x8000D, 0x0, goto_sv48 # satp.MODE = sv48, with base page table PPN = 0x8000D and ASID = 0. current VPN: megapage at 0x80000000. Nothing written to output
 .8byte 0x10082777778, 0x0EE0DEADBEEF0CC0, read64_test      # terapage at Vaddr 0x010000000000, Paddr 0x0
 .8byte 0x8005BC0AB0, 0x0000DEADBEEF0000, read64_test       # gigapage at Vaddr 0x008000000000, Paddr 0x80000000
 .8byte 0x800F0AB8, 0x0880DEADBEEF0055, read64_test         # megapage at Vaddr 0x80000000, Paddr 0x80000000
 .8byte 0xFFFFFFFFFFFFF888, 0x0220DEADBEEF0099, read64_test # kilopage at Vaddr 0xFFFFFFFFFFFFF000, Paddr 0x80201000
 
-# =========== test 12.3.1.2 page fault tests ===========
+# =========== test 8.3.1.2 page fault tests ===========
 
-# test 12.3.1.2.1 page fault if upper bits of Vaddr are not the same
+# test 8.3.1.2.1 page fault if upper bits of Vaddr are not the same
 .8byte 0x001000800ABC0AB0, 0x0, read64_test# gigapage at Vaddr 0x008000000000, Paddr 0x80000000, bad 1 in upper bits
 .8byte 0xFF0FFFFFFFFFF888, 0x0, read64_test# kilopage at Vaddr 0xFFFFFFFFFFFFF000, Paddr 0x80201000, bad 0000 in upper bits
 
-# test 12.3.1.2.2 read fault when reading an address where the valid flag is zero
+# test 8.3.1.2.2 read fault when reading an address where the valid flag is zero
 .8byte 0x80205000, 0x0, read64_test
 
-# test 12.3.1.2.3 write fault if PTE has W and ~R flags set
+# test 8.3.1.2.3 write fault if PTE has W and ~R flags set
 .8byte 0x80202000, 0x0, write64_test 
 
-# test 12.3.1.2.4 Fault if last level PTE is a pointer
+# test 8.3.1.2.4 Fault if last level PTE is a pointer
 .8byte 0x80200000, 0x0, read64_test
 
-# test 12.3.1.2.5 read fault on misaligned pages
+# test 8.3.1.2.5 read fault on misaligned pages
 .8byte 0x18000000000, 0x0, read64_test # misaligned terapage
 .8byte 0x8080000000, 0x0, read64_test  # misaligned gigapage
 .8byte 0x80400000, 0x0, read64_test    # misaligned megapage
 
-# =========== test 12.3.1.3 PTE Protection flags ===========
+# =========== test 8.3.1.3 PTE Protection flags ===========
 
-# test 12.3.1.3.1 User flag == 0
-# reads on pages with U=0 already tested in 12.3.1.1.4
+# test 8.3.1.3.1 User flag == 0
+# reads on pages with U=0 already tested in 8.3.1.1.4
 .8byte 0x008000099000, 0x111, executable_test                   # execute success when U=0, priv=S
 .8byte 0x008040000000, 0x1, goto_u_mode                     # go to U mode, return to gigapage at 0x008040000000 where PTE.U = 1. 0x9 written to output
 .8byte 0xFFFFFFFFFFFFFC80, 0x0880DEADBEEF0550, read64_test # read fault when U=0, priv=U
 .8byte 0x008000099000, 0xbad, executable_test                   # execute fault when U=0, priv=U
 
-# test 12.3.1.3.2 User flag == 1
+# test 8.3.1.3.2 User flag == 1
 .8byte 0x80201AC0, 0x0990DEADBEEF0033, read64_test # read success when U=1, priv=U
 .8byte 0x80000000, 0x2, goto_s_mode 
 .8byte 0x0, 0x3, write_mxr_sum                        # set sstatus.[MXR, SUM] = 11
@@ -173,58 +173,58 @@ test_cases:
 .8byte 0x0, 0x2, write_mxr_sum                        # set sstatus.[MXR, SUM] = 10.
 .8byte 0x80201AC0, 0x0990DEADBEEF0033, read64_test # read fault when U=1, priv=S, sstatus.SUM=0
 
-# test 12.3.1.3.3 Read flag
-# reads on pages with R=1 already tested in 12.3.1.1.4
+# test 8.3.1.3.3 Read flag
+# reads on pages with R=1 already tested in 8.3.1.1.4
 .8byte 0x0, 0x1, write_mxr_sum                        # set sstatus.[MXR, SUM] = 01.
 .8byte 0x80612348, 0x0330DEADBEEF0440, read64_test # read fault when R=0, sstatus.MXR=0
 .8byte 0x0, 0x3, write_mxr_sum                        # set sstatus.[MXR, SUM] = 11.
 .8byte 0x80612348, 0x0330DEADBEEF0440, read64_test # read success when MXR=1, X=1
 
-# test 12.3.1.3.4 Write flag
+# test 8.3.1.3.4 Write flag
 .8byte 0x10080BCDED8, 0x0440DEADBEEF0110, write64_test    # write success when W=1 (corresponding Paddr = 0x80BCDED8)
 .8byte 0x10080BCDED8, 0x0440DEADBEEF0110, read64_test   # check write success by reading value back
 .8byte 0x8000009E88, 0x0220DEADBEEF0BB0, write64_test     # write fault when W=0
 
-# test 12.3.1.3.5 eXecute flag
-# executes on pages with X = 1 already tested in 12.3.1.3.1
+# test 8.3.1.3.5 eXecute flag
+# executes on pages with X = 1 already tested in 8.3.1.3.1
 .8byte 0x010088888000, 0x2, executable_test               # execute fault when X=0 
 
-# test 12.3.1.3.6 Accessed flag == 0
+# test 8.3.1.3.6 Accessed flag == 0
 .8byte 0x802036D0, 0x0990DEADBEEF0770, write64_test # write fault when A=0
 .8byte 0x80203AB8, 0x0990DEADBEEF0990, read64_test# read fault when A=0
 
-# test 12.3.1.3.7 Dirty flag == 0
+# test 8.3.1.3.7 Dirty flag == 0
 .8byte 0x80204658, 0x0440DEADBEEF0AA0, write64_test # write fault when D=0
 .8byte 0x80204AA0, 0x0440DEADBEEF0BB0, read64_test# read success when D=0
 
-# =========== test 12.3.1.4 SATP Register ===========
+# =========== test 8.3.1.4 SATP Register ===========
 
-# test 12.3.1.4.1 SATP ASID and PPN fields (test having two page tables with different ASID)
+# test 8.3.1.4.1 SATP ASID and PPN fields (test having two page tables with different ASID)
 // *** .8byte 0xFFFFFFFFFFFFF888, 0x0220DEADBEEF0099, write64_test # write identical value to global PTE to make sure it's still in the TLB
 .8byte 0x8000F, 0x11, goto_sv48 # go to SV39 on a second, very minimal page table
 .8byte 0x5BC0AB0, 0x0000DEADBEEF0000, read64_test # Read success of old written value from a new page table mapping 
 
-# test 12.3.1.4.2 Test Global mapping
+# test 8.3.1.4.2 Test Global mapping
 // ***.8byte 0x7FFFFFF888, 0x0220DEADBEEF0099, read64_test # read success of global PTE undefined in current mapping.
 
 
-# =========== test 12.3.1.5 STATUS Registers ===========
+# =========== test 8.3.1.5 STATUS Registers ===========
 
-# test 12.3.1.5.1 mstatus.mprv translation
+# test 8.3.1.5.1 mstatus.mprv translation
 # *** mstatus.mprv = 0 tested on every one of the translated reads and writes before this.
 .8byte 0x8000D, 0x0, goto_sv48 // go back to old, extensive page table
 .8byte 0x80000000, 0x1, goto_m_mode // go to m mode to be able to write mstatus
 .8byte 0x1, 0x1, read_write_mprv // write 1 to mstatus.mprv and set mstatus.mpp to be 01=S
 .8byte 0xFFFFFFFFFFFFF888, 0x0220DEADBEEF0099, read64_test // read test succeeds with translation even though we're in M mode since MPP=S and MPRV=1
 
-# test 12.3.1.5.2 mstatus.mprv clearing
+# test 8.3.1.5.2 mstatus.mprv clearing
 # mstatus.mprv is already 1 from the last test so going to S mode should clear it with the mret
 .8byte 0x80000000, 0x1, goto_s_mode // This should zero out the mprv bit but now to read and write mstatus, we have to 
 .8byte 0x80000000, 0x1, goto_m_mode // go back to m mode to allow us to reread mstatus.
 .8byte 0x0, 0x0, read_write_mprv // read what should be a zeroed out mprv value and then force it back to zero.
 
-# test 12.3.1.5.3 sstatus.mxr read
-# this bitfield already tested in 12.3.1.3.3
+# test 8.3.1.5.3 sstatus.mxr read
+# this bitfield already tested in 8.3.1.3.3
 
 # terminate tests
 .8byte 0x0, 0x0, terminate_test # brings us back into machine mode with a final ecall, writing 0x9 to the output.


### PR DESCRIPTION
Cleaned up 28nm memory-based synthesis
Removed TOPO flag; now implied by tsmc28psyn