### PR TITLE
Remove some fpu/fctrl test cases from coverage statistics

### DIFF
--- a/src/fpu/fctrl.sv
+++ b/src/fpu/fctrl.sv
@@ -147,6 +147,7 @@ module fctrl (
                     7'b0100001: if (Rs2D[4:2] == 3'b000  & SupportedFmt2 & Rs2D[1:0] != 2'b01)
                                                ControlsD = `FCTRLW'b1_0_01_00_001_0_0_0; // fcvt.d.(s/h/q)
                     // coverage off
+                    // Not covered in testing because rv64gc does not support half or quad precision
                     7'b0100010: if (Rs2D[4:2] == 3'b000 & SupportedFmt2 & Rs2D[1:0] != 2'b10)
                                                ControlsD = `FCTRLW'b1_0_01_00_010_0_0_0; // fcvt.h.(s/d/q)
                     7'b0100011: if (Rs2D[4:2] == 3'b000  & SupportedFmt2 & Rs2D[1:0] != 2'b11)
@@ -177,6 +178,7 @@ module fctrl (
                                   5'b00011:    ControlsD = `FCTRLW'b0_1_01_00_010_0_0_1; // fcvt.lu.d  d->lu
                                 endcase
                     // coverage off
+                    // Not covered in testing because rv64gc does not support half or quad precision
                     7'b1101010: case(Rs2D)
                                   5'b00000:    ControlsD = `FCTRLW'b1_0_01_00_101_0_0_0; // fcvt.h.w   w->h
                                   5'b00001:    ControlsD = `FCTRLW'b1_0_01_00_100_0_0_0; // fcvt.h.wu wu->h

--- a/src/fpu/fctrl.sv
+++ b/src/fpu/fctrl.sv
@@ -146,11 +146,13 @@ module fctrl (
                                                ControlsD = `FCTRLW'b1_0_01_00_000_0_0_0; // fcvt.s.(d/q/h)
                     7'b0100001: if (Rs2D[4:2] == 3'b000  & SupportedFmt2 & Rs2D[1:0] != 2'b01)
                                                ControlsD = `FCTRLW'b1_0_01_00_001_0_0_0; // fcvt.d.(s/h/q)
+                    // coverage off
                     7'b0100010: if (Rs2D[4:2] == 3'b000 & SupportedFmt2 & Rs2D[1:0] != 2'b10)
                                                ControlsD = `FCTRLW'b1_0_01_00_010_0_0_0; // fcvt.h.(s/d/q)
                     7'b0100011: if (Rs2D[4:2] == 3'b000  & SupportedFmt2 & Rs2D[1:0] != 2'b11)
                                                ControlsD = `FCTRLW'b1_0_01_00_011_0_0_0; // fcvt.q.(s/h/d)
-                   7'b1101000: case(Rs2D)
+                    // coverage on                  
+                    7'b1101000: case(Rs2D)
                                   5'b00000:    ControlsD = `FCTRLW'b1_0_01_00_101_0_0_0; // fcvt.s.w   w->s
                                   5'b00001:    ControlsD = `FCTRLW'b1_0_01_00_100_0_0_0; // fcvt.s.wu wu->s
                                   5'b00010:    ControlsD = `FCTRLW'b1_0_01_00_111_0_0_0; // fcvt.s.l   l->s
@@ -174,6 +176,7 @@ module fctrl (
                                   5'b00010:    ControlsD = `FCTRLW'b0_1_01_00_011_0_0_1; // fcvt.l.d   d->l
                                   5'b00011:    ControlsD = `FCTRLW'b0_1_01_00_010_0_0_1; // fcvt.lu.d  d->lu
                                 endcase
+                    // coverage off
                     7'b1101010: case(Rs2D)
                                   5'b00000:    ControlsD = `FCTRLW'b1_0_01_00_101_0_0_0; // fcvt.h.w   w->h
                                   5'b00001:    ControlsD = `FCTRLW'b1_0_01_00_100_0_0_0; // fcvt.h.wu wu->h
@@ -197,7 +200,8 @@ module fctrl (
                                   5'b00001:    ControlsD = `FCTRLW'b0_1_01_00_000_0_0_1; // fcvt.wu.q  q->wu
                                   5'b00010:    ControlsD = `FCTRLW'b0_1_01_00_011_0_0_1; // fcvt.l.q   q->l
                                   5'b00011:    ControlsD = `FCTRLW'b0_1_01_00_010_0_0_1; // fcvt.lu.q  q->lu
-                                endcase                            
+                                endcase
+                    // coverage on
                   endcase
       endcase
       /* verilator lint_off CASEINCOMPLETE */

--- a/tests/coverage/fpu.S
+++ b/tests/coverage/fpu.S
@@ -28,7 +28,7 @@
 
 main:
 
-    bseti t0, zero, 14  # turn on FPU
+    #bseti t0, zero, 14  # turn on FPU
     csrs mstatus, t0
 
     # Test legal instructions not covered elsewhere
@@ -36,8 +36,12 @@ main:
     flh ft0, 8(a0)
     fsq ft0, 0(a0)
     fsh ft0, 8(a0)
+
+    # Tests for fpu/fctrl.sv
+    ## The following cover lines 149 to 154
     fcvt.h.s ft1, ft0
     fcvt.q.s ft2, ft0
+    ## The following cover lines 179 to 204
     fcvt.h.w ft3, a0
     fcvt.h.wu ft3, a0
     fcvt.h.l ft3, a0
@@ -55,7 +59,6 @@ main:
     fcvt.l.q a0, ft3
     fcvt.lu.q a0, ft3
 
- 
     # Test illegal instructions are detected
     .word 0x00000007 // illegal floating-point load (bad Funct3)
     .word 0x00000027 // illegal floating-point store (bad Funct3)

--- a/tests/coverage/fpu.S
+++ b/tests/coverage/fpu.S
@@ -38,10 +38,8 @@ main:
     fsh ft0, 8(a0)
 
     # Tests for fpu/fctrl.sv
-    ## The following cover lines 149 to 154
     fcvt.h.s ft1, ft0
     fcvt.q.s ft2, ft0
-    ## The following cover lines 179 to 204
     fcvt.h.w ft3, a0
     fcvt.h.wu ft3, a0
     fcvt.h.l ft3, a0


### PR DESCRIPTION
This PR turns coverage off for the following instructions which are not reached when running `./regression-wally -coverage`:

- Conversions to/from half precision
    - fcvt.h.(s/d/q) 
    - fcvt.w.h
    - fcvt.wu.h
    - fcvt.l.h
    - fcvt.lu.h
    - fcvt.h.w
    - fcvt.h.wu
    - fcvt.h.l
    - fcvt.h.lu
- Conversions to/from quad precision
    - fcvt.q.(s/h/d) 
    - fcvt.q.w
    - fcvt.q.wu
    - fcvt.q.l
    - fcvt.q.lu
    - fcvt.w.q
    - fcvt.wu.q
    - fcvt.l.q
    - fcvt.lu.q

These instructions are instead tested by running fpu.s with the `run-elf.bash` script.

Not 100% certain this is the correct approach here. Feel free to point me in the right direction!