### PR TITLE
Added notes on linux image generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,22 @@ $ make all
 
 Note: When the make tasks complete, you’ll find source code in $RISCV/buildroot/output/build and the executables in $RISCV/buildroot/output/images.
 
+### Generate load images for linux boot
+
+The Questa linux boot uses preloaded bootram and ram memory.  We use QEMU to generate these preloaded memory files.  Files output in $RISCV/linux-testvectors
+
+	cd cvw/linux/testvector-generation
+	./genInitMem.sh
+
+This may require changing file permissions to the linux-testvectors directory.
+
+### Generate QEMU linux trace
+
+The linux testbench can instruction by instruction compare Wally's committed instructions against QEMU.  To do this QEMU outputs a log file consisting of all instructions executed.  Interrupts are handled by forcing the testbench to generate an interrupt at the same cycle as in QEMU.  Generating this trace will take more than 24 hours.
+
+	cd cvw/linux/testvector-generation
+	./genTrace.sh
+
 ### Download Synthesis Libraries
 
 For logic synthesis, we need a synthesis tool (see Section 3.XREF) and a cell library.  Clone the OSU 12-track cell library for the Skywater 130 nm process:


### PR DESCRIPTION
- editorconfig to specify tabs/spaces.  Fixed some tabs.  Turn off coverage to speed up simulation
- Updated testbench to record coremark performance counters. Added comment about mtval probably not being correct for compressed instructions.
- Simplified SLT and SLTU code in ALU
- Modified setup to add Imperas/scripts/cvw to path
- Modified regression and wally-batch.do to support -coverage
- Enhancements to support the PMA ranges
- Removed unneeded echo from setup
- Fixed crash with wrong number of arguments for coverage in regression-wally
- Fixes to wally-batch for coverage
- Replaced DCACHE parameter with READ_ONLY_CACHE as the name was confusing in chapter 10.
- Changes BTA to BPBTA.
- Modified the branch log to include markers for the start and end of tests with exclusion of warmup period.
- Added script to separate branch.log into separate logs for each benchmark.
- Renamed script to parse branch.log
- Created script to batch processes all the embench branch outcomes into C model branch prediction rate.
- Modified branch logger to indicate when the warmup period is done. The branch-predictor-simulator also changed to support this.
- Added reference data.
- On our way to finish the C reference data collection.
- More accurate c model gshare results.
- Updated CAdr to CacheSet.
- Updated NextAdr to NextSet.
- Book updates.
- Added notes on how to run QEMU to generate linux image.
