### PR TITLE
Fix MISA RO and UART addresses

### DIFF
--- a/sim/imperas.ic
+++ b/sim/imperas.ic
@@ -6,6 +6,7 @@
 --override cpu/ignore_non_leaf_DAU=1
 --override cpu/wfi_is_nop=T
 --override cpu/mimpid=0x100
+--override cpu/misa_Extensions_mask=0x0
 
 # THIS NEEDS FIXING to 16
 --override cpu/PMP_registers=0

--- a/testbench/testbench_imperas.sv
+++ b/testbench/testbench_imperas.sv
@@ -178,8 +178,7 @@ module testbench;
           void'(rvviRefMemorySetVolatile(`GPIO_BASE, (`GPIO_BASE + `GPIO_RANGE)));
       end
       if (`UART_SUPPORTED) begin
-          //void'(rvviRefMemorySetVolatile(`UART_BASE, (`UART_BASE + `UART_RANGE)));
-          void'(rvviRefMemorySetVolatile(`UART_BASE, (`UART_BASE + 7))); // BUG
+          void'(rvviRefMemorySetVolatile(`UART_BASE, (`UART_BASE + `UART_RANGE)));
       end
       if (`PLIC_SUPPORTED) begin
           void'(rvviRefMemorySetVolatile(`PLIC_BASE, (`PLIC_BASE + `PLIC_RANGE)));


### PR DESCRIPTION
It appears on inspection that the MISA register is read only in Wally In which case this has now also been set in the ImperasDV representation Also the Addresss for the UART R/W privileges are corrected

@ross144 @davidharrishmc 
Could you please confirm that MISA is Read only, otherwise this will need correcting in the tool configuration file