### PR TITLE
Modified Performance Counter Data Collection

### DIFF
--- a/bin/parseHPMC.py
+++ b/bin/parseHPMC.py
@@ -67,11 +67,23 @@ def ComputeICacheMissRate(benchmark):
     ICacheMR = 100.0 * int(dataDict['I Cache Miss']) / int(dataDict['I Cache Access'])
     dataDict['ICacheMR'] = ICacheMR
 
+def ComputeICacheMissTime(benchmark):
+    'Computes and inserts instruction class miss prediction rate.'
+    (nameString, opt, dataDict) = benchmark
+    ICacheMR = 100.0 * int(dataDict['I Cache Cycles']) / int(dataDict['I Cache Miss'])
+    dataDict['ICacheMT'] = ICacheMR
+    
 def ComputeDCacheMissRate(benchmark):
     'Computes and inserts instruction class miss prediction rate.'
     (nameString, opt, dataDict) = benchmark
     DCacheMR = 100.0 * int(dataDict['D Cache Miss']) / int(dataDict['D Cache Access'])
     dataDict['DCacheMR'] = DCacheMR
+
+def ComputeDCacheMissTime(benchmark):
+    'Computes and inserts instruction class miss prediction rate.'
+    (nameString, opt, dataDict) = benchmark
+    ICacheMR = 100.0 * int(dataDict['D Cache Cycles']) / int(dataDict['D Cache Miss'])
+    dataDict['DCacheMT'] = ICacheMR
 
 def ComputeAll(benchmarks):
     for benchmark in benchmarks:
@@ -81,23 +93,23 @@ def ComputeAll(benchmarks):
         ComputeRASMissRate(benchmark)
         ComputeInstrClassMissRate(benchmark)
         ComputeICacheMissRate(benchmark)
+        ComputeICacheMissTime(benchmark)
         ComputeDCacheMissRate(benchmark)
+        ComputeDCacheMissTime(benchmark)
     
 def printStats(benchmark):
     (nameString, opt, dataDict) = benchmark
-    CPI = dataDict['CPI']
-    BDMR = dataDict['BDMR']
-    BTMR = dataDict['BTMR']
-    RASMPR = dataDict['RASMPR']
     print('Test', nameString)
     print('Compile configuration', opt)
-    print('CPI \t\t\t  %1.2f' % CPI)
-    print('Branch Dir Pred Miss Rate %2.2f' % BDMR)
-    print('Branch Target Pred Miss Rate %2.2f' % BTMR)
-    print('RAS Miss Rate \t\t  %1.2f' % RASMPR)
+    print('CPI \t\t\t  %1.2f' % dataDict['CPI'])
+    print('Branch Dir Pred Miss Rate %2.2f' % dataDict['BDMR'])
+    print('Branch Target Pred Miss Rate %2.2f' % dataDict['BTMR'])
+    print('RAS Miss Rate \t\t  %1.2f' % dataDict['RASMPR'])
     print('Instr Class Miss Rate  %1.2f' % dataDict['ClassMPR'])
     print('I Cache Miss Rate  %1.4f' % dataDict['ICacheMR'])
+    print('I Cache Miss Ave Cycles  %1.4f' % dataDict['ICacheMT'])
     print('D Cache Miss Rate  %1.4f' % dataDict['DCacheMR'])
+    print('D Cache Miss Ave Cycles  %1.4f' % dataDict['DCacheMT'])
     print()
 
 def ProcessFile(fileName):
@@ -156,7 +168,7 @@ def GeometricAverage(benchmarks, field):
     return Product ** (1.0/index)
 
 def ComputeGeometricAverage(benchmarks):
-    fields = ['BDMR', 'BTMR', 'RASMPR', 'ClassMPR', 'ICacheMR', 'DCacheMR', 'CPI']
+    fields = ['BDMR', 'BTMR', 'RASMPR', 'ClassMPR', 'ICacheMR', 'DCacheMR', 'CPI', 'ICacheMT', 'DCacheMT']
     AllAve = {}
     for field in fields:
         Product = 1

--- a/sim/wally-batch.do
+++ b/sim/wally-batch.do
@@ -81,11 +81,11 @@ if {$2 eq "buildroot" || $2 eq "buildroot-checkpoint"} {
     # start and run simulation
     # remove +acc flag for faster sim during regressions if there is no need to access internal signals
     vopt wkdir/work_${1}_${2}.testbench -work wkdir/work_${1}_${2} -G TEST=$2 -o testbenchopt
-    vsim -lib wkdir/work_${1}_${2} testbenchopt  -fatal 7
+    vsim -lib wkdir/work_${1}_${2} testbenchopt  -fatal 7 -suppress 3829
     # Adding coverage increases runtime from 2:00 to 4:29.  Can't run it all the time
     #vopt work_$2.testbench -work work_$2 -o workopt_$2 +cover=sbectf
     #vsim -coverage -lib work_$2 workopt_$2
-
+    do wave.do
     # power add generates the logging necessary for said generation.
     # power add -r /dut/core/*
     run -all

--- a/sim/wally-batch.do
+++ b/sim/wally-batch.do
@@ -85,7 +85,6 @@ if {$2 eq "buildroot" || $2 eq "buildroot-checkpoint"} {
     # Adding coverage increases runtime from 2:00 to 4:29.  Can't run it all the time
     #vopt work_$2.testbench -work work_$2 -o workopt_$2 +cover=sbectf
     #vsim -coverage -lib work_$2 workopt_$2
-    do wave.do
     # power add generates the logging necessary for said generation.
     # power add -r /dut/core/*
     run -all

--- a/sim/wave.do
+++ b/sim/wave.do
@@ -6,7 +6,6 @@ add wave -noupdate /testbench/reset
 add wave -noupdate /testbench/reset_ext
 add wave -noupdate /testbench/memfilename
 add wave -noupdate /testbench/dut/core/SATP_REGW
-add wave -noupdate -group HDU -expand -group hazards /testbench/dut/core/hzu/BPPredWrongE
 add wave -noupdate -group HDU -expand -group hazards /testbench/dut/core/hzu/RetM
 add wave -noupdate -group HDU -expand -group hazards -color Pink /testbench/dut/core/hzu/TrapM
 add wave -noupdate -group HDU -expand -group hazards /testbench/dut/core/hzu/LoadStallD
@@ -56,11 +55,11 @@ add wave -noupdate -group {Decode Stage} /testbench/dut/core/ieu/c/RegWriteD
 add wave -noupdate -group {Decode Stage} /testbench/dut/core/ieu/dp/RdD
 add wave -noupdate -group {Decode Stage} /testbench/dut/core/ieu/dp/Rs1D
 add wave -noupdate -group {Decode Stage} /testbench/dut/core/ieu/dp/Rs2D
-add wave -noupdate -group {Execution Stage} /testbench/dut/core/ifu/PCE
-add wave -noupdate -group {Execution Stage} /testbench/dut/core/ifu/InstrE
-add wave -noupdate -group {Execution Stage} /testbench/InstrEName
-add wave -noupdate -group {Execution Stage} /testbench/dut/core/ieu/c/InstrValidE
-add wave -noupdate -group {Execution Stage} /testbench/FunctionName/FunctionName/FunctionName
+add wave -noupdate -expand -group {Execution Stage} /testbench/dut/core/ifu/PCE
+add wave -noupdate -expand -group {Execution Stage} /testbench/dut/core/ifu/InstrE
+add wave -noupdate -expand -group {Execution Stage} /testbench/InstrEName
+add wave -noupdate -expand -group {Execution Stage} /testbench/dut/core/ieu/c/InstrValidE
+add wave -noupdate -expand -group {Execution Stage} /testbench/FunctionName/FunctionName/FunctionName
 add wave -noupdate -expand -group {Memory Stage} /testbench/dut/core/PCM
 add wave -noupdate -expand -group {Memory Stage} /testbench/dut/core/InstrM
 add wave -noupdate -expand -group {Memory Stage} /testbench/InstrMName
@@ -91,19 +90,10 @@ add wave -noupdate -group CSRs -group {user mode} /testbench/dut/core/priv/priv/
 add wave -noupdate -group Bpred -group {branch update selection inputs} -divider {class check}
 add wave -noupdate -group Bpred -group prediction /testbench/dut/core/ifu/bpred/bpred/RASPCF
 add wave -noupdate -group Bpred -group prediction -expand -group ex /testbench/dut/core/ifu/bpred/bpred/PCSrcE
-add wave -noupdate -group Bpred -group {bp wrong} /testbench/dut/core/ifu/bpred/bpred/PredictionPCWrongE
-add wave -noupdate -group Bpred -group {bp wrong} /testbench/dut/core/ifu/bpred/bpred/InstrClassE
-add wave -noupdate -group Bpred -group {bp wrong} /testbench/dut/core/ifu/bpred/bpred/BPPredWrongE
-add wave -noupdate -group Bpred /testbench/dut/core/ifu/bpred/bpred/BPPredWrongE
 add wave -noupdate -group {PCNext Generation} /testbench/dut/core/ifu/PCNextF
 add wave -noupdate -group {PCNext Generation} /testbench/dut/core/ifu/bpred/bpred/NextValidPCE
 add wave -noupdate -group {PCNext Generation} /testbench/dut/core/ifu/PCF
 add wave -noupdate -group {PCNext Generation} /testbench/dut/core/ifu/PCPlus2or4F
-add wave -noupdate -group {PCNext Generation} /testbench/dut/core/ifu/bpred/bpred/BPPredPCF
-add wave -noupdate -group {PCNext Generation} /testbench/dut/core/ifu/bpred/bpred/SelBPPredF
-add wave -noupdate -group {PCNext Generation} /testbench/dut/core/ifu/bpred/bpred/PCNext0F
-add wave -noupdate -group {PCNext Generation} /testbench/dut/core/ifu/PCNext1F
-add wave -noupdate -group {PCNext Generation} /testbench/dut/core/ifu/BPPredWrongE
 add wave -noupdate -group RegFile -expand /testbench/dut/core/ieu/dp/regf/rf
 add wave -noupdate -group RegFile /testbench/dut/core/ieu/dp/regf/a1
 add wave -noupdate -group RegFile /testbench/dut/core/ieu/dp/regf/a2
@@ -457,7 +447,6 @@ add wave -noupdate -group {debug trace} -expand -group mem -color Yellow /testbe
 add wave -noupdate -group {debug trace} -expand -group mem /testbench/dut/core/PCM
 add wave -noupdate -group {debug trace} -expand -group mem -color Brown /testbench/dut/core/hzu/TrapM
 add wave -noupdate -group {debug trace} -expand -group wb /testbench/PCW
-add wave -noupdate -group {pc selection} /testbench/dut/core/ifu/PCNext2F
 add wave -noupdate -group ifu /testbench/dut/core/ifu/InstrRawF
 add wave -noupdate -group ifu /testbench/dut/core/ifu/PostSpillInstrRawF
 add wave -noupdate -group ifu /testbench/dut/core/ifu/IFUStallF
@@ -465,7 +454,6 @@ add wave -noupdate -group ifu -group Spill /testbench/dut/core/ifu/Spill/spill/C
 add wave -noupdate -group ifu -group Spill -expand -group takespill /testbench/dut/core/ifu/Spill/spill/SpillF
 add wave -noupdate -group ifu -group Spill -expand -group takespill /testbench/dut/core/ifu/Spill/spill/IFUCacheBusStallD
 add wave -noupdate -group ifu -group Spill -expand -group takespill /testbench/dut/core/ifu/Spill/spill/ITLBMissF
-add wave -noupdate -group ifu -group Spill -expand -group takespill /testbench/dut/core/ifu/Spill/spill/InstrDAPageFaultF
 add wave -noupdate -group ifu -group Spill -expand -group takespill /testbench/dut/core/ifu/Spill/spill/TakeSpillF
 add wave -noupdate -group ifu -group Spill /testbench/dut/core/ifu/SelNextSpillF
 add wave -noupdate -group ifu -group bus /testbench/dut/core/ifu/bus/icache/ahbcacheinterface/HSIZE
@@ -558,19 +546,29 @@ add wave -noupdate -group ifu -group itlb -expand -group key19 {/testbench/dut/c
 add wave -noupdate -group ifu -group itlb -expand -group key19 {/testbench/dut/core/ifu/immu/immu/tlb/tlb/tlbcam/camlines[19]/Query1}
 add wave -noupdate -expand -group {Performance Counters} -label MCYCLE -radix unsigned {/testbench/dut/core/priv/priv/csr/counters/counters/HPMCOUNTER_REGW[0]}
 add wave -noupdate -expand -group {Performance Counters} -label MINSTRET -radix unsigned {/testbench/dut/core/priv/priv/csr/counters/counters/HPMCOUNTER_REGW[2]}
-add wave -noupdate -expand -group {Performance Counters} -label {LOAD STORE HAZARD} -radix unsigned {/testbench/dut/core/priv/priv/csr/counters/counters/HPMCOUNTER_REGW[3]}
-add wave -noupdate -expand -group {Performance Counters} -expand -group BRP -label {BP DIRECTION WRONG} -radix unsigned {/testbench/dut/core/priv/priv/csr/counters/counters/HPMCOUNTER_REGW[4]}
-add wave -noupdate -expand -group {Performance Counters} -expand -group BRP -label {BP INSTRUCTION} -radix unsigned {/testbench/dut/core/priv/priv/csr/counters/counters/HPMCOUNTER_REGW[5]}
-add wave -noupdate -expand -group {Performance Counters} -expand -group BRP -label {BTA/JTA WRONG} -radix unsigned {/testbench/dut/core/priv/priv/csr/counters/counters/HPMCOUNTER_REGW[6]}
-add wave -noupdate -expand -group {Performance Counters} -expand -group BRP -label {JAL(R) INSTRUCTION} -radix unsigned {/testbench/dut/core/priv/priv/csr/counters/counters/HPMCOUNTER_REGW[7]}
-add wave -noupdate -expand -group {Performance Counters} -expand -group BRP -label {RAS WRONG} -radix unsigned {/testbench/dut/core/priv/priv/csr/counters/counters/HPMCOUNTER_REGW[8]}
-add wave -noupdate -expand -group {Performance Counters} -expand -group BRP -label {RETURN INSTRUCTION} -radix unsigned {/testbench/dut/core/priv/priv/csr/counters/counters/HPMCOUNTER_REGW[9]}
-add wave -noupdate -expand -group {Performance Counters} -expand -group BRP -label {BP CLASS WRONG} -radix unsigned {/testbench/dut/core/priv/priv/csr/counters/counters/HPMCOUNTER_REGW[10]}
-add wave -noupdate -expand -group {Performance Counters} -expand -group BRP -label {Branch Predictor Wrong} -radix unsigned {/testbench/dut/core/priv/priv/csr/counters/counters/HPMCOUNTER_REGW[15]}
-add wave -noupdate -expand -group {Performance Counters} -expand -group ICACHE -label {ICACHE ACCESS} -radix unsigned {/testbench/dut/core/priv/priv/csr/counters/counters/HPMCOUNTER_REGW[13]}
-add wave -noupdate -expand -group {Performance Counters} -expand -group ICACHE -label {ICACHE MISS} -radix unsigned {/testbench/dut/core/priv/priv/csr/counters/counters/HPMCOUNTER_REGW[14]}
-add wave -noupdate -expand -group {Performance Counters} -expand -group DCACHE -label {DCACHE ACCESS} -radix unsigned {/testbench/dut/core/priv/priv/csr/counters/counters/HPMCOUNTER_REGW[11]}
-add wave -noupdate -expand -group {Performance Counters} -expand -group DCACHE -label {DCACHE MISS} -radix unsigned {/testbench/dut/core/priv/priv/csr/counters/counters/HPMCOUNTER_REGW[12]}
+add wave -noupdate -expand -group {Performance Counters} -expand -group BP -label Branch -radix unsigned {/testbench/dut/core/priv/priv/csr/counters/counters/HPMCOUNTER_REGW[3]}
+add wave -noupdate -expand -group {Performance Counters} -expand -group BP -label {Jump (Not Return)} -radix unsigned {/testbench/dut/core/priv/priv/csr/counters/counters/HPMCOUNTER_REGW[4]}
+add wave -noupdate -expand -group {Performance Counters} -expand -group BP -label Return -radix unsigned {/testbench/dut/core/priv/priv/csr/counters/counters/HPMCOUNTER_REGW[5]}
+add wave -noupdate -expand -group {Performance Counters} -expand -group BP -label {BP Wrong} -radix unsigned {/testbench/dut/core/priv/priv/csr/counters/counters/HPMCOUNTER_REGW[6]}
+add wave -noupdate -expand -group {Performance Counters} -expand -group BP -label {BP Dir Wrong} -radix unsigned {/testbench/dut/core/priv/priv/csr/counters/counters/HPMCOUNTER_REGW[7]}
+add wave -noupdate -expand -group {Performance Counters} -expand -group BP -label {BTA Wrong} -radix unsigned {/testbench/dut/core/priv/priv/csr/counters/counters/HPMCOUNTER_REGW[8]}
+add wave -noupdate -expand -group {Performance Counters} -expand -group BP -label {RAS Wrong} -radix unsigned {/testbench/dut/core/priv/priv/csr/counters/counters/HPMCOUNTER_REGW[9]}
+add wave -noupdate -expand -group {Performance Counters} -expand -group BP -label {BP CLASS WRONG} -radix unsigned {/testbench/dut/core/priv/priv/csr/counters/counters/HPMCOUNTER_REGW[10]}
+add wave -noupdate -expand -group {Performance Counters} -group ICACHE -label {I Cache Access} {/testbench/dut/core/priv/priv/csr/counters/counters/HPMCOUNTER_REGW[16]}
+add wave -noupdate -expand -group {Performance Counters} -group ICACHE -label {I Cache Miss} {/testbench/dut/core/priv/priv/csr/counters/counters/HPMCOUNTER_REGW[17]}
+add wave -noupdate -expand -group {Performance Counters} -group ICACHE -label {I Cache Miss Cycles} {/testbench/dut/core/priv/priv/csr/counters/counters/HPMCOUNTER_REGW[18]}
+add wave -noupdate -expand -group {Performance Counters} -group DCACHE -label {Load Stall} -radix unsigned {/testbench/dut/core/priv/priv/csr/counters/counters/HPMCOUNTER_REGW[11]}
+add wave -noupdate -expand -group {Performance Counters} -group DCACHE -label {Store Stall} -radix unsigned {/testbench/dut/core/priv/priv/csr/counters/counters/HPMCOUNTER_REGW[12]}
+add wave -noupdate -expand -group {Performance Counters} -group DCACHE -label {DCACHE MISS} -radix unsigned {/testbench/dut/core/priv/priv/csr/counters/counters/HPMCOUNTER_REGW[14]}
+add wave -noupdate -expand -group {Performance Counters} -group DCACHE -label {DCACHE ACCESS} -radix unsigned {/testbench/dut/core/priv/priv/csr/counters/counters/HPMCOUNTER_REGW[13]}
+add wave -noupdate -expand -group {Performance Counters} -group DCACHE -label {D Cache Miss Cycles} -radix unsigned {/testbench/dut/core/priv/priv/csr/counters/counters/HPMCOUNTER_REGW[15]}
+add wave -noupdate -expand -group {Performance Counters} -group Privileged -label {CSR Write} {/testbench/dut/core/priv/priv/csr/counters/counters/HPMCOUNTER_REGW[19]}
+add wave -noupdate -expand -group {Performance Counters} -group Privileged -label Fence.I {/testbench/dut/core/priv/priv/csr/counters/counters/HPMCOUNTER_REGW[20]}
+add wave -noupdate -expand -group {Performance Counters} -group Privileged -label sfence.VMA {/testbench/dut/core/priv/priv/csr/counters/counters/HPMCOUNTER_REGW[21]}
+add wave -noupdate -expand -group {Performance Counters} -group Privileged -label Interrupt {/testbench/dut/core/priv/priv/csr/counters/counters/HPMCOUNTER_REGW[22]}
+add wave -noupdate -expand -group {Performance Counters} -group Privileged -label Exception {/testbench/dut/core/priv/priv/csr/counters/counters/HPMCOUNTER_REGW[23]}
+add wave -noupdate -expand -group {Performance Counters} -label {FDiv or IDiv Cycles} {/testbench/dut/core/priv/priv/csr/counters/counters/HPMCOUNTER_REGW[24]}
+add wave -noupdate -expand -group {Performance Counters} /testbench/dut/core/priv/priv/csr/counters/counters/HPMCOUNTER_REGW
 add wave -noupdate -group {ifu } -color Gold /testbench/dut/core/ifu/bus/icache/ahbcacheinterface/AHBBuscachefsm/CurrState
 add wave -noupdate -group {ifu } /testbench/dut/core/ifu/bus/icache/ahbcacheinterface/AHBBuscachefsm/HREADY
 add wave -noupdate -group {ifu } /testbench/dut/core/ifu/bus/icache/ahbcacheinterface/FetchBuffer
@@ -604,10 +602,6 @@ add wave -noupdate -group uncore /testbench/dut/uncore/uncore/HRDATA
 add wave -noupdate /testbench/dut/core/ifu/bpred/bpred/rd
 add wave -noupdate -group {branch direction} /testbench/dut/core/ifu/bpred/bpred/Predictor/DirPredictor/IndexNextF
 add wave -noupdate -group {branch direction} -expand -group {branch outcome} /testbench/dut/core/ifu/bpred/bpred/Predictor/DirPredictor/PCSrcE
-add wave -noupdate -group {branch direction} -expand -group {branch outcome} /testbench/dut/core/ifu/bpred/bpred/Predictor/DirPredictor/DirPredictionE
-add wave -noupdate -group {branch direction} /testbench/dut/core/ifu/bpred/bpred/Predictor/DirPredictor/TableDirPredictionF
-add wave -noupdate -group {branch direction} /testbench/dut/core/ifu/bpred/bpred/Predictor/DirPredictor/MatchXF
-add wave -noupdate -group {branch direction} -expand -group conditions /testbench/dut/core/ifu/bpred/bpred/Predictor/DirPredictor/DirPredictionWrongE
 add wave -noupdate -group {branch direction} -expand -group conditions /testbench/dut/core/ifu/bpred/bpred/Predictor/DirPredictor/FlushM
 add wave -noupdate -group {branch direction} -expand -group conditions /testbench/dut/core/ifu/bpred/bpred/Predictor/DirPredictor/FlushE
 add wave -noupdate -group {branch direction} -expand -group ghr /testbench/dut/core/ifu/bpred/bpred/Predictor/DirPredictor/GHRF
@@ -615,27 +609,23 @@ add wave -noupdate -group {branch direction} -expand -group ghr /testbench/dut/c
 add wave -noupdate -group {branch direction} -expand -group ghr /testbench/dut/core/ifu/bpred/bpred/Predictor/DirPredictor/GHRE
 add wave -noupdate -group {branch direction} /testbench/dut/core/ifu/bpred/bpred/Predictor/DirPredictor/FlushD
 add wave -noupdate -group {branch direction} -expand -group nextghr2 /testbench/dut/core/ifu/bpred/bpred/Predictor/DirPredictor/GHRNextF
-add wave -noupdate -group {branch direction} /testbench/dut/core/ifu/bpred/bpred/Predictor/DirPredictor/NewDirPredictionE
 add wave -noupdate -group {branch direction} /testbench/dut/core/ifu/bpred/bpred/Predictor/DirPredictor/IndexE
 add wave -noupdate -group {branch direction} /testbench/dut/core/ifu/bpred/bpred/Predictor/DirPredictor/StallM
 add wave -noupdate -group {branch direction} /testbench/dut/core/ifu/bpred/bpred/Predictor/DirPredictor/FlushM
-add wave -noupdate /testbench/dut/core/ifu/bpred/bpred/Predictor/DirPredictor/GHR
 add wave -noupdate /testbench/dut/core/ifu/bpred/bpred/Predictor/DirPredictor/GHRF
 add wave -noupdate /testbench/dut/core/ifu/bpred/bpred/Predictor/DirPredictor/PCNextF
 add wave -noupdate /testbench/dut/core/ifu/bpred/bpred/Predictor/DirPredictor/GHRNextF
 add wave -noupdate /testbench/dut/core/ifu/bpred/bpred/Predictor/DirPredictor/IndexNextF
-add wave -noupdate /testbench/dut/core/ifu/bpred/bpred/Predictor/DirPredictor/DirPredictionF
-add wave -noupdate /testbench/dut/core/ifu/bpred/bpred/Predictor/DirPredictor/BranchInstrF
-add wave -noupdate /testbench/dut/core/ifu/bpred/bpred/Predictor/DirPredictor/MatchNextX
-add wave -noupdate /testbench/dut/core/ifu/bpred/bpred/PredInstrClassF
-add wave -noupdate /testbench/dut/core/ifu/bpred/bpred/PredValidF
 add wave -noupdate /testbench/dut/core/priv/priv/csr/counters/counters/DCacheAccess
 add wave -noupdate /testbench/dut/core/priv/priv/csr/counters/counters/ICacheMiss
 add wave -noupdate /testbench/dut/core/priv/priv/csr/counters/counters/ICacheAccess
 add wave -noupdate /testbench/dut/core/priv/priv/csr/counters/counters/DCacheMiss
 add wave -noupdate /testbench/dut/core/priv/priv/csr/counters/counters/InstrValidNotFlushedM
+add wave -noupdate /testbench/clk
+add wave -noupdate /testbench/HPMCSample/FinalHPMCOUNTERH
+add wave -noupdate /testbench/HPMCSample/InitialHPMCOUNTERH
 TreeUpdate [SetDefaultTree]
-WaveRestoreCursors {{Cursor 2} {314596 ns} 1} {{Cursor 3} {314460 ns} 1} {{Cursor 4} {391801 ns} 1} {{Cursor 4} {368581 ns} 0} {{Cursor 5} {394987 ns} 1}
+WaveRestoreCursors {{Cursor 2} {314596 ns} 1} {{Cursor 3} {314460 ns} 1} {{Cursor 4} {391801 ns} 1} {{Cursor 4} {717301 ns} 0} {{Cursor 5} {394987 ns} 1}
 quietly wave cursor active 4
 configure wave -namecolwidth 250
 configure wave -valuecolwidth 194
@@ -651,4 +641,4 @@ configure wave -griddelta 40
 configure wave -timeline 0
 configure wave -timelineunits ns
 update
-WaveRestoreZoom {368125 ns} {368797 ns}
+WaveRestoreZoom {717254 ns} {717585 ns}

--- a/testbench/testbench.sv
+++ b/testbench/testbench.sv
@@ -155,9 +155,9 @@ logic [3:0] dummy;
   logic        HREADY;
   logic        HSELEXT;
   
-  logic             InitializingMemories;
-  integer           ResetCount, ResetThreshold;
-  logic             InReset;
+  logic 	   InitializingMemories;
+  integer 	   ResetCount, ResetThreshold;
+  logic 	   InReset;
 
   // instantiate device to be tested
   assign GPIOPinsIn = 0;
@@ -228,7 +228,7 @@ logic [3:0] dummy;
       // read test vectors into memory
       pathname = tvpaths[tests[0].atoi()];
       /* if (tests[0] == `IMPERASTEST)
-        pathname = tvpaths[0];
+       pathname = tvpaths[0];
        else pathname = tvpaths[1]; */
       if (riscofTest) memfilename = {pathname, tests[test], "/ref/ref.elf.memfile"};
       else memfilename = {pathname, tests[test], ".elf.memfile"};
@@ -268,9 +268,6 @@ logic [3:0] dummy;
       // if ($time % 100000 == 0) $display("Time is %0t", $time);
     end
    
-  logic [`XLEN-1:0] debugmemoryadr;
-//  assign debugmemoryadr = dut.uncore.uncore.ram.ram.memory.RAM[5140];
-
   // check results
   assign reset_ext = InReset;
   
@@ -285,97 +282,97 @@ logic [3:0] dummy;
           ResetCount = 0;
         end
       end else begin
-      if (TEST == "coremark")
-        if (dut.core.priv.priv.EcallFaultM) begin
-          $display("Benchmark: coremark is done.");
-          $stop;
-        end
-      // Termination condition (i.e. we finished running current test) 
-      if (DCacheFlushDone) begin
-        integer begin_signature_addr;
-        InReset = 1;
-        begin_signature_addr = ProgramAddrLabelArray["begin_signature"];
-        if (!begin_signature_addr)
-          $display("begin_signature addr not found in %s", ProgramLabelMapFile);
-        testadr = ($unsigned(begin_signature_addr))/(`XLEN/8);
-        testadrNoBase = (begin_signature_addr - `UNCORE_RAM_BASE)/(`XLEN/8);
-        #600; // give time for instructions in pipeline to finish
-        if (TEST == "embench") begin
-          // Writes contents of begin_signature to .sim.output file
-          // this contains instret and cycles for start and end of test run, used by embench python speed script to calculate embench speed score
-          // also begin_signature contains the results of the self checking mechanism, which will be read by the python script for error checking
-          $display("Embench Benchmark: %s is done.", tests[test]);
-          if (riscofTest) outputfile = {pathname, tests[test], "/ref/ref.sim.output"};
-          else outputfile = {pathname, tests[test], ".sim.output"};
-          outputFilePointer = $fopen(outputfile);
-          i = 0;
-          while ($unsigned(i) < $unsigned(5'd5)) begin
-            $fdisplayh(outputFilePointer, DCacheFlushFSM.ShadowRAM[testadr+i]);
-            i = i + 1;
+		if (TEST == "coremark")
+          if (dut.core.priv.priv.EcallFaultM) begin
+			$display("Benchmark: coremark is done.");
+			$stop;
           end
-          $fclose(outputFilePointer);
-          $display("Embench Benchmark: created output file: %s", outputfile);
-        end else begin 
-          // for tests with no self checking mechanism, read .signature.output file and compare to check for errors
-          // clear signature to prevent contamination from previous tests
-          for(i=0; i<SIGNATURESIZE; i=i+1) begin
-            sig32[i] = 'bx;
-          end
-          if (riscofTest) signame = {pathname, tests[test], "/ref/Reference-sail_c_simulator.signature"};
-          else signame = {pathname, tests[test], ".signature.output"};
-          // read signature, reformat in 64 bits if necessary
-          $readmemh(signame, sig32);
-          i = 0;
-          while (i < SIGNATURESIZE) begin
-            if (`XLEN == 32) begin
-              signature[i] = sig32[i];
-              i = i+1;
-            end else begin
-              signature[i/2] = {sig32[i+1], sig32[i]};
-              i = i + 2;
-            end
-            if (i >= 4 & sig32[i-4] === 'bx) begin
-              if (i == 4) begin
-                i = SIGNATURESIZE+1; // flag empty file
-                $display("  Error: empty test file");
-              end else i = SIGNATURESIZE; // skip over the rest of the x's for efficiency
-            end
-          end
+		// Termination condition (i.e. we finished running current test) 
+		if (DCacheFlushDone) begin
+          integer begin_signature_addr;
+          InReset = 1;
+          begin_signature_addr = ProgramAddrLabelArray["begin_signature"];
+          if (!begin_signature_addr)
+			$display("begin_signature addr not found in %s", ProgramLabelMapFile);
+          testadr = ($unsigned(begin_signature_addr))/(`XLEN/8);
+          testadrNoBase = (begin_signature_addr - `UNCORE_RAM_BASE)/(`XLEN/8);
+          #600; // give time for instructions in pipeline to finish
+          if (TEST == "embench") begin
+			// Writes contents of begin_signature to .sim.output file
+			// this contains instret and cycles for start and end of test run, used by embench python speed script to calculate embench speed score
+			// also begin_signature contains the results of the self checking mechanism, which will be read by the python script for error checking
+			$display("Embench Benchmark: %s is done.", tests[test]);
+			if (riscofTest) outputfile = {pathname, tests[test], "/ref/ref.sim.output"};
+			else outputfile = {pathname, tests[test], ".sim.output"};
+			outputFilePointer = $fopen(outputfile);
+			i = 0;
+			while ($unsigned(i) < $unsigned(5'd5)) begin
+              $fdisplayh(outputFilePointer, DCacheFlushFSM.ShadowRAM[testadr+i]);
+              i = i + 1;
+			end
+			$fclose(outputFilePointer);
+			$display("Embench Benchmark: created output file: %s", outputfile);
+          end else begin 
+			// for tests with no self checking mechanism, read .signature.output file and compare to check for errors
+			// clear signature to prevent contamination from previous tests
+			for(i=0; i<SIGNATURESIZE; i=i+1) begin
+              sig32[i] = 'bx;
+			end
+			if (riscofTest) signame = {pathname, tests[test], "/ref/Reference-sail_c_simulator.signature"};
+			else signame = {pathname, tests[test], ".signature.output"};
+			// read signature, reformat in 64 bits if necessary
+			$readmemh(signame, sig32);
+			i = 0;
+			while (i < SIGNATURESIZE) begin
+              if (`XLEN == 32) begin
+				signature[i] = sig32[i];
+				i = i+1;
+              end else begin
+				signature[i/2] = {sig32[i+1], sig32[i]};
+				i = i + 2;
+              end
+              if (i >= 4 & sig32[i-4] === 'bx) begin
+				if (i == 4) begin
+                  i = SIGNATURESIZE+1; // flag empty file
+                  $display("  Error: empty test file");
+				end else i = SIGNATURESIZE; // skip over the rest of the x's for efficiency
+              end
+			end
 
-          // Check errors
-          errors = (i == SIGNATURESIZE+1); // error if file is empty
-          i = 0;
-          /* verilator lint_off INFINITELOOP */
-          while (signature[i] !== 'bx) begin
-            logic [`XLEN-1:0] sig;
-            if (`DTIM_SUPPORTED) sig = dut.core.lsu.dtim.dtim.ram.RAM[testadrNoBase+i];
-            else if (`UNCORE_RAM_SUPPORTED) sig = dut.uncore.uncore.ram.ram.memory.RAM[testadrNoBase+i];
-            //$display("signature[%h] = %h sig = %h", i, signature[i], sig);
-            if (signature[i] !== sig & (signature[i] !== DCacheFlushFSM.ShadowRAM[testadr+i])) begin  
-              errors = errors+1;
-              $display("  Error on test %s result %d: adr = %h sim (D$) %h sim (DTIM_SUPPORTED) = %h, signature = %h", 
-                    tests[test], i, (testadr+i)*(`XLEN/8), DCacheFlushFSM.ShadowRAM[testadr+i], sig, signature[i]);
-              $stop;//***debug
-             end
-            i = i + 1;
+			// Check errors
+			errors = (i == SIGNATURESIZE+1); // error if file is empty
+			i = 0;
+			/* verilator lint_off INFINITELOOP */
+			while (signature[i] !== 'bx) begin
+              logic [`XLEN-1:0] sig;
+              if (`DTIM_SUPPORTED) sig = dut.core.lsu.dtim.dtim.ram.RAM[testadrNoBase+i];
+              else if (`UNCORE_RAM_SUPPORTED) sig = dut.uncore.uncore.ram.ram.memory.RAM[testadrNoBase+i];
+              //$display("signature[%h] = %h sig = %h", i, signature[i], sig);
+              if (signature[i] !== sig & (signature[i] !== DCacheFlushFSM.ShadowRAM[testadr+i])) begin  
+				errors = errors+1;
+				$display("  Error on test %s result %d: adr = %h sim (D$) %h sim (DTIM_SUPPORTED) = %h, signature = %h", 
+						 tests[test], i, (testadr+i)*(`XLEN/8), DCacheFlushFSM.ShadowRAM[testadr+i], sig, signature[i]);
+				$stop;//***debug
+              end
+              i = i + 1;
+			end
+			/* verilator lint_on INFINITELOOP */
+			if (errors == 0) begin
+              $display("%s succeeded.  Brilliant!!!", tests[test]);
+			end
+			else begin
+              $display("%s failed with %d errors. :(", tests[test], errors);
+              totalerrors = totalerrors+1;
+			end
           end
-          /* verilator lint_on INFINITELOOP */
-          if (errors == 0) begin
-            $display("%s succeeded.  Brilliant!!!", tests[test]);
+          // move onto the next test, check to see if we're done
+          test = test + 1;
+          if (test == tests.size()) begin
+			if (totalerrors == 0) $display("SUCCESS! All tests ran without failures.");
+			else $display("FAIL: %d test programs had errors", totalerrors);
+			$stop;
           end
           else begin
-            $display("%s failed with %d errors. :(", tests[test], errors);
-            totalerrors = totalerrors+1;
-          end
-        end
-        // move onto the next test, check to see if we're done
-        test = test + 1;
-        if (test == tests.size()) begin
-          if (totalerrors == 0) $display("SUCCESS! All tests ran without failures.");
-          else $display("FAIL: %d test programs had errors", totalerrors);
-          $stop;
-        end
-        else begin
             InitializingMemories = 1;
             // If there are still additional tests to run, read in information for the next test
             //pathname = tvpaths[tests[0]];
@@ -394,12 +391,12 @@ logic [3:0] dummy;
               ProgramLabelMapFile = {pathname, tests[test], ".elf.objdump.lab"};
             end
             ProgramAddrLabelArray = '{ "begin_signature" : 0, "tohost" : 0 };
-          if(!`FPGA) begin
-            updateProgramAddrLabelArray(ProgramAddrMapFile, ProgramLabelMapFile, ProgramAddrLabelArray);
-            $display("Read memfile %s", memfilename);
+			if(!`FPGA) begin
+              updateProgramAddrLabelArray(ProgramAddrMapFile, ProgramLabelMapFile, ProgramAddrLabelArray);
+              $display("Read memfile %s", memfilename);
+			end
           end
-        end
-      end // if (DCacheFlushDone)
+		end // if (DCacheFlushDone)
       end
     end // always @ (negedge clk)
 
@@ -409,19 +406,29 @@ logic [3:0] dummy;
     string  HPMCnames[] = '{"Mcycle",
                             "------",
                             "InstRet",
-                            "Load Stall",
-                            "Br Dir Wrong",
                             "Br Count",
-                            "Br Target Wrong",
                             "Jump, JR, Jal",
+                            "Return",
+                            "Br Dir Wrong",
+                            "Br Pred Wrong",
+                            "Br Target Wrong",
                             "RAS Wrong",
-                            "ret",
                             "Instr Class Wrong",
+							"Load Stall",
+							"Store Stall",
                             "D Cache Access",
                             "D Cache Miss",
+                            "D Cache Cycles",
                             "I Cache Access",
                             "I Cache Miss",
-							"Br Pred Wrong"};
+                            "I Cache Cycles",
+                            "CSR Write",
+                            "FenceI",
+                            "SFenceVMA",
+                            "Interrupt",
+                            "Exception",
+                            "Divide Cycles"
+							};
     always @(negedge clk) begin
       if(DCacheFlushStart & ~DCacheFlushDone) begin
         for(HPMCindex = 0; HPMCindex < HPMCnames.size(); HPMCindex += 1) begin
@@ -487,40 +494,22 @@ logic [3:0] dummy;
 
   
   if (`BPRED_SUPPORTED == 1) begin
-/* -----\/----- EXCLUDED -----\/-----
-    genvar adrindex;
-      // Initializing all zeroes into the branch predictor memory.
-      for(adrindex = 0; adrindex < 2**`BTB_SIZE; adrindex++) begin
-        initial begin 
-        force dut.core.ifu.bpred.bpred.TargetPredictor.memory.mem[adrindex] = 0;
-        #1;
-        release dut.core.ifu.bpred.bpred.TargetPredictor.memory.mem[adrindex];
-        end
-      end
-      for(adrindex = 0; adrindex < 2**`BPRED_SIZE; adrindex++) begin
-        initial begin 
-        force dut.core.ifu.bpred.bpred.Predictor.DirPredictor.PHT.mem[adrindex] = 0;
-        #1;
-        release dut.core.ifu.bpred.bpred.Predictor.DirPredictor.PHT.mem[adrindex];
-        end
-      end
- -----/\----- EXCLUDED -----/\----- */
-
-      if (`BPRED_LOGGER) begin
-        string direction;
-        int    file;
-		logic  PCSrcM;
-		flopenrc #(1) PCSrcMReg(clk, reset, dut.core.FlushM, ~dut.core.StallM, dut.core.ifu.bpred.bpred.Predictor.DirPredictor.PCSrcE, PCSrcM);
-        initial
-          file = $fopen("branch.log", "w");
-        always @(posedge clk) begin
-           if(dut.core.ifu.InstrClassM[0] & ~dut.core.StallW & ~dut.core.FlushW & dut.core.InstrValidM) begin
-             direction = PCSrcM ? "t" : "n";
-             $fwrite(file, "%h %s\n", dut.core.PCM, direction);
-           end
-        end
-      end
+    if (`BPRED_LOGGER) begin
+      string direction;
+      int    file;
+	  logic  PCSrcM;
+	  flopenrc #(1) PCSrcMReg(clk, reset, dut.core.FlushM, ~dut.core.StallM, dut.core.ifu.bpred.bpred.Predictor.DirPredictor.PCSrcE, PCSrcM);
+      initial begin
+        file = $fopen("branch.log", "w");
+	  end
+      always @(posedge clk) begin
+		if(dut.core.ifu.InstrClassM[0] & ~dut.core.StallW & ~dut.core.FlushW & dut.core.InstrValidM) begin
+		  direction = PCSrcM ? "t" : "n";
+		  $fwrite(file, "%h %s\n", dut.core.PCM, direction);
+		end
+	  end
     end
+  end
 
   // check for hange up.
   logic [`XLEN-1:0] OldPCW;


### PR DESCRIPTION
Performance counters now exclude embench warmup from analysis.
- Added performance new counter prints to testbench.
- Setup the testbench to exclude the warmup from performance counter reports.
- Fixed batch mode regression test to work with hpmc loggic. Added logic to exclude the embench warmups from preformance counters.
