### PR TITLE
Add tests/coverage/ tests as a target to sim/Makefile

### DIFF
--- a/sim/Makefile
+++ b/sim/Makefile
@@ -1,5 +1,5 @@
 
-all: riscoftests memfiles
+all: riscoftests memfiles coveragetests
 	# *** Build old tests/imperas-riscv-tests for now;
 	# Delete this part when the privileged tests transition over to tests/wally-riscv-arch-test
 	# DH: 2/27/22 temporarily commented out imperas-riscv-tests because license expired
@@ -50,3 +50,6 @@ riscoftests:
 	make -C ../tests/riscof/ 
 memfiles:
 	make -f makefile-memfile wally-sim-files --jobs
+
+coveragetests:
+	make -C ../tests/coverage/


### PR DESCRIPTION
Hi all, I am a student in Prof. Harris' SoC class and look forward to contributing to this project!

Currently, the `sim/Makefile`, which is called by the top-level makefile to run tests, does not build the `tests/coverage` tests. This causes `./regression-wally -coverage` to fail for `rv64gc_coverage64gc` unless manually going into `tests/coverage` and running make there. 

This PR adds those coverage tests as a default target to `sim/Makefile`.