### PR TITLE
Fixed regression after cause CSR fix

### DIFF
--- a/src/privileged/csrm.sv
+++ b/src/privileged/csrm.sv
@@ -93,7 +93,6 @@ module csrm #(parameter
 
   logic [`XLEN-1:0]               MISA_REGW, MHARTID_REGW;
   logic [`XLEN-1:0]               MSCRATCH_REGW, MTVAL_REGW, MCAUSE_REGW;
-  // logic [4:0]                     ;
   logic                           WriteMTVECM, WriteMEDELEGM, WriteMIDELEGM;
   logic                           WriteMSCRATCHM, WriteMEPCM, WriteMCAUSEM, WriteMTVALM;
   logic                           WriteMCOUNTERENM, WriteMCOUNTINHIBITM;

--- a/src/privileged/csrm.sv
+++ b/src/privileged/csrm.sv
@@ -92,8 +92,8 @@ module csrm #(parameter
 );
 
   logic [`XLEN-1:0]               MISA_REGW, MHARTID_REGW;
-  logic [`XLEN-1:0]               MSCRATCH_REGW, MTVAL_REGW;
-  logic [4:0]                     MCAUSE_REGW;
+  logic [`XLEN-1:0]               MSCRATCH_REGW, MTVAL_REGW, MCAUSE_REGW;
+  // logic [4:0]                     ;
   logic                           WriteMTVECM, WriteMEDELEGM, WriteMIDELEGM;
   logic                           WriteMSCRATCHM, WriteMEPCM, WriteMCAUSEM, WriteMTVALM;
   logic                           WriteMCOUNTERENM, WriteMCOUNTINHIBITM;
@@ -157,7 +157,7 @@ module csrm #(parameter
 
   flopenr #(`XLEN) MSCRATCHreg(clk, reset, WriteMSCRATCHM, CSRWriteValM, MSCRATCH_REGW);
   flopenr #(`XLEN) MEPCreg(clk, reset, WriteMEPCM, NextEPCM, MEPC_REGW); 
