### PR TITLE
Improve I$ coverage by simplifying logic

### DIFF
--- a/src/cache/cacheLRU.sv
+++ b/src/cache/cacheLRU.sv
@@ -98,7 +98,9 @@ module cacheLRU
     assign LRUUpdate[t1] = LRUUpdate[s] & WayEncoded[r];
   end
 
-  mux2 #(1) LRUMuxes[NUMWAYS-2:0](CurrLRU, ~WayExpanded, LRUUpdate, NextLRU);
+  // The root node of the LRU tree will always be selected in LRUUpdate. No mux needed.
+  assign NextLRU[NUMWAYS-2] = ~WayExpanded[NUMWAYS-2];
+  mux2 #(1) LRUMuxes[NUMWAYS-3:0](CurrLRU[NUMWAYS-3:0], ~WayExpanded[NUMWAYS-3:0], LRUUpdate[NUMWAYS-3:0], NextLRU[NUMWAYS-3:0]);
 
   // Compute next victim way.
   for(s = NUMWAYS-2; s >= NUMWAYS/2; s--) begin
@@ -128,8 +130,8 @@ module cacheLRU
   always_ff @(posedge clk) begin
     if (reset) for (int set = 0; set < NUMLINES; set++) LRUMemory[set] <= '0;
     if(CacheEn) begin
-      if((InvalidateCache | FlushCache) & ~FlushStage) for (int set = 0; set < NUMLINES; set++) LRUMemory[set] <= '0;
-      else if (LRUWriteEn & ~FlushStage) begin 
+      // if((InvalidateCache | FlushCache) & ~FlushStage) for (int set = 0; set < NUMLINES; set++) LRUMemory[set] <= '0;
+      if (LRUWriteEn & ~FlushStage) begin 
         LRUMemory[PAdr] <= NextLRU;
       end
       if(LRUWriteEn & ~FlushStage & (PAdr == CacheSet))


### PR DESCRIPTION
Hi all, this PR hopes to improve I$ coverage as part of Lim and I's E154 final project.

@ross144, Prof. Harris has reviewed everything else but was hoping you might be able to take a look at the proposed change to the LRUMemory reset. We've written up a bit about the change in this project report [google doc](https://docs.google.com/document/d/15kmg0c1-cOloDY3EaORa20bwu9_kD3s5c1ZRB6zqN0E/edit) which you should have access to.

A summary of proposed changes:
 - Make the cache write path conditional on whether or not it is read-only
 - Remove the LRUMux that corresponds to the root (always hit) node of the LRU tree.
 - Remove an unhit case of the LRUMemory reset logic (unreviewed!)

Regression passed on everything except for timing out on priv and periph, but those cases timed out even on the main branch for me before adding the changes (I'm a few commits behind upstream).

Thanks!