### PR TITLE
Fix the branch predictor's gshare and btb critical path issue

### DIFF
--- a/bin/parseHPMC.py
+++ b/bin/parseHPMC.py
@@ -247,13 +247,25 @@ if(sys.argv[1] == '-b'):
                     currPercent.append(percent)
                     dct[PredType] = (currSize, currPercent)
         print(dct)
+        fig, axes = plt.subplots()
+        marker={'twobit' : '^', 'gshare' : 'o', 'global' : 's', 'gshareBasic' : '*', 'globalBasic' : 'x'}
+        colors={'twobit' : 'black', 'gshare' : 'blue', 'global' : 'dodgerblue', 'gshareBasic' : 'turquoise', 'globalBasic' : 'lightsteelblue'}
         for cat in dct:
             (x, y) = dct[cat]
-            plt.scatter(x, y, label='k')
-            plt.plot(x, y)
-            plt.ylabel('Prediction Accuracy')
-            plt.xlabel('Size (b or k)')
-            plt.legend(loc='upper left')
+            x=[int(2**int(v)/4) for v in x]
+            print(x, y)
+            axes.plot(x,y, color=colors[cat])
+            axes.scatter(x,y, label=cat, marker=marker[cat], color=colors[cat])
+            #plt.scatter(x, y, label=cat)
+            #plt.plot(x, y)
+            #axes.set_xticks([4, 6, 8, 10, 12, 14])
+        axes.legend(loc='upper left')
+        axes.set_xscale("log")
+        axes.set_ylabel('Prediction Accuracy')
+        axes.set_xlabel('Size (bytes)')
+        axes.set_xticks([16, 64, 256, 1024, 4096, 16384])        
+        axes.set_xticklabels([16, 64, 256, 1024, 4096, 16384])
+        axes.grid(color='b', alpha=0.5, linestyle='dashed', linewidth=0.5)
     plt.show()
     
             

--- a/src/ifu/bpred/RASPredictor.sv
+++ b/src/ifu/bpred/RASPredictor.sv
@@ -33,7 +33,7 @@ module RASPredictor #(parameter int StackSize = 16 )(
   input  logic             clk,
   input  logic 			   reset, 
   input  logic 			   StallF, StallD, StallE, StallM, FlushD, FlushE, FlushM,
-  input  logic [3:0] 	   WrongPredInstrClassD,                      // Prediction class is wrong
+  input  logic       	   WrongBPRetD,                      // Prediction class is wrong
   input  logic [3:0] 	   InstrClassD,
   input  logic [3:0]       InstrClassE,                  // Instr class
   input  logic [3:0]       PredInstrClassF,
@@ -61,7 +61,7 @@ module RASPredictor #(parameter int StackSize = 16 )(
   assign PopF = PredInstrClassF[2] & ~StallD & ~FlushD;
   assign PushE = InstrClassE[3] & ~StallM & ~FlushM;
 
-  assign WrongPredRetD = (WrongPredInstrClassD[2]) & ~StallE & ~FlushE;
+  assign WrongPredRetD = (WrongBPRetD) & ~StallE & ~FlushE;
   assign FlushedRetDE = (~StallE & FlushE & InstrClassD[2]) | (~StallM & FlushM & InstrClassE[2]); // flushed ret
 
   assign RepairD = WrongPredRetD | FlushedRetDE ;

--- a/src/ifu/bpred/RASPredictor.sv
+++ b/src/ifu/bpred/RASPredictor.sv
@@ -34,9 +34,9 @@ module RASPredictor #(parameter int StackSize = 16 )(
   input  logic 			   reset, 
   input  logic 			   StallF, StallD, StallE, StallM, FlushD, FlushE, FlushM,
   input  logic       	   WrongBPRetD,                      // Prediction class is wrong
-  input  logic [3:0] 	   InstrClassD,
-  input  logic [3:0]       InstrClassE,                  // Instr class
-  input  logic [3:0]       PredInstrClassF,
+  input  logic      	   RetD,
+  input  logic             RetE, JalE,                  // Instr class
+  input  logic             BPRetF,
   input  logic [`XLEN-1:0] PCLinkE,                                   // PC of instruction after a jal
   output logic [`XLEN-1:0] RASPCF                                     // Top of the stack
    );
@@ -58,17 +58,17 @@ module RASPredictor #(parameter int StackSize = 16 )(
   logic 		 WrongPredRetD;
   
   
-  assign PopF = PredInstrClassF[2] & ~StallD & ~FlushD;
-  assign PushE = InstrClassE[3] & ~StallM & ~FlushM;
+  assign PopF = BPRetF & ~StallD & ~FlushD;
+  assign PushE = JalE & ~StallM & ~FlushM;
 
   assign WrongPredRetD = (WrongBPRetD) & ~StallE & ~FlushE;
-  assign FlushedRetDE = (~StallE & FlushE & InstrClassD[2]) | (~StallM & FlushM & InstrClassE[2]); // flushed ret
+  assign FlushedRetDE = (~StallE & FlushE & RetD) | (~StallM & FlushM & RetE); // flushed ret
 
   assign RepairD = WrongPredRetD | FlushedRetDE ;
 
-  assign IncrRepairD = FlushedRetDE | (WrongPredRetD & ~InstrClassD[2]); // Guessed it was a ret, but its not
+  assign IncrRepairD = FlushedRetDE | (WrongPredRetD & ~RetD); // Guessed it was a ret, but its not
 