-  flopenr #(5)     MCAUSEreg(clk, reset, WriteMCAUSEM, NextCauseM, MCAUSE_REGW);
+  flopenr #(`XLEN) MCAUSEreg(clk, reset, WriteMCAUSEM, {NextCauseM[4], {(`XLEN-5){1'b0}}, NextCauseM[3:0]}, MCAUSE_REGW);
   if(`QEMU) assign MTVAL_REGW = `XLEN'b0; // MTVAL tied to 0 in QEMU configuration
   else flopenr #(`XLEN) MTVALreg(clk, reset, WriteMTVALM, NextMtvalM, MTVAL_REGW);
   flopenr #(32)   MCOUNTINHIBITreg(clk, reset, WriteMCOUNTINHIBITM, CSRWriteValM[31:0], MCOUNTINHIBIT_REGW);
@@ -199,7 +199,7 @@ module csrm #(parameter
       MIE:       CSRMReadValM = {{(`XLEN-12){1'b0}}, MIE_REGW};
       MSCRATCH:  CSRMReadValM = MSCRATCH_REGW;
       MEPC:      CSRMReadValM = MEPC_REGW;
-      MCAUSE:    CSRMReadValM = {MCAUSE_REGW[4], {(`XLEN-5){1'b0}}, MCAUSE_REGW[3:0]};
+      MCAUSE:    CSRMReadValM = MCAUSE_REGW;
       MTVAL:     CSRMReadValM = MTVAL_REGW;
       MTINST:    CSRMReadValM = 0; // implemented as trivial zero
       MCOUNTEREN:CSRMReadValM = {{(`XLEN-32){1'b0}}, MCOUNTEREN_REGW};

--- a/src/privileged/csrs.sv
+++ b/src/privileged/csrs.sv
@@ -74,7 +74,6 @@ module csrs #(parameter
   logic                    WriteSCAUSEM, WriteSTVALM, WriteSATPM, WriteSCOUNTERENM;
   logic                    WriteSTIMECMPM, WriteSTIMECMPHM;
   logic [`XLEN-1:0]        SSCRATCH_REGW, STVAL_REGW, SCAUSE_REGW;
-  // logic [4:0]              ;      
   logic [63:0]             STIMECMP_REGW;
   
   // write enables

--- a/src/privileged/csrs.sv
+++ b/src/privileged/csrs.sv
@@ -73,8 +73,8 @@ module csrs #(parameter
   logic                    WriteSSCRATCHM, WriteSEPCM;
   logic                    WriteSCAUSEM, WriteSTVALM, WriteSATPM, WriteSCOUNTERENM;
   logic                    WriteSTIMECMPM, WriteSTIMECMPHM;
-  logic [`XLEN-1:0]        SSCRATCH_REGW, STVAL_REGW;
-  logic [4:0]              SCAUSE_REGW;      
+  logic [`XLEN-1:0]        SSCRATCH_REGW, STVAL_REGW, SCAUSE_REGW;
+  // logic [4:0]              ;      
   logic [63:0]             STIMECMP_REGW;
   
   // write enables
@@ -94,7 +94,7 @@ module csrs #(parameter
   flopenr #(`XLEN) STVECreg(clk, reset, WriteSTVECM, {CSRWriteValM[`XLEN-1:2], 1'b0, CSRWriteValM[0]}, STVEC_REGW); 
   flopenr #(`XLEN) SSCRATCHreg(clk, reset, WriteSSCRATCHM, CSRWriteValM, SSCRATCH_REGW);
   flopenr #(`XLEN) SEPCreg(clk, reset, WriteSEPCM, NextEPCM, SEPC_REGW); 
-  flopenr #(5)     SCAUSEreg(clk, reset, WriteSCAUSEM, NextCauseM, SCAUSE_REGW);
+  flopenr #(`XLEN) SCAUSEreg(clk, reset, WriteSCAUSEM, {NextCauseM[4], {(`XLEN-5){1'b0}}, NextCauseM[3:0]}, SCAUSE_REGW);
   flopenr #(`XLEN) STVALreg(clk, reset, WriteSTVALM, NextMtvalM, STVAL_REGW);
   if (`VIRTMEM_SUPPORTED)
     flopenr #(`XLEN) SATPreg(clk, reset, WriteSATPM, CSRWriteValM, SATP_REGW);
@@ -127,7 +127,7 @@ module csrs #(parameter
       SIE:       CSRSReadValM = {{(`XLEN-12){1'b0}}, MIE_REGW & 12'h222 & MIDELEG_REGW}; // only read supervisor fields
       SSCRATCH:  CSRSReadValM = SSCRATCH_REGW;
       SEPC:      CSRSReadValM = SEPC_REGW;
-      SCAUSE:    CSRSReadValM = {SCAUSE_REGW[4], {(`XLEN-5){1'b0}}, SCAUSE_REGW[3:0]};
+      SCAUSE:    CSRSReadValM = SCAUSE_REGW;
       STVAL:     CSRSReadValM = STVAL_REGW;
       SATP:      if (`VIRTMEM_SUPPORTED & (PrivilegeModeW == `M_MODE | ~STATUS_TVM)) CSRSReadValM = SATP_REGW;
                  else begin

--- a/tests/wally-riscv-arch-test/riscv-test-suite/rv32i_m/privilege/references/WALLY-trap-01.reference_output
+++ b/tests/wally-riscv-arch-test/riscv-test-suite/rv32i_m/privilege/references/WALLY-trap-01.reference_output
@@ -53,7 +53,7 @@
 8000000b # mcause value from m ext interrupt
 00000000 # mtval for mext interrupt (0x0)
 00001880 # masked out mstatus.MPP = 11, mstatus.MPIE = 1, and mstatus.MIE = 0
-fffff7ff # medeleg after attempted write of all 1's (only some bits are writeable)
+0000b3ff # medeleg after attempted write of all 1's (only some bits are writeable)
 00000222 # mideleg after attempted write of all 1's (only some bits are writeable) # skipping instruction address fault since they're impossible with compressed instrs enabled
 00000001 # mcause from an instruction access fault
 00000000 # mtval of faulting instruction address (0x0)

--- a/tests/wally-riscv-arch-test/riscv-test-suite/rv32i_m/privilege/references/WALLY-trap-s-01.reference_output
+++ b/tests/wally-riscv-arch-test/riscv-test-suite/rv32i_m/privilege/references/WALLY-trap-s-01.reference_output
@@ -48,7 +48,7 @@
 00000009 # scause from S mode ecall
 00000000 # stval of ecall (*** defined to be zero for now)
 00000800 # masked out mstatus.mpp = 1, mstatus.MPIE = 0, and mstatus.MIE = 0
-fffff7ff # medeleg after attempted write of all 1's (only some bits are writeable)
+0000b3ff # medeleg after attempted write of all 1's (only some bits are writeable)
 00000222 # mideleg after attempted write of all 1's (only some bits are writeable)
 0000000b # scause from M mode ecall
 00000000 # stval of ecall (*** defined to be zero for now)

--- a/tests/wally-riscv-arch-test/riscv-test-suite/rv32i_m/privilege/references/WALLY-trap-u-01.reference_output
+++ b/tests/wally-riscv-arch-test/riscv-test-suite/rv32i_m/privilege/references/WALLY-trap-u-01.reference_output
@@ -45,7 +45,7 @@
 00000008 # scause from U mode ecall
 00000000 # stval of ecall (*** defined to be zero for now)
 00000000 # masked out mstatus.mpp = 0, mstatus.MPIE = 0, and mstatus.MIE = 0
-fffff7ff # medeleg after attempted write of all 1's (only some bits are writeable)
+0000b3ff # medeleg after attempted write of all 1's (only some bits are writeable)
 00000222 # mideleg after attempted write of all 1's (only some bits are writeable)
 0000000b # scause from M mode ecall 
 00000000 # stval of ecall (*** defined to be zero for now)

--- a/tests/wally-riscv-arch-test/riscv-test-suite/rv64i_m/privilege/references/WALLY-trap-01.reference_output
+++ b/tests/wally-riscv-arch-test/riscv-test-suite/rv64i_m/privilege/references/WALLY-trap-01.reference_output
@@ -108,8 +108,8 @@
 00000000
 00001880 # masked out mstatus.MPP = 11, mstatus.MPIE = 1, and mstatus.MIE = 0
 00000000
-fffff7ff # medeleg after attempted write of all 1's (only some bits are writeable)
-ffffffff
+0000b3ff # medeleg after attempted write of all 1's (only some bits are writeable)
+00000000
 00000222 # mideleg after attempted write of all 1's (only some bits are writeable)
 00000000 # skipping instruction address fault since they're impossible with compressed instrs enabled
 00000001 # mcause from an instruction access fault

--- a/tests/wally-riscv-arch-test/riscv-test-suite/rv64i_m/privilege/references/WALLY-trap-s-01.reference_output
+++ b/tests/wally-riscv-arch-test/riscv-test-suite/rv64i_m/privilege/references/WALLY-trap-s-01.reference_output
@@ -98,8 +98,8 @@
 00000000
 00000800 # masked out mstatus.mpp = 1, mstatus.MPIE = 0, and mstatus.MIE = 0
 00000000
-fffff7ff # medeleg after attempted write of all 1's (only some bits are writeable)
-ffffffff
+0000b3ff # medeleg after attempted write of all 1's (only some bits are writeable)
+00000000
 00000222 # mideleg after attempted write of all 1's (only some bits are writeable)
 00000000
 0000000b # scause from M mode ecall 

--- a/tests/wally-riscv-arch-test/riscv-test-suite/rv64i_m/privilege/references/WALLY-trap-u-01.reference_output
+++ b/tests/wally-riscv-arch-test/riscv-test-suite/rv64i_m/privilege/references/WALLY-trap-u-01.reference_output
@@ -92,8 +92,8 @@
 00000000
 00000000 # masked out mstatus.mpp = 0, mstatus.MPIE = 0, and mstatus.MIE = 0
 00000000
-fffff7ff # medeleg after attempted write of all 1's (only some bits are writeable)
-ffffffff
+0000b3ff # medeleg after attempted write of all 1's (only some bits are writeable)
+00000000
 00000222 # mideleg after attempted write of all 1's (only some bits are writeable)
 00000000
 0000000b # scause from M mode ecall 


### PR DESCRIPTION
Reducing the number of bits in the cause and edeleg CRSs caused an issue with the wally priv tests.
This pull fixes it and updates the writing of both CSRs to match the Imperas DV tests.

Requires a make allclean