### PR TITLE
Added clarificaiton to buildroot linux testvector generation

### DIFF
--- a/docs/README-linux.md
+++ b/docs/README-linux.md
@@ -1,0 +1,40 @@
+### Cross-Compile Buildroot Linux
+
+Building Linux is only necessary for exploring the boot process in Chapter 17.  Building and generating a trace is a time-consuming operation that could be skipped for now; you can return to this section later if you are interested in the Linux details.
+
+Buildroot depends on configuration files in riscv-wally, so the cad user must install Wally first according to the instructions in Section 2.2.2.  However, don’t source ~/wally-riscv/setup.sh because it will set LD_LIBRARY_PATH in a way to cause make to fail on buildroot.
+
+To configure and build Buildroot:
+
+	$ cd $RISCV
+	$ export WALLY=~/riscv-wally  # make sure you haven’t sourced ~/riscv-wally/setup.sh by now
+	$ git clone https://github.com/buildroot/buildroot.git
+	$ cd buildroot
+	$ git checkout 2021.05 # last tested working version
+	$ cp -r $WALLY/linux/buildroot-config-src/wally ./board
+	$ cp ./board/wally/main.config .config
+	$ make --jobs
+
+To generate disassembly files and the device tree, run another make script.  Note that you can expect some warnings about phandle references while running dtc on wally-virt.dtb.
+
+$ source ~/riscv-wally/setup.sh
+$ cd $WALLY/linux/buildroot-scripts
+$ make all
+
+Note: When the make tasks complete, you’ll find source code in $RISCV/buildroot/output/build and the executables in $RISCV/buildroot/output/images.
+
+### Generate load images for linux boot
+
+The Questa linux boot uses preloaded bootram and ram memory.  We use QEMU to generate these preloaded memory files.  Files output in $RISCV/linux-testvectors
+
+	cd cvw/linux/testvector-generation
+	./genInitMem.sh
+
+This may require changing file permissions to the linux-testvectors directory.
+
+### Generate QEMU linux trace
+
+The linux testbench can instruction by instruction compare Wally's committed instructions against QEMU.  To do this QEMU outputs a log file consisting of all instructions executed.  Interrupts are handled by forcing the testbench to generate an interrupt at the same cycle as in QEMU.  Generating this trace will take more than 24 hours.
+
+	cd cvw/linux/testvector-generation
+	./genTrace.sh

--- a/testbench/testbench-linux-imperas.sv
+++ b/testbench/testbench-linux-imperas.sv
@@ -263,8 +263,8 @@ module testbench;
   logic [3:0]       HPROT;
   logic [1:0]       HTRANS;
   logic             HMASTLOCK;
-  logic [31:0]      GPIOPinsIn;
-  logic [31:0]      GPIOPinsOut, GPIOPinsEn;
+  logic [31:0]      GPIOIN;
+  logic [31:0]      GPIOOUT, GPIOEN;
   logic             UARTSin, UARTSout;
 
   // FPGA-specific Stuff
@@ -430,7 +430,7 @@ module testbench;
                         .HRDATAEXT, .HREADYEXT, .HREADY, .HSELEXT, .HRESPEXT, .HCLK, 
 			.HRESETn, .HADDR, .HWDATA, .HWRITE, .HWSTRB, .HSIZE, .HBURST, .HPROT, 
 			.HTRANS, .HMASTLOCK, 
-			.TIMECLK('0), .GPIOPinsIn, .GPIOPinsOut, .GPIOPinsEn,
+			.TIMECLK('0), .GPIOIN, .GPIOOUT, .GPIOEN,
                         .UARTSin, .UARTSout,
 			.SDCCLK, .SDCCmdIn, .SDCCmdOut, .SDCCmdOE, .SDCDatIn);
 

--- a/testbench/testbench.sv
+++ b/testbench/testbench.sv
@@ -30,6 +30,7 @@
 
 `define PrintHPMCounters 1
 `define BPRED_LOGGER 1
+`define INSTR_FETCH_ADDR_LOGGER 0
 
 module testbench;
   parameter DEBUG=0;
@@ -546,7 +547,29 @@ logic [3:0] dummy;
 		end
 	  end
 	end
+end
+
+
+  if (`INSTR_FETCH_ADDR_LOGGER == 1) begin
+    int    file;
+	string LogFile;
+	logic  resetD, resetEdge;
+	flop #(1) ResetDReg(clk, reset, resetD);
+	assign resetEdge = ~reset & resetD;
+    initial begin
+	  LogFile = $psprintf("ICache.log");
+      file = $fopen(LogFile, "w");
+	end
+    always @(posedge clk) begin
+	  if(resetEdge) $fwrite(file, "TRAIN\n");
+	  if(StartSample) $fwrite(file, "BEGIN %s\n", memfilename);
+	  if(dut.core.StallD & ~dut.core.FlushD) begin
+	    $fwrite(file, "%h R\n", dut.core.ifu.PCF);
+	  end
+	  if(EndSample) $fwrite(file, "END %s\n", memfilename);
+    end
   end
+  
 
   
   if (`BPRED_SUPPORTED == 1) begin

--- a/testbench/testbench.sv
+++ b/testbench/testbench.sv
@@ -30,7 +30,8 @@
 
 `define PrintHPMCounters 1
 `define BPRED_LOGGER 1
-`define INSTR_FETCH_ADDR_LOGGER 0
+`define I_CACHE_ADDR_LOGGER 1
+`define D_CACHE_ADDR_LOGGER 1
 
 module testbench;
   parameter DEBUG=0;
@@ -550,7 +551,7 @@ logic [3:0] dummy;
 end
 
 
-  if (`INSTR_FETCH_ADDR_LOGGER == 1) begin
+  if (`I_CACHE_ADDR_LOGGER == 1) begin
     int    file;
 	string LogFile;
 	logic  resetD, resetEdge;
@@ -563,15 +564,41 @@ end
     always @(posedge clk) begin
 	  if(resetEdge) $fwrite(file, "TRAIN\n");
 	  if(StartSample) $fwrite(file, "BEGIN %s\n", memfilename);
-	  if(dut.core.StallD & ~dut.core.FlushD) begin
-	    $fwrite(file, "%h R\n", dut.core.ifu.PCF);
+	  if(~dut.core.StallD & ~dut.core.FlushD) begin
+	    $fwrite(file, "%h R\n", dut.core.ifu.PCPF);
 	  end
 	  if(EndSample) $fwrite(file, "END %s\n", memfilename);
     end
   end
-  
 
-  
+  if (`D_CACHE_ADDR_LOGGER == 1) begin
+    int    file;
+	string LogFile;
+	logic  resetD, resetEdge;
+	flop #(1) ResetDReg(clk, reset, resetD);
+	assign resetEdge = ~reset & resetD;
+    initial begin
+	  LogFile = $psprintf("DCache.log");
+      file = $fopen(LogFile, "w");
+	end
+    always @(posedge clk) begin
+	  if(resetEdge) $fwrite(file, "TRAIN\n");
+	  if(StartSample) $fwrite(file, "BEGIN %s\n", memfilename);
+	  if(~dut.core.StallW & ~dut.core.FlushW & dut.core.InstrValidM) begin
+        if(dut.core.lsu.bus.dcache.CacheRWM == 2'b10) begin
+	      $fwrite(file, "%h R\n", dut.core.lsu.PAdrM);
+        end else if (dut.core.lsu.bus.dcache.CacheRWM == 2'b01) begin
+	      $fwrite(file, "%h W\n", dut.core.lsu.PAdrM);
+        end else if (dut.core.lsu.bus.dcache.CacheAtomicM[1] == 1'b1) begin // *** This may change
+	      $fwrite(file, "%h A\n", dut.core.lsu.PAdrM);
+        end else if (dut.core.lsu.bus.dcache.FlushDCache) begin
+	      $fwrite(file, "%h F\n", dut.core.lsu.PAdrM);
+        end
+	  end
+	  if(EndSample) $fwrite(file, "END %s\n", memfilename);
+    end
+  end
+
   if (`BPRED_SUPPORTED == 1) begin
     if (`BPRED_LOGGER) begin
       string direction;


### PR DESCRIPTION
- Renamed controllerinputstage to controllerinput to match book.
- Updated GPIO signal names to reflect book.
- Updated fpga constraints to remove critical warning.
- Modified plic and uart to remove async reset. This removes vivado critical warning.
- Started constrains file for arty a7 fpga.
- Added buildroot instructions back to readme. moved these instructions to the docs directory.
- Added some additional details about the buildroot install.