-  assign DecRepairD =  WrongPredRetD & InstrClassD[2]; // Guessed non ret but is a ret.
+  assign DecRepairD =  WrongPredRetD & RetD; // Guessed non ret but is a ret.
     
   assign CounterEn = PopF | PushE | RepairD;
 

--- a/src/ifu/bpred/bpred.sv
+++ b/src/ifu/bpred/bpred.sv
@@ -108,14 +108,14 @@ module bpred (
 
   end else if (`BPRED_TYPE == "BP_GSHARE") begin:Predictor
     gshare #(`BPRED_SIZE) DirPredictor(.clk, .reset, .StallF, .StallD, .StallE, .StallM, .StallW, .FlushD, .FlushE, .FlushM, .FlushW,
-      .PCNextF, .PCF, .PCD, .PCE, .PCM, .DirPredictionF, .DirPredictionWrongE,
-      .BPBranchF, .BranchD, .BranchE, .BranchM,
+      .PCNextF, .PCF, .PCD, .PCE, .PCM, .PCW, .DirPredictionF, .DirPredictionWrongE,
+      .BPBranchF, .BranchD, .BranchE, .BranchM, .BranchW, 
       .PCSrcE);
 
   end else if (`BPRED_TYPE == "BP_GLOBAL") begin:Predictor
     gshare #(`BPRED_SIZE, 0) DirPredictor(.clk, .reset, .StallF, .StallD, .StallE, .StallM, .StallW, .FlushD, .FlushE, .FlushM, .FlushW,
-      .PCNextF, .PCF, .PCD, .PCE, .PCM, .DirPredictionF, .DirPredictionWrongE,
-      .BPBranchF, .BranchD, .BranchE, .BranchM,
+      .PCNextF, .PCF, .PCD, .PCE, .PCM, .PCW, .DirPredictionF, .DirPredictionWrongE,
+      .BPBranchF, .BranchD, .BranchE, .BranchM, .BranchW,
       .PCSrcE);
 
   end else if (`BPRED_TYPE == "BP_GSHARE_BASIC") begin:Predictor

--- a/src/ifu/bpred/bpred.sv
+++ b/src/ifu/bpred/bpred.sv
@@ -72,12 +72,9 @@ module bpred (
 
   logic [1:0]               DirPredictionF;
 
-  logic [3:0]               BTBPredInstrClassF, PredInstrClassF, PredInstrClassD;
   logic [`XLEN-1:0]         BTAF, RASPCF;
   logic                     PredictionPCWrongE;
   logic                     AnyWrongPredInstrClassD, AnyWrongPredInstrClassE;
-  logic [3:0]               InstrClassD;
-  logic [3:0] 				InstrClassE;
   logic                     DirPredictionWrongE;
   
   logic                     SelBPPredF;
@@ -91,34 +88,44 @@ module bpred (
 
   logic [`XLEN-1:0] 		BTAD;
 
+  logic 					BTBJalF, BTBRetF, BTBJumpF, BTBBranchF;
+  logic 					BPBranchF, BPJumpF, BPRetF, BPJalF;
+  logic 					BPBranchD, BPJumpD, BPRetD, BPJalD;
+  logic 					RetD, JalD;
+  logic 					RetE, JalE;
+  logic 					BranchM, JumpM, RetM, JalM;
+  logic 					WrongBPRetD;
+
+
   // Part 1 branch direction prediction
   // look into the 2 port Sram model. something is wrong. 
   if (`BPRED_TYPE == "BP_TWOBIT") begin:Predictor
-    twoBitPredictor #(`BPRED_SIZE) DirPredictor(.clk, .reset, .StallF, .StallD, .StallE, .StallM, .FlushD, .FlushE, .FlushM,
+    twoBitPredictor #(`BPRED_SIZE) DirPredictor(.clk, .reset, .StallF, .StallD, .StallE, .StallM, .StallW, 
+      .FlushD, .FlushE, .FlushM, .FlushW,
       .PCNextF, .PCM, .DirPredictionF, .DirPredictionWrongE,
-      .BranchInstrE(InstrClassE[0]), .BranchInstrM(InstrClassM[0]), .PCSrcE);
+      .BranchInstrE(BranchE), .BranchInstrM(BranchM), .PCSrcE);
 
   end else if (`BPRED_TYPE == "BP_GSHARE") begin:Predictor
     gshare #(`BPRED_SIZE) DirPredictor(.clk, .reset, .StallF, .StallD, .StallE, .StallM, .StallW, .FlushD, .FlushE, .FlushM, .FlushW,
       .PCNextF, .PCF, .PCD, .PCE, .PCM, .DirPredictionF, .DirPredictionWrongE,
-      .BranchInstrF(PredInstrClassF[0]), .BranchInstrD(InstrClassD[0]), .BranchInstrE(InstrClassE[0]), .BranchInstrM(InstrClassM[0]),
+      .BranchInstrF(BPBranchF), .BranchInstrD(BranchD), .BranchInstrE(BranchE), .BranchInstrM(BranchM),
       .PCSrcE);
 
   end else if (`BPRED_TYPE == "BP_GLOBAL") begin:Predictor
     gshare #(`BPRED_SIZE, 0) DirPredictor(.clk, .reset, .StallF, .StallD, .StallE, .StallM, .StallW, .FlushD, .FlushE, .FlushM, .FlushW,
       .PCNextF, .PCF, .PCD, .PCE, .PCM, .DirPredictionF, .DirPredictionWrongE,
-      .BranchInstrF(PredInstrClassF[0]), .BranchInstrD(InstrClassD[0]), .BranchInstrE(InstrClassE[0]), .BranchInstrM(InstrClassM[0]),
+      .BranchInstrF(BPBranchF), .BranchInstrD(BranchD), .BranchInstrE(BranchE), .BranchInstrM(BranchM),
       .PCSrcE);
 
   end else if (`BPRED_TYPE == "BP_GSHARE_BASIC") begin:Predictor
     gsharebasic #(`BPRED_SIZE) DirPredictor(.clk, .reset, .StallF, .StallD, .StallE, .StallM, .StallW, .FlushD, .FlushE, .FlushM, .FlushW,
       .PCNextF, .PCM, .DirPredictionF, .DirPredictionWrongE,
-      .BranchInstrE(InstrClassE[0]), .BranchInstrM(InstrClassM[0]), .PCSrcE);
+      .BranchInstrE(BranchE), .BranchInstrM(BranchM), .PCSrcE);
 
   end else if (`BPRED_TYPE == "BP_GLOBAL_BASIC") begin:Predictor
     gsharebasic #(`BPRED_SIZE, 0) DirPredictor(.clk, .reset, .StallF, .StallD, .StallE, .StallM, .StallW, .FlushD, .FlushE, .FlushM, .FlushW,
       .PCNextF, .PCM, .DirPredictionF, .DirPredictionWrongE,
-      .BranchInstrE(InstrClassE[0]), .BranchInstrM(InstrClassM[0]), .PCSrcE);
+      .BranchInstrE(BranchE), .BranchInstrM(BranchM), .PCSrcE);
 	
   end else if (`BPRED_TYPE == "BPLOCALPAg") begin:Predictor
     // *** Fix me
@@ -142,16 +149,16 @@ module bpred (
     TargetPredictor(.clk, .reset, .StallF, .StallD, .StallE, .StallM, .StallW, .FlushD, .FlushE, .FlushM, .FlushW,
           .PCNextF, .PCF, .PCD, .PCE, .PCM,
           .BTAF, .BTAD,
-          .BTBPredInstrClassF,
+          .BTBPredInstrClassF({BTBJalF, BTBRetF, BTBJumpF, BTBBranchF}),
           .PredictionInstrClassWrongM,
           .IEUAdrE, .IEUAdrM,
-          .InstrClassD, .InstrClassE, .InstrClassM);
+          .InstrClassD({JalD, RetD, JumpD, BranchD}), .InstrClassE({JalE, RetE, JumpE, BranchE}), .InstrClassM({JalM, RetM, JumpM, BranchM}));
 
   // the branch predictor needs a compact decoding of the instruction class.
   if (`INSTR_CLASS_PRED == 0) begin : DirectClassDecode
 	logic [3:0] InstrClassF;
 	logic 		cjal, cj, cjr, cjalr, CJumpF, CBranchF;
-	logic 		JumpF, BranchF;
+	logic 		NCJumpF, NCBranchF;
 
 	if(`C_SUPPORTED) begin
 	  logic [4:0] CompressedOpcF;
@@ -166,48 +173,46 @@ module bpred (
 	  assign {cjal, cj, cjr, cjalr, CJumpF, CBranchF} = '0;
 	end
 
-	assign JumpF = PostSpillInstrRawF[6:0] == 7'h67 | PostSpillInstrRawF[6:0] == 7'h6F;
-	assign BranchF = PostSpillInstrRawF[6:0] == 7'h63;
+	assign NCJumpF = PostSpillInstrRawF[6:0] == 7'h67 | PostSpillInstrRawF[6:0] == 7'h6F;
+	assign NCBranchF = PostSpillInstrRawF[6:0] == 7'h63;
 	
-	assign InstrClassF[0] = BranchF | (`C_SUPPORTED & CBranchF);
-	assign InstrClassF[1] = JumpF | (`C_SUPPORTED & (CJumpF));
-	assign InstrClassF[2] = (JumpF & (PostSpillInstrRawF[19:15] & 5'h1B) == 5'h01) | // return must return to ra or r5
-							(`C_SUPPORTED & (cjalr | cjr) & ((PostSpillInstrRawF[11:7] & 5'h1B) == 5'h01));
+	assign BPBranchF = NCBranchF | (`C_SUPPORTED & CBranchF);
+	assign BPJumpF = NCJumpF | (`C_SUPPORTED & (CJumpF));
+	assign BPRetF = (NCJumpF & (PostSpillInstrRawF[19:15] & 5'h1B) == 5'h01) | // return must return to ra or r5
+					(`C_SUPPORTED & (cjalr | cjr) & ((PostSpillInstrRawF[11:7] & 5'h1B) == 5'h01));
 	
-	assign InstrClassF[3] = (JumpF & (PostSpillInstrRawF[11:07] & 5'h1B) == 5'h01) | // jal(r) must link to ra or x5
+	assign BPJalF = (NCJumpF & (PostSpillInstrRawF[11:07] & 5'h1B) == 5'h01) | // jal(r) must link to ra or x5
 							(`C_SUPPORTED & (cjal | (cjalr & (PostSpillInstrRawF[11:7] & 5'h1b) == 5'h01)));
 
-	assign PredInstrClassF = InstrClassF;
-	assign SelBPPredF = (PredInstrClassF[0] & DirPredictionF[1]) | 
-						PredInstrClassF[1];
   end else begin
-	assign PredInstrClassF = BTBPredInstrClassF;
-	assign SelBPPredF = (PredInstrClassF[0] & DirPredictionF[1]) | 
-						PredInstrClassF[1];
+	assign {BPJalF, BPRetF, BPJumpF, BPBranchF} = {BTBJalF, BTBRetF, BTBJumpF, BTBBranchF};
   end
+	assign SelBPPredF = (BPBranchF & DirPredictionF[1]) | BPJumpF;
   
   // Part 3 RAS
   RASPredictor RASPredictor(.clk, .reset, .StallF, .StallD, .StallE, .StallM, .FlushD, .FlushE, .FlushM,
-							.PredInstrClassF, .InstrClassD, .InstrClassE,
-							.WrongPredInstrClassD, .RASPCF, .PCLinkE);
+							.PredInstrClassF({BPJalF, BPRetF, BPJumpF, BPBranchF}), .InstrClassD({JalD, RetD, JumpD, BranchD}), .InstrClassE({JalE, RetE, JumpE, BranchE}),
+							.WrongBPRetD, .RASPCF, .PCLinkE);
 
-  assign BPPredPCF = PredInstrClassF[2] ? RASPCF : BTAF;
+  assign BPPredPCF = BPRetF ? RASPCF : BTAF;
 
-  assign InstrClassD[0] = BranchD;
-  assign InstrClassD[1] = JumpD ;
-  assign InstrClassD[2] = JumpD & (InstrD[19:15] & 5'h1B) == 5'h01; // return must return to ra or x5
-  assign InstrClassD[3] = JumpD & (InstrD[11:7] & 5'h1B) == 5'h01; // jal(r) must link to ra or x5
+  //assign InstrClassD[0] = BranchD;
+  //assign InstrClassD[1] = JumpD ;
+  //assign InstrClassD[2] = JumpD & (InstrD[19:15] & 5'h1B) == 5'h01; // return must return to ra or x5
+  assign RetD = JumpD & (InstrD[19:15] & 5'h1B) == 5'h01; // return must return to ra or x5
+  //assign InstrClassD[3] = JumpD & (InstrD[11:7] & 5'h1B) == 5'h01; // jal(r) must link to ra or x5
+  assign JalD = JumpD & (InstrD[11:7] & 5'h1B) == 5'h01; // jal(r) must link to ra or x5
 
-  flopenrc #(4) InstrClassRegE(clk, reset,  FlushE, ~StallE, InstrClassD, InstrClassE);
-  flopenrc #(4) InstrClassRegM(clk, reset,  FlushM, ~StallM, InstrClassE, InstrClassM);
+  flopenrc #(2) InstrClassRegE(clk, reset,  FlushE, ~StallE, {JalD, RetD}, {JalE, RetE});
+  flopenrc #(4) InstrClassRegM(clk, reset,  FlushM, ~StallM, {JalE, RetE, JumpE, BranchE}, {JalM, RetM, JumpM, BranchM});
   flopenrc #(1) BPPredWrongMReg(clk, reset, FlushM, ~StallM, BPPredWrongE, BPPredWrongM);
 
   // branch predictor
   flopenrc #(1) BPClassWrongRegM(clk, reset, FlushM, ~StallM, AnyWrongPredInstrClassE, PredictionInstrClassWrongM);
-
-  // pipeline the class
-  flopenrc #(4) PredInstrClassRegD(clk, reset, FlushD, ~StallD, PredInstrClassF, PredInstrClassD);
   flopenrc #(1) WrongInstrClassRegE(clk, reset, FlushE, ~StallE, AnyWrongPredInstrClassD, AnyWrongPredInstrClassE);
+
+  // pipeline the predicted class
+  flopenrc #(4) PredInstrClassRegD(clk, reset, FlushD, ~StallD, {BPJalF, BPRetF, BPJumpF, BPBranchF}, {BPJalD, BPRetD, BPJumpD, BPBranchD});
  
   // Check the prediction
   // if it is a CFI then check if the next instruction address (PCD) matches the branch's target or fallthrough address.
@@ -218,8 +223,8 @@ module bpred (
   assign PredictionPCWrongE = PCCorrectE != PCD;
 
   // branch class prediction wrong.
-  assign WrongPredInstrClassD = PredInstrClassD ^ InstrClassD[3:0];
-  assign AnyWrongPredInstrClassD = |WrongPredInstrClassD;
+  assign AnyWrongPredInstrClassD = |({BPJalD, BPRetD, BPJumpD, BPBranchD} ^ {JalD, RetD, JumpD, BranchD});
+  assign WrongBPRetD = BPRetD ^ RetD;
   
   // branch is wrong only if the PC does not match and both the Decode and Fetch stages have valid instructions.
   //assign BPPredWrongE = (PredictionPCWrongE & |InstrClassE | (AnyWrongPredInstrClassE & ~|InstrClassE));
@@ -257,10 +262,10 @@ module bpred (
 	// could be wrong or the fall through address selected for branch predict not taken.
 	// By pipeline the BTB's PC and RAS address through the pipeline we can measure the accuracy of
 	// both without the above inaccuracies.
-	assign BTBPredPCWrongE = (BTAE != IEUAdrE) & (InstrClassE[0] | InstrClassE[1] & ~InstrClassE[2]) & PCSrcE;
-	assign RASPredPCWrongE = (RASPCE != IEUAdrE) & InstrClassE[2] & PCSrcE;
+	assign BTBPredPCWrongE = (BTAE != IEUAdrE) & (BranchE | JumpE & ~RetE) & PCSrcE;
+	assign RASPredPCWrongE = (RASPCE != IEUAdrE) & RetE & PCSrcE;
 
-	assign JumpOrTakenBranchE = (InstrClassE[0] & PCSrcE) | InstrClassE[1];
+	assign JumpOrTakenBranchE = (BranchE & PCSrcE) | JumpE;
 	
 	flopenrc #(1) JumpOrTakenBranchMReg(clk, reset, FlushM, ~StallM, JumpOrTakenBranchE, JumpOrTakenBranchM);
 
@@ -275,5 +280,8 @@ module bpred (
   end else begin
 	assign {BTBPredPCWrongM, RASPredPCWrongM, JumpOrTakenBranchM} = '0;
   end
+
+  // **** Fix me
+  assign InstrClassM = {JalM, RetM, JumpM, BranchM};
   
 endmodule

--- a/src/ifu/bpred/bpred.sv
+++ b/src/ifu/bpred/bpred.sv
@@ -94,9 +94,9 @@ module bpred (
   logic 					RetD, JalD;
   logic 					RetE, JalE;
   logic 					BranchM, JumpM, RetM, JalM;
+  logic 					BranchW, JumpW, RetW, JalW;
   logic 					WrongBPRetD;
-
-  logic [`XLEN-1:0] 		PCW;
+  logic [`XLEN-1:0] 		PCW, IEUAdrW;
 
   // Part 1 branch direction prediction
   // look into the 2 port Sram model. something is wrong. 
@@ -152,8 +152,9 @@ module bpred (
           .BTAF, .BTAD,
           .BTBPredInstrClassF({BTBJalF, BTBRetF, BTBJumpF, BTBBranchF}),
           .PredictionInstrClassWrongM,
-          .IEUAdrE, .IEUAdrM,
-          .InstrClassD({JalD, RetD, JumpD, BranchD}), .InstrClassE({JalE, RetE, JumpE, BranchE}), .InstrClassM({JalM, RetM, JumpM, BranchM}));
+          .IEUAdrE, .IEUAdrM, .IEUAdrW,
+          .InstrClassD({JalD, RetD, JumpD, BranchD}), .InstrClassE({JalE, RetE, JumpE, BranchE}), .InstrClassM({JalM, RetM, JumpM, BranchM}),
+          .InstrClassW({JalW, RetW, JumpW, BranchW}));
 
   if (!`INSTR_CLASS_PRED) begin : DirectClassDecode
 	// This section is mainly for testing, verification, and PPA comparison.
@@ -205,6 +206,7 @@ module bpred (
 
   flopenrc #(2) InstrClassRegE(clk, reset,  FlushE, ~StallE, {JalD, RetD}, {JalE, RetE});
   flopenrc #(4) InstrClassRegM(clk, reset,  FlushM, ~StallM, {JalE, RetE, JumpE, BranchE}, {JalM, RetM, JumpM, BranchM});
+  flopenrc #(4) InstrClassRegW(clk, reset,  FlushM, ~StallW, {JalM, RetM, JumpM, BranchM}, {JalW, RetW, JumpW, BranchW});
   flopenrc #(1) BPPredWrongMReg(clk, reset, FlushM, ~StallM, BPPredWrongE, BPPredWrongM);
 
   // branch predictor
@@ -283,5 +285,7 @@ module bpred (
   // **** Fix me
   assign InstrClassM = {JalM, RetM, JumpM, BranchM};
   flopenr #(`XLEN) PCWReg(clk, reset, ~StallW, PCM, PCW);
+  flopenrc #(`XLEN) IEUAdrWReg(clk, reset, FlushW, ~StallW, IEUAdrM, IEUAdrW);
+
   
 endmodule

--- a/src/ifu/bpred/bpred.sv
+++ b/src/ifu/bpred/bpred.sv
@@ -285,7 +285,7 @@ module bpred (
   // **** Fix me
   assign InstrClassM = {JalM, RetM, JumpM, BranchM};
   flopenr #(`XLEN) PCWReg(clk, reset, ~StallW, PCM, PCW);
-  flopenrc #(`XLEN) IEUAdrWReg(clk, reset, FlushW, ~StallW, IEUAdrM, IEUAdrW);
+  flopenr #(`XLEN) IEUAdrWReg(clk, reset, ~StallW, IEUAdrM, IEUAdrW);
 
   
 endmodule

--- a/src/ifu/bpred/bpred.sv
+++ b/src/ifu/bpred/bpred.sv
@@ -103,29 +103,29 @@ module bpred (
     twoBitPredictor #(`BPRED_SIZE) DirPredictor(.clk, .reset, .StallF, .StallD, .StallE, .StallM, .StallW, 
       .FlushD, .FlushE, .FlushM, .FlushW,
       .PCNextF, .PCM, .DirPredictionF, .DirPredictionWrongE,
-      .BranchInstrE(BranchE), .BranchInstrM(BranchM), .PCSrcE);
+      .BranchE, .BranchM, .PCSrcE);
 
   end else if (`BPRED_TYPE == "BP_GSHARE") begin:Predictor
     gshare #(`BPRED_SIZE) DirPredictor(.clk, .reset, .StallF, .StallD, .StallE, .StallM, .StallW, .FlushD, .FlushE, .FlushM, .FlushW,
       .PCNextF, .PCF, .PCD, .PCE, .PCM, .DirPredictionF, .DirPredictionWrongE,
-      .BranchInstrF(BPBranchF), .BranchInstrD(BranchD), .BranchInstrE(BranchE), .BranchInstrM(BranchM),
+      .BPBranchF, .BranchD, .BranchE, .BranchM,
       .PCSrcE);
 
   end else if (`BPRED_TYPE == "BP_GLOBAL") begin:Predictor
     gshare #(`BPRED_SIZE, 0) DirPredictor(.clk, .reset, .StallF, .StallD, .StallE, .StallM, .StallW, .FlushD, .FlushE, .FlushM, .FlushW,
       .PCNextF, .PCF, .PCD, .PCE, .PCM, .DirPredictionF, .DirPredictionWrongE,
-      .BranchInstrF(BPBranchF), .BranchInstrD(BranchD), .BranchInstrE(BranchE), .BranchInstrM(BranchM),
+      .BPBranchF, .BranchD, .BranchE, .BranchM,
       .PCSrcE);
 
   end else if (`BPRED_TYPE == "BP_GSHARE_BASIC") begin:Predictor
     gsharebasic #(`BPRED_SIZE) DirPredictor(.clk, .reset, .StallF, .StallD, .StallE, .StallM, .StallW, .FlushD, .FlushE, .FlushM, .FlushW,
       .PCNextF, .PCM, .DirPredictionF, .DirPredictionWrongE,
-      .BranchInstrE(BranchE), .BranchInstrM(BranchM), .PCSrcE);
+      .BranchE, .BranchM, .PCSrcE);
 
   end else if (`BPRED_TYPE == "BP_GLOBAL_BASIC") begin:Predictor
     gsharebasic #(`BPRED_SIZE, 0) DirPredictor(.clk, .reset, .StallF, .StallD, .StallE, .StallM, .StallW, .FlushD, .FlushE, .FlushM, .FlushW,
       .PCNextF, .PCM, .DirPredictionF, .DirPredictionWrongE,
-      .BranchInstrE(BranchE), .BranchInstrM(BranchM), .PCSrcE);
+      .BranchE, .BranchM, .PCSrcE);
 	
   end else if (`BPRED_TYPE == "BPLOCALPAg") begin:Predictor
     // *** Fix me
@@ -191,7 +191,7 @@ module bpred (
   
   // Part 3 RAS
   RASPredictor RASPredictor(.clk, .reset, .StallF, .StallD, .StallE, .StallM, .FlushD, .FlushE, .FlushM,
-							.PredInstrClassF({BPJalF, BPRetF, BPJumpF, BPBranchF}), .InstrClassD({JalD, RetD, JumpD, BranchD}), .InstrClassE({JalE, RetE, JumpE, BranchE}),
+							.BPRetF, .RetD, .RetE, .JalE,
 							.WrongBPRetD, .RASPCF, .PCLinkE);
 
   assign BPPredPCF = BPRetF ? RASPCF : BTAF;

--- a/src/ifu/bpred/btb.sv
+++ b/src/ifu/bpred/btb.sv
@@ -42,9 +42,11 @@ module btb #(parameter Depth = 10 ) (
   input  logic 			   PredictionInstrClassWrongM, // BTB's instruction class guess was wrong
   input  logic [`XLEN-1:0] IEUAdrE, // Branch/jump target address to insert into btb
   input  logic [`XLEN-1:0] IEUAdrM, // Branch/jump target address to insert into btb
+  input  logic [`XLEN-1:0] IEUAdrW,
   input  logic [3:0] 	   InstrClassD, // Instruction class to insert into btb
   input  logic [3:0] 	   InstrClassE, // Instruction class to insert into btb
-  input  logic [3:0] 	   InstrClassM                            // Instruction class to insert into btb
+  input  logic [3:0] 	   InstrClassM,                            // Instruction class to insert into btb
+  input  logic [3:0]       InstrClassW
 );
 
   logic [Depth-1:0]         PCNextFIndex, PCFIndex, PCDIndex, PCEIndex, PCMIndex, PCWIndex;
@@ -53,8 +55,6 @@ module btb #(parameter Depth = 10 ) (
   logic [`XLEN+3:0] 		ForwardBTBPrediction, ForwardBTBPredictionF;
   logic [`XLEN+3:0] 		TableBTBPredictionF;
   logic 					UpdateEn;
-  logic [3:0] 				InstrClassW;
-  logic [`XLEN-1:0] 		IEUAdrW;
     
   // hashing function for indexing the PC
   // We have Depth bits to index, but XLEN bits as the input.
@@ -102,7 +102,5 @@ module btb #(parameter Depth = 10 ) (
      .ce2(~StallW & ~FlushW), .wa2(PCMIndex), .wd2({InstrClassM, IEUAdrM}), .we2(UpdateEn), .bwe2('1));
 
   flopenrc #(`XLEN) BTBD(clk, reset, FlushD, ~StallD, BTAF, BTAD);
-
-  flopenrc #(`XLEN+4) IEUAdrWReg(clk, reset, FlushW, ~StallW, {InstrClassM, IEUAdrM}, {InstrClassW, IEUAdrW});
 
 endmodule

--- a/src/ifu/bpred/btb.sv
+++ b/src/ifu/bpred/btb.sv
@@ -51,7 +51,7 @@ module btb #(parameter Depth = 10 ) (
 
   logic [Depth-1:0]         PCNextFIndex, PCFIndex, PCDIndex, PCEIndex, PCMIndex, PCWIndex;
   logic [`XLEN-1:0] 		ResetPC;
-  logic 					MatchF, MatchD, MatchE, MatchM, MatchW, MatchX;
+  logic 					MatchD, MatchE, MatchM, MatchW, MatchX;
   logic [`XLEN+3:0] 		ForwardBTBPrediction, ForwardBTBPredictionF;
   logic [`XLEN+3:0] 		TableBTBPredictionF;
   logic 					UpdateEn;
@@ -73,7 +73,6 @@ module btb #(parameter Depth = 10 ) (
   assign ResetPC = `RESET_VECTOR;
   assign PCNextFIndex = reset ? ResetPC[Depth+1:2] : {PCNextF[Depth+1] ^ PCNextF[1], PCNextF[Depth:2]}; 
 
-  assign MatchF = PCNextFIndex == PCFIndex;
   assign MatchD = PCFIndex == PCDIndex;
   assign MatchE = PCFIndex == PCEIndex;
   assign MatchM = PCFIndex == PCMIndex;
@@ -81,9 +80,9 @@ module btb #(parameter Depth = 10 ) (
   assign MatchX = MatchD | MatchE | MatchM | MatchW;
 
   assign ForwardBTBPredictionF = MatchD ? {InstrClassD, BTAD} :
-                                MatchE ? {InstrClassE, IEUAdrE} :
-                                MatchM ? {InstrClassM, IEUAdrM} :
-                                {InstrClassW, IEUAdrW} ;
+                                 MatchE ? {InstrClassE, IEUAdrE} :
+                                 MatchM ? {InstrClassM, IEUAdrM} :
+                                 {InstrClassW, IEUAdrW} ;
 
   assign {BTBPredInstrClassF, BTAF} = MatchX ? ForwardBTBPredictionF : {TableBTBPredictionF};
 

--- a/src/ifu/bpred/btb.sv
+++ b/src/ifu/bpred/btb.sv
@@ -51,7 +51,7 @@ module btb #(parameter Depth = 10 ) (
 
   logic [Depth-1:0]         PCNextFIndex, PCFIndex, PCDIndex, PCEIndex, PCMIndex, PCWIndex;
   logic [`XLEN-1:0] 		ResetPC;
-  logic 					MatchF, MatchD, MatchE, MatchM, MatchW, MatchNextX, MatchX;
+  logic 					MatchF, MatchD, MatchE, MatchM, MatchW, MatchX;
   logic [`XLEN+3:0] 		ForwardBTBPrediction, ForwardBTBPredictionF;
   logic [`XLEN+3:0] 		TableBTBPredictionF;
   logic 					UpdateEn;
@@ -79,20 +79,13 @@ module btb #(parameter Depth = 10 ) (
   assign MatchM = PCFIndex == PCMIndex;
   assign MatchW = PCFIndex == PCWIndex;
   assign MatchX = MatchD | MatchE | MatchM | MatchW;
-  
-//  flopenr #(1) MatchReg(clk, reset, ~StallF, MatchNextX, MatchXF);
 
   assign ForwardBTBPredictionF = MatchD ? {InstrClassD, BTAD} :
                                 MatchE ? {InstrClassE, IEUAdrE} :
                                 MatchM ? {InstrClassM, IEUAdrM} :
                                 {InstrClassW, IEUAdrW} ;
 
-/* -----\/----- EXCLUDED -----\/-----
-  flopenr #(`XLEN+4) ForwardBTBPredicitonReg(clk, reset, ~StallF, ForwardBTBPrediction, ForwardBTBPredictionF);
- -----/\----- EXCLUDED -----/\----- */
-
   assign {BTBPredInstrClassF, BTAF} = MatchX ? ForwardBTBPredictionF : {TableBTBPredictionF};
-
 
   assign UpdateEn = |InstrClassM | PredictionInstrClassWrongM;
 

--- a/src/ifu/bpred/gshare.sv
+++ b/src/ifu/bpred/gshare.sv
@@ -43,9 +43,9 @@ module gshare #(parameter k = 10,
 );
 
   logic                    MatchF, MatchD, MatchE, MatchM, MatchW;
-  logic                    MatchX, MatchXF;
+  logic                    MatchX;
 
-  logic [1:0]              TableDirPredictionF, DirPredictionD, DirPredictionE, ForwardNewDirPredictionF, ForwardDirPredictionF;
+  logic [1:0]              TableDirPredictionF, DirPredictionD, DirPredictionE, ForwardNewDirPredictionF;
   logic [1:0]              NewDirPredictionE, NewDirPredictionM, NewDirPredictionW;
 
   logic [k-1:0]            IndexNextF, IndexF, IndexD, IndexE, IndexM, IndexW;
@@ -70,22 +70,17 @@ module gshare #(parameter k = 10,
 
   flopenrc #(k) IndexWReg(clk, reset, FlushW, ~StallW, IndexM, IndexW);
 
-  //assign MatchF = BPBranchF & ~FlushD & (IndexNextF == IndexF);
   assign MatchD = BranchD & ~FlushE & (IndexF == IndexD);
   assign MatchE = BranchE & ~FlushM & (IndexF == IndexE);
   assign MatchM = BranchM & ~FlushW & (IndexF == IndexM);
   assign MatchW = BranchW & ~FlushW & (IndexF == IndexW);
   assign MatchX = MatchD | MatchE | MatchM | MatchW;
 
-//  flopenr #(1) MatchReg(clk, reset, ~StallF, MatchNextX, MatchXF);
-
   assign ForwardNewDirPredictionF = MatchD ? {2{DirPredictionD[1]}} :
                                    MatchE ? {NewDirPredictionE} :
                                    MatchM ? {NewDirPredictionM} :
 								   NewDirPredictionW ;
   
-  //flopenr #(2) ForwardDirPredicitonReg(clk, reset, ~StallF, ForwardNewDirPrediction, ForwardDirPredictionF);
-
   assign DirPredictionF = MatchX ? ForwardNewDirPredictionF : TableDirPredictionF;
 
   ram2p1r1wbe #(2**k, 2) PHT(.clk(clk),

--- a/src/ifu/bpred/gsharebasic.sv
+++ b/src/ifu/bpred/gsharebasic.sv
@@ -39,7 +39,7 @@ module gsharebasic #(parameter k = 10,
   output logic            DirPredictionWrongE,
   // update
   input logic [`XLEN-1:0] PCNextF, PCM,
-  input logic             BranchInstrE, BranchInstrM, PCSrcE
+  input logic             BranchE, BranchM, PCSrcE
 );
 
   logic [k-1:0] 		  IndexNextF, IndexM;
@@ -64,7 +64,7 @@ module gsharebasic #(parameter k = 10,
     .rd1(DirPredictionF),
     .wa2(IndexM),
     .wd2(NewDirPredictionM),
-    .we2(BranchInstrM),
+    .we2(BranchM),
     .bwe2(1'b1));
 
   flopenrc #(2) PredictionRegD(clk, reset,  FlushD, ~StallD, DirPredictionF, DirPredictionD);
@@ -73,10 +73,10 @@ module gsharebasic #(parameter k = 10,
   satCounter2 BPDirUpdateE(.BrDir(PCSrcE), .OldState(DirPredictionE), .NewState(NewDirPredictionE));
   flopenrc #(2) NewPredictionRegM(clk, reset,  FlushM, ~StallM, NewDirPredictionE, NewDirPredictionM);
 
-  assign DirPredictionWrongE = PCSrcE != DirPredictionE[1] & BranchInstrE;
+  assign DirPredictionWrongE = PCSrcE != DirPredictionE[1] & BranchE;
 
-  assign GHRNext = BranchInstrM ? {PCSrcM, GHR[k-1:1]} : GHR;
-  flopenr #(k) GHRReg(clk, reset, ~StallM & ~FlushM & BranchInstrM, GHRNext, GHR);
+  assign GHRNext = BranchM ? {PCSrcM, GHR[k-1:1]} : GHR;
+  flopenr #(k) GHRReg(clk, reset, ~StallM & ~FlushM & BranchM, GHRNext, GHR);
   flopenrc #(1) PCSrcMReg(clk, reset, FlushM, ~StallM, PCSrcE, PCSrcM);
     
   flopenrc #(k) GHRFReg(clk, reset, FlushD, ~StallF, GHR, GHRF);

--- a/src/ifu/bpred/twoBitPredictor.sv
+++ b/src/ifu/bpred/twoBitPredictor.sv
@@ -31,8 +31,8 @@
 module twoBitPredictor #(parameter k = 10) (
   input  logic             clk,
   input  logic             reset,
-  input  logic             StallF, StallD, StallE, StallM,
-  input  logic             FlushD, FlushE, FlushM,
+  input  logic             StallF, StallD, StallE, StallM, StallW,
+  input  logic             FlushD, FlushE, FlushM, FlushW,
   input  logic [`XLEN-1:0] PCNextF, PCM,
   output logic [1:0]       DirPredictionF,
   output logic             DirPredictionWrongE,
@@ -55,12 +55,12 @@ module twoBitPredictor #(parameter k = 10) (
 
 
   ram2p1r1wbe #(2**k, 2) PHT(.clk(clk),
-    .ce1(~StallF), .ce2(~StallM & ~FlushM),
+    .ce1(~StallF), .ce2(~StallW & ~FlushW),
     .ra1(IndexNextF),
     .rd1(DirPredictionF),
     .wa2(IndexM),
     .wd2(NewDirPredictionM),
-    .we2(BranchInstrM & ~StallM & ~FlushM),
+    .we2(BranchInstrM),
     .bwe2(1'b1));
   
   flopenrc #(2) PredictionRegD(clk, reset,  FlushD, ~StallD, DirPredictionF, DirPredictionD);

--- a/src/ifu/bpred/twoBitPredictor.sv
+++ b/src/ifu/bpred/twoBitPredictor.sv
@@ -36,7 +36,7 @@ module twoBitPredictor #(parameter k = 10) (
   input  logic [`XLEN-1:0] PCNextF, PCM,
   output logic [1:0]       DirPredictionF,
   output logic             DirPredictionWrongE,
-  input  logic             BranchInstrE, BranchInstrM,
+  input  logic             BranchE, BranchM,
   input  logic             PCSrcE
 );
 
@@ -60,13 +60,13 @@ module twoBitPredictor #(parameter k = 10) (
     .rd1(DirPredictionF),
     .wa2(IndexM),
     .wd2(NewDirPredictionM),
-    .we2(BranchInstrM),
+    .we2(BranchM),
     .bwe2(1'b1));
   
   flopenrc #(2) PredictionRegD(clk, reset,  FlushD, ~StallD, DirPredictionF, DirPredictionD);
   flopenrc #(2) PredictionRegE(clk, reset,  FlushE, ~StallE, DirPredictionD, DirPredictionE);
 
-  assign DirPredictionWrongE = PCSrcE != DirPredictionE[1] & BranchInstrE;
+  assign DirPredictionWrongE = PCSrcE != DirPredictionE[1] & BranchE;
 
   satCounter2 BPDirUpdateE(.BrDir(PCSrcE), .OldState(DirPredictionE), .NewState(NewDirPredictionE));
   flopenrc #(2) NewPredictionRegM(clk, reset,  FlushM, ~StallM, NewDirPredictionE, NewDirPredictionM);


### PR DESCRIPTION
- Partial replacement of InstrClassX with {JalX, RetX, JumpX, and BranchX}.
- Major cleanup of bp.
- Improved branch predictor graph generation.
- Modified btb forwarding logic to reduce critical path.
- Prep to fix gshare critical path.
- Completed critical path gshare fix.
- Cleanup.
- Possible fix to btb performance issue.
