### PR TITLE
expanded ifu coverage including 4 added directed tests and 1 exclusion, expanded fpu coverage including 6 directed tests and 2 multiline exclusions

### DIFF
--- a/src/fpu/fctrl.sv
+++ b/src/fpu/fctrl.sv
@@ -146,10 +146,13 @@ module fctrl (
                                                ControlsD = `FCTRLW'b1_0_01_00_000_0_0_0; // fcvt.s.(d/q/h)
                     7'b0100001: if (Rs2D[4:2] == 3'b000  & SupportedFmt2 & Rs2D[1:0] != 2'b01)
                                                ControlsD = `FCTRLW'b1_0_01_00_001_0_0_0; // fcvt.d.(s/h/q)
+                    // coverage off                           
+                    // We are turning off coverage because rv64gc configuration doesn't support quad or half
                     7'b0100010: if (Rs2D[4:2] == 3'b000 & SupportedFmt2 & Rs2D[1:0] != 2'b10)
                                                ControlsD = `FCTRLW'b1_0_01_00_010_0_0_0; // fcvt.h.(s/d/q)
                     7'b0100011: if (Rs2D[4:2] == 3'b000  & SupportedFmt2 & Rs2D[1:0] != 2'b11)
                                                ControlsD = `FCTRLW'b1_0_01_00_011_0_0_0; // fcvt.q.(s/h/d)
+                    // coverage on
                    7'b1101000: case(Rs2D)
                                   5'b00000:    ControlsD = `FCTRLW'b1_0_01_00_101_0_0_0; // fcvt.s.w   w->s
                                   5'b00001:    ControlsD = `FCTRLW'b1_0_01_00_100_0_0_0; // fcvt.s.wu wu->s
@@ -174,6 +177,9 @@ module fctrl (
                                   5'b00010:    ControlsD = `FCTRLW'b0_1_01_00_011_0_0_1; // fcvt.l.d   d->l
                                   5'b00011:    ControlsD = `FCTRLW'b0_1_01_00_010_0_0_1; // fcvt.lu.d  d->lu
                                 endcase
+                    //coverage off
+                    // turning coverage off here because rv64gc configuration does not support floating point halfs and quads
+                    // verified that these branches will not ever be taken in rv64gc configuration.
                     7'b1101010: case(Rs2D)
                                   5'b00000:    ControlsD = `FCTRLW'b1_0_01_00_101_0_0_0; // fcvt.h.w   w->h
                                   5'b00001:    ControlsD = `FCTRLW'b1_0_01_00_100_0_0_0; // fcvt.h.wu wu->h
@@ -197,7 +203,8 @@ module fctrl (
                                   5'b00001:    ControlsD = `FCTRLW'b0_1_01_00_000_0_0_1; // fcvt.wu.q  q->wu
                                   5'b00010:    ControlsD = `FCTRLW'b0_1_01_00_011_0_0_1; // fcvt.l.q   q->l
                                   5'b00011:    ControlsD = `FCTRLW'b0_1_01_00_010_0_0_1; // fcvt.lu.q  q->lu
-                                endcase                            
+                                endcase
+                    // coverage on                            
                   endcase
       endcase
       /* verilator lint_off CASEINCOMPLETE */

--- a/src/fpu/fctrl.sv
+++ b/src/fpu/fctrl.sv
@@ -100,105 +100,111 @@ module fctrl (
       ControlsD = `FCTRLW'b0_0_00_xx_000_0_1_0; // default: non-implemented instruction
       /* verilator lint_off CASEINCOMPLETE */ // default value above has priority so no other default needed
       case(OpD)
-      7'b0000111: case(Funct3D)
-                    3'b010:                      ControlsD = `FCTRLW'b1_0_10_xx_0xx_0_0_0; // flw
-                    3'b011:  if (`D_SUPPORTED)   ControlsD = `FCTRLW'b1_0_10_xx_0xx_0_0_0; // fld
-                    3'b100:  if (`Q_SUPPORTED)   ControlsD = `FCTRLW'b1_0_10_xx_0xx_0_0_0; // flq
-                    3'b001:  if (`ZFH_SUPPORTED) ControlsD = `FCTRLW'b1_0_10_xx_0xx_0_0_0; // flh
-                  endcase
-      7'b0100111: case(Funct3D)
-                    3'b010:                      ControlsD = `FCTRLW'b0_0_10_xx_0xx_0_0_0; // fsw
-                    3'b011:  if (`D_SUPPORTED)   ControlsD = `FCTRLW'b0_0_10_xx_0xx_0_0_0; // fsd
-                    3'b100:  if (`Q_SUPPORTED)   ControlsD = `FCTRLW'b0_0_10_xx_0xx_0_0_0; // fsq
-                    3'b001:  if (`ZFH_SUPPORTED) ControlsD = `FCTRLW'b0_0_10_xx_0xx_0_0_0; // fsh
-                  endcase
-      7'b1000011:   ControlsD = `FCTRLW'b1_0_01_10_000_0_0_0; // fmadd
-      7'b1000111:   ControlsD = `FCTRLW'b1_0_01_10_001_0_0_0; // fmsub
-      7'b1001011:   ControlsD = `FCTRLW'b1_0_01_10_010_0_0_0; // fnmsub
-      7'b1001111:   ControlsD = `FCTRLW'b1_0_01_10_011_0_0_0; // fnmadd
-      7'b1010011: casez(Funct7D)
-                    7'b00000??: ControlsD = `FCTRLW'b1_0_01_10_110_0_0_0; // fadd
-                    7'b00001??: ControlsD = `FCTRLW'b1_0_01_10_111_0_0_0; // fsub
-                    7'b00010??: ControlsD = `FCTRLW'b1_0_01_10_100_0_0_0; // fmul
-                    7'b00011??: ControlsD = `FCTRLW'b1_0_01_01_xx0_1_0_0; // fdiv
-                    7'b01011??: if (Rs2D == 5'b0000) ControlsD = `FCTRLW'b1_0_01_01_xx1_1_0_0; // fsqrt
-                    7'b00100??: case(Funct3D)
-                                  3'b000:  ControlsD = `FCTRLW'b1_0_00_xx_000_0_0_0; // fsgnj
-                                  3'b001:  ControlsD = `FCTRLW'b1_0_00_xx_001_0_0_0; // fsgnjn
-                                  3'b010:  ControlsD = `FCTRLW'b1_0_00_xx_010_0_0_0; // fsgnjx
-                               endcase
-                    7'b00101??: case(Funct3D)
-                                  3'b000:  ControlsD = `FCTRLW'b1_0_00_xx_110_0_0_0; // fmin
-                                  3'b001:  ControlsD = `FCTRLW'b1_0_00_xx_101_0_0_0; // fmax
-                                endcase
-                    7'b10100??: case(Funct3D)
-                                  3'b010:  ControlsD = `FCTRLW'b0_1_00_xx_010_0_0_0; // feq
-                                  3'b001:  ControlsD = `FCTRLW'b0_1_00_xx_001_0_0_0; // flt
-                                  3'b000:  ControlsD = `FCTRLW'b0_1_00_xx_011_0_0_0; // fle
-                                endcase
-                    7'b11100??: if (Funct3D == 3'b001 & Rs2D == 5'b00000)          
-                                               ControlsD = `FCTRLW'b0_1_10_xx_000_0_0_0; // fclass
-                                else if (Funct3D == 3'b000 & Rs2D == 5'b00000) 
-                                               ControlsD = `FCTRLW'b0_1_11_xx_000_0_0_0; // fmv.x.w / fmv.x.d to int register
-                    7'b111100?: if (Funct3D == 3'b000 & Rs2D == 5'b00000) 
-                                               ControlsD = `FCTRLW'b1_0_00_xx_011_0_0_0; // fmv.w.x / fmv.d.x   to fp reg
-                    7'b0100000: if (Rs2D[4:2] == 3'b000 & SupportedFmt2 & Rs2D[1:0] != 2'b00)
-                                               ControlsD = `FCTRLW'b1_0_01_00_000_0_0_0; // fcvt.s.(d/q/h)
-                    7'b0100001: if (Rs2D[4:2] == 3'b000  & SupportedFmt2 & Rs2D[1:0] != 2'b01)
-                                               ControlsD = `FCTRLW'b1_0_01_00_001_0_0_0; // fcvt.d.(s/h/q)
-                    7'b0100010: if (Rs2D[4:2] == 3'b000 & SupportedFmt2 & Rs2D[1:0] != 2'b10)
-                                               ControlsD = `FCTRLW'b1_0_01_00_010_0_0_0; // fcvt.h.(s/d/q)
-                    7'b0100011: if (Rs2D[4:2] == 3'b000  & SupportedFmt2 & Rs2D[1:0] != 2'b11)
-                                               ControlsD = `FCTRLW'b1_0_01_00_011_0_0_0; // fcvt.q.(s/h/d)
-                   7'b1101000: case(Rs2D)
-                                  5'b00000:    ControlsD = `FCTRLW'b1_0_01_00_101_0_0_0; // fcvt.s.w   w->s
-                                  5'b00001:    ControlsD = `FCTRLW'b1_0_01_00_100_0_0_0; // fcvt.s.wu wu->s
-                                  5'b00010:    ControlsD = `FCTRLW'b1_0_01_00_111_0_0_0; // fcvt.s.l   l->s
-                                  5'b00011:    ControlsD = `FCTRLW'b1_0_01_00_110_0_0_0; // fcvt.s.lu lu->s
-                                endcase
-                    7'b1100000: case(Rs2D)
-                                  5'b00000:    ControlsD = `FCTRLW'b0_1_01_00_001_0_0_1; // fcvt.w.s   s->w
-                                  5'b00001:    ControlsD = `FCTRLW'b0_1_01_00_000_0_0_1; // fcvt.wu.s  s->wu
-                                  5'b00010:    ControlsD = `FCTRLW'b0_1_01_00_011_0_0_1; // fcvt.l.s   s->l
-                                  5'b00011:    ControlsD = `FCTRLW'b0_1_01_00_010_0_0_1; // fcvt.lu.s  s->lu
-                                endcase
-                    7'b1101001: case(Rs2D)
-                                  5'b00000:    ControlsD = `FCTRLW'b1_0_01_00_101_0_0_0; // fcvt.d.w   w->d
-                                  5'b00001:    ControlsD = `FCTRLW'b1_0_01_00_100_0_0_0; // fcvt.d.wu wu->d
-                                  5'b00010:    ControlsD = `FCTRLW'b1_0_01_00_111_0_0_0; // fcvt.d.l   l->d
-                                  5'b00011:    ControlsD = `FCTRLW'b1_0_01_00_110_0_0_0; // fcvt.d.lu lu->d
-                                endcase
-                    7'b1100001: case(Rs2D)
-                                  5'b00000:    ControlsD = `FCTRLW'b0_1_01_00_001_0_0_1; // fcvt.w.d   d->w
-                                  5'b00001:    ControlsD = `FCTRLW'b0_1_01_00_000_0_0_1; // fcvt.wu.d  d->wu
-                                  5'b00010:    ControlsD = `FCTRLW'b0_1_01_00_011_0_0_1; // fcvt.l.d   d->l
-                                  5'b00011:    ControlsD = `FCTRLW'b0_1_01_00_010_0_0_1; // fcvt.lu.d  d->lu
-                                endcase
-                    7'b1101010: case(Rs2D)
-                                  5'b00000:    ControlsD = `FCTRLW'b1_0_01_00_101_0_0_0; // fcvt.h.w   w->h
-                                  5'b00001:    ControlsD = `FCTRLW'b1_0_01_00_100_0_0_0; // fcvt.h.wu wu->h
-                                  5'b00010:    ControlsD = `FCTRLW'b1_0_01_00_111_0_0_0; // fcvt.h.l   l->h
-                                  5'b00011:    ControlsD = `FCTRLW'b1_0_01_00_110_0_0_0; // fcvt.h.lu lu->h
-                                endcase
-                    7'b1100010: case(Rs2D)
-                                  5'b00000:    ControlsD = `FCTRLW'b0_1_01_00_001_0_0_1; // fcvt.w.h   h->w
-                                  5'b00001:    ControlsD = `FCTRLW'b0_1_01_00_000_0_0_1; // fcvt.wu.h  h->wu
-                                  5'b00010:    ControlsD = `FCTRLW'b0_1_01_00_011_0_0_1; // fcvt.l.h   h->l
-                                  5'b00011:    ControlsD = `FCTRLW'b0_1_01_00_010_0_0_1; // fcvt.lu.h  h->lu
-                                endcase
-                    7'b1101011: case(Rs2D)
-                                  5'b00000:    ControlsD = `FCTRLW'b1_0_01_00_101_0_0_0; // fcvt.q.w   w->q
-                                  5'b00001:    ControlsD = `FCTRLW'b1_0_01_00_100_0_0_0; // fcvt.q.wu wu->q
-                                  5'b00010:    ControlsD = `FCTRLW'b1_0_01_00_111_0_0_0; // fcvt.q.l   l->q
-                                  5'b00011:    ControlsD = `FCTRLW'b1_0_01_00_110_0_0_0; // fcvt.q.lu lu->q
-                                endcase
-                    7'b1100011: case(Rs2D)
-                                  5'b00000:    ControlsD = `FCTRLW'b0_1_01_00_001_0_0_1; // fcvt.w.q   q->w
-                                  5'b00001:    ControlsD = `FCTRLW'b0_1_01_00_000_0_0_1; // fcvt.wu.q  q->wu
-                                  5'b00010:    ControlsD = `FCTRLW'b0_1_01_00_011_0_0_1; // fcvt.l.q   q->l
-                                  5'b00011:    ControlsD = `FCTRLW'b0_1_01_00_010_0_0_1; // fcvt.lu.q  q->lu
-                                endcase                            
-                  endcase
+        7'b0000111: case(Funct3D)
+                      3'b010:                      ControlsD = `FCTRLW'b1_0_10_xx_0xx_0_0_0; // flw
+                      3'b011:  if (`D_SUPPORTED)   ControlsD = `FCTRLW'b1_0_10_xx_0xx_0_0_0; // fld
+                      3'b100:  if (`Q_SUPPORTED)   ControlsD = `FCTRLW'b1_0_10_xx_0xx_0_0_0; // flq
+                      3'b001:  if (`ZFH_SUPPORTED) ControlsD = `FCTRLW'b1_0_10_xx_0xx_0_0_0; // flh
+                    endcase
+        7'b0100111: case(Funct3D)
+                      3'b010:                      ControlsD = `FCTRLW'b0_0_10_xx_0xx_0_0_0; // fsw
+                      3'b011:  if (`D_SUPPORTED)   ControlsD = `FCTRLW'b0_0_10_xx_0xx_0_0_0; // fsd
+                      3'b100:  if (`Q_SUPPORTED)   ControlsD = `FCTRLW'b0_0_10_xx_0xx_0_0_0; // fsq
+                      3'b001:  if (`ZFH_SUPPORTED) ControlsD = `FCTRLW'b0_0_10_xx_0xx_0_0_0; // fsh
+                    endcase
+        7'b1000011:   ControlsD = `FCTRLW'b1_0_01_10_000_0_0_0; // fmadd
+        7'b1000111:   ControlsD = `FCTRLW'b1_0_01_10_001_0_0_0; // fmsub
+        7'b1001011:   ControlsD = `FCTRLW'b1_0_01_10_010_0_0_0; // fnmsub
+        7'b1001111:   ControlsD = `FCTRLW'b1_0_01_10_011_0_0_0; // fnmadd
+        7'b1010011: casez(Funct7D)
+                      7'b00000??: ControlsD = `FCTRLW'b1_0_01_10_110_0_0_0; // fadd
+                      7'b00001??: ControlsD = `FCTRLW'b1_0_01_10_111_0_0_0; // fsub
+                      7'b00010??: ControlsD = `FCTRLW'b1_0_01_10_100_0_0_0; // fmul
+                      7'b00011??: ControlsD = `FCTRLW'b1_0_01_01_xx0_1_0_0; // fdiv
+                      7'b01011??: if (Rs2D == 5'b0000) ControlsD = `FCTRLW'b1_0_01_01_xx1_1_0_0; // fsqrt
+                      7'b00100??: case(Funct3D)
+                                    3'b000:  ControlsD = `FCTRLW'b1_0_00_xx_000_0_0_0; // fsgnj
+                                    3'b001:  ControlsD = `FCTRLW'b1_0_00_xx_001_0_0_0; // fsgnjn
+                                    3'b010:  ControlsD = `FCTRLW'b1_0_00_xx_010_0_0_0; // fsgnjx
+                                  endcase
+                      7'b00101??: case(Funct3D)
+                                    3'b000:  ControlsD = `FCTRLW'b1_0_00_xx_110_0_0_0; // fmin
+                                    3'b001:  ControlsD = `FCTRLW'b1_0_00_xx_101_0_0_0; // fmax
+                                  endcase
+                      7'b10100??: case(Funct3D)
+                                    3'b010:  ControlsD = `FCTRLW'b0_1_00_xx_010_0_0_0; // feq
+                                    3'b001:  ControlsD = `FCTRLW'b0_1_00_xx_001_0_0_0; // flt
+                                    3'b000:  ControlsD = `FCTRLW'b0_1_00_xx_011_0_0_0; // fle
+                                  endcase
+                      7'b11100??: if (Funct3D == 3'b001 & Rs2D == 5'b00000)          
+                                                ControlsD = `FCTRLW'b0_1_10_xx_000_0_0_0; // fclass
+                                  else if (Funct3D == 3'b000 & Rs2D == 5'b00000) 
+                                                ControlsD = `FCTRLW'b0_1_11_xx_000_0_0_0; // fmv.x.w / fmv.x.d to int register
+                      7'b111100?: if (Funct3D == 3'b000 & Rs2D == 5'b00000) 
+                                                ControlsD = `FCTRLW'b1_0_00_xx_011_0_0_0; // fmv.w.x / fmv.d.x   to fp reg
+                      7'b0100000: if (Rs2D[4:2] == 3'b000 & SupportedFmt2 & Rs2D[1:0] != 2'b00)
+                                                ControlsD = `FCTRLW'b1_0_01_00_000_0_0_0; // fcvt.s.(d/q/h)
+                      7'b0100001: if (Rs2D[4:2] == 3'b000  & SupportedFmt2 & Rs2D[1:0] != 2'b01)
+                                                ControlsD = `FCTRLW'b1_0_01_00_001_0_0_0; // fcvt.d.(s/h/q)
+                      // coverage off
+                      // Not covered in testing because rv64gc does not support half or quad precision
+                      7'b0100010: if (Rs2D[4:2] == 3'b000 & SupportedFmt2 & Rs2D[1:0] != 2'b10)
+                                                ControlsD = `FCTRLW'b1_0_01_00_010_0_0_0; // fcvt.h.(s/d/q)
+                      7'b0100011: if (Rs2D[4:2] == 3'b000  & SupportedFmt2 & Rs2D[1:0] != 2'b11)
+                                                ControlsD = `FCTRLW'b1_0_01_00_011_0_0_0; // fcvt.q.(s/h/d)
+                      // coverage on
+                      7'b1101000: case(Rs2D)
+                                    5'b00000:    ControlsD = `FCTRLW'b1_0_01_00_101_0_0_0; // fcvt.s.w   w->s
+                                    5'b00001:    ControlsD = `FCTRLW'b1_0_01_00_100_0_0_0; // fcvt.s.wu wu->s
+                                    5'b00010:    ControlsD = `FCTRLW'b1_0_01_00_111_0_0_0; // fcvt.s.l   l->s
+                                    5'b00011:    ControlsD = `FCTRLW'b1_0_01_00_110_0_0_0; // fcvt.s.lu lu->s
+                                  endcase
+                      7'b1100000: case(Rs2D)
+                                    5'b00000:    ControlsD = `FCTRLW'b0_1_01_00_001_0_0_1; // fcvt.w.s   s->w
+                                    5'b00001:    ControlsD = `FCTRLW'b0_1_01_00_000_0_0_1; // fcvt.wu.s  s->wu
+                                    5'b00010:    ControlsD = `FCTRLW'b0_1_01_00_011_0_0_1; // fcvt.l.s   s->l
+                                    5'b00011:    ControlsD = `FCTRLW'b0_1_01_00_010_0_0_1; // fcvt.lu.s  s->lu
+                                  endcase
+                      7'b1101001: case(Rs2D)
+                                    5'b00000:    ControlsD = `FCTRLW'b1_0_01_00_101_0_0_0; // fcvt.d.w   w->d
+                                    5'b00001:    ControlsD = `FCTRLW'b1_0_01_00_100_0_0_0; // fcvt.d.wu wu->d
+                                    5'b00010:    ControlsD = `FCTRLW'b1_0_01_00_111_0_0_0; // fcvt.d.l   l->d
+                                    5'b00011:    ControlsD = `FCTRLW'b1_0_01_00_110_0_0_0; // fcvt.d.lu lu->d
+                                  endcase
+                      7'b1100001: case(Rs2D)
+                                    5'b00000:    ControlsD = `FCTRLW'b0_1_01_00_001_0_0_1; // fcvt.w.d   d->w
+                                    5'b00001:    ControlsD = `FCTRLW'b0_1_01_00_000_0_0_1; // fcvt.wu.d  d->wu
+                                    5'b00010:    ControlsD = `FCTRLW'b0_1_01_00_011_0_0_1; // fcvt.l.d   d->l
+                                    5'b00011:    ControlsD = `FCTRLW'b0_1_01_00_010_0_0_1; // fcvt.lu.d  d->lu
+                                  endcase
+                      // coverage off
+                      // Not covered in testing because rv64gc does not support half or quad precision
+                      7'b1101010: case(Rs2D)
+                                    5'b00000:    ControlsD = `FCTRLW'b1_0_01_00_101_0_0_0; // fcvt.h.w   w->h
+                                    5'b00001:    ControlsD = `FCTRLW'b1_0_01_00_100_0_0_0; // fcvt.h.wu wu->h
+                                    5'b00010:    ControlsD = `FCTRLW'b1_0_01_00_111_0_0_0; // fcvt.h.l   l->h
+                                    5'b00011:    ControlsD = `FCTRLW'b1_0_01_00_110_0_0_0; // fcvt.h.lu lu->h
+                                  endcase
+                      7'b1100010: case(Rs2D)
+                                    5'b00000:    ControlsD = `FCTRLW'b0_1_01_00_001_0_0_1; // fcvt.w.h   h->w
+                                    5'b00001:    ControlsD = `FCTRLW'b0_1_01_00_000_0_0_1; // fcvt.wu.h  h->wu
+                                    5'b00010:    ControlsD = `FCTRLW'b0_1_01_00_011_0_0_1; // fcvt.l.h   h->l
+                                    5'b00011:    ControlsD = `FCTRLW'b0_1_01_00_010_0_0_1; // fcvt.lu.h  h->lu
+                                  endcase
+                      7'b1101011: case(Rs2D)
+                                    5'b00000:    ControlsD = `FCTRLW'b1_0_01_00_101_0_0_0; // fcvt.q.w   w->q
+                                    5'b00001:    ControlsD = `FCTRLW'b1_0_01_00_100_0_0_0; // fcvt.q.wu wu->q
+                                    5'b00010:    ControlsD = `FCTRLW'b1_0_01_00_111_0_0_0; // fcvt.q.l   l->q
+                                    5'b00011:    ControlsD = `FCTRLW'b1_0_01_00_110_0_0_0; // fcvt.q.lu lu->q
+                                  endcase
+                      7'b1100011: case(Rs2D)
+                                    5'b00000:    ControlsD = `FCTRLW'b0_1_01_00_001_0_0_1; // fcvt.w.q   q->w
+                                    5'b00001:    ControlsD = `FCTRLW'b0_1_01_00_000_0_0_1; // fcvt.wu.q  q->wu
+                                    5'b00010:    ControlsD = `FCTRLW'b0_1_01_00_011_0_0_1; // fcvt.l.q   q->l
+                                    5'b00011:    ControlsD = `FCTRLW'b0_1_01_00_010_0_0_1; // fcvt.lu.q  q->lu
+                                  endcase
+                      // coverage on
+                    endcase
       endcase
     end
     /* verilator lint_on CASEINCOMPLETE */

--- a/src/ifu/decompress.sv
+++ b/src/ifu/decompress.sv
@@ -135,10 +135,16 @@ module decompress (
                       IllegalCompInstrD = 1;
                       InstrD = {16'b0, instr16}; // preserve instruction for mtval on trap
                     end
+                  // coverage off
+                  // are excluding this branch from coverage because in rv64gc XLEN is always 64 and thus greater than 32 bits
+                  // This branch will only be taken if instr16[12:10] == 3'b111 and 'XLEN !> 32, because all other 
+                  // possible values for instr16[12:10] are covered by branches above. XLEN !> 32 
+                  // will never occur in rv64gc so this branch can not be covered
                   else begin // illegal instruction
                     IllegalCompInstrD = 1;
                     InstrD = {16'b0, instr16}; // preserve instruction for mtval on trap
                   end
+                  // coverage on
         5'b01101: InstrD = {immCJ, 5'b00000, 7'b1101111}; // c.j
         5'b01110: InstrD = {immCB[11:5], 5'b00000, rs1p, 3'b000, immCB[4:0], 7'b1100011}; // c.beqz
         5'b01111: InstrD = {immCB[11:5], 5'b00000, rs1p, 3'b001, immCB[4:0], 7'b1100011}; // c.bnez

--- a/tests/coverage/fpu.S
+++ b/tests/coverage/fpu.S
@@ -57,7 +57,6 @@ main:
     fcvt.l.q a0, ft3
     fcvt.lu.q a0, ft3
 
-<<<<<<< HEAD
 
     // Tests verfying that half and quad floating point convertion instructions are not supported by rv64gc
     # fcvt.h.d ft3, ft0 // Somehow this instruction is taking the route on line 124
@@ -75,8 +74,6 @@ main:
     .word 0xd2400053    // Line 168 All False Test case - illegal instruction?
     .word 0xc2400053    // Line 174 All False Test case - illegal instruction?
 
-=======
->>>>>>> d4b7da34dee55ec8394ab391ecd6514c887a9790
     # Test illegal instructions are detected
     .word 0x00000007 // illegal floating-point load (bad Funct3)
     .word 0x00000027 // illegal floating-point store (bad Funct3)

--- a/tests/coverage/fpu.S
+++ b/tests/coverage/fpu.S
@@ -55,7 +55,23 @@ main:
     fcvt.l.q a0, ft3
     fcvt.lu.q a0, ft3
 
- 
+
+    // Tests verfying that half and quad floating point convertion instructions are not supported by rv64gc
+    # fcvt.h.d ft3, ft0 // Somehow this instruction is taking the route on line 124
+                      // idea: enable the Q extension for this to work properly? A: Q and halfs not supported in rv64gc
+    # fcvt.h.w ft3, a0
+    # fcvt.w.h a0, ft0
+    # fcvt.q.w ft3, a0
+    # fcvt.w.q a0, ft0
+    # fcvt.q.d ft3, ft0
+
+    .word 0x38007553    // Testing the all False case for 119 - funct7 under, op = 101 0011
+    .word 0x40000053    // Line 145 All False Test case - illegal instruction?
+    .word 0xd0400053    // Line 156 All False Test case - illegal instruction?
+    .word 0xc0400053    // Line 162 All False Test case - illegal instruction?
+    .word 0xd2400053    // Line 168 All False Test case - illegal instruction?
+    .word 0xc2400053    // Line 174 All False Test case - illegal instruction?
+
     # Test illegal instructions are detected
     .word 0x00000007 // illegal floating-point load (bad Funct3)
     .word 0x00000027 // illegal floating-point store (bad Funct3)

--- a/tests/coverage/ifu.S
+++ b/tests/coverage/ifu.S
@@ -32,9 +32,26 @@ main:
     csrs mstatus, t0
 
     # calling compressed floating point load double instruction
-    //.halfword 0x2000 // CL type compressed floating-point ld-->funct3,imm,rs1',imm,rd',op
+    //.hword 0x2000 // CL type compressed floating-point ld-->funct3,imm,rs1',imm,rd',op
                         // binary version 0000 0000 0000 0000 0010 0000 0000 0000
     mv s0, sp
     c.fld fs0, 0(s0)
+    c.fsd fs0, 0(s0)
+
+    // c.fldsp fs0, 0
+    .hword 0x2002
+
+    // c.fsdsp fs0, 0
+    .hword 0xA002
+
+    # set XLEN to 64
+    li t0, 0x200000000
+    csrs mstatus, t0
+
+    //# Illegal compressed instruction with op = 01, instr[15:10] = 100111, and 0's everywhere else
+    //.hword 0x9C01
+
+    # Illegal compressed instruction 
+    .hword 0x9C41
 
     j done

--- a/tests/coverage/ifu.S
+++ b/tests/coverage/ifu.S
@@ -36,6 +36,7 @@ main:
                         // binary version 0000 0000 0000 0000 0010 0000 0000 0000
     mv s0, sp
     c.fld fs0, 0(s0)
+
     c.fsd fs0, 0(s0)
 
     // c.fldsp fs0, 0
@@ -44,14 +45,10 @@ main:
     // c.fsdsp fs0, 0
     .hword 0xA002
 
-    # set XLEN to 64
-    li t0, 0x200000000
-    csrs mstatus, t0
-
     //# Illegal compressed instruction with op = 01, instr[15:10] = 100111, and 0's everywhere else
     //.hword 0x9C01
 
-    # Illegal compressed instruction 
+    # Line Illegal compressed instruction 
     .hword 0x9C41
 
     j done


### PR DESCRIPTION
4 files were edited

1) src/fpu/fctrl.sv
- Added 2 multiline coverage exclusions to exclude branches that cannot be covered by the rv64gc configuration because it doesn't support floating point half or quad precision

2) src/ifu/decompress.sv
- Added 1 exclusion of a branch that will never be hit in the rv64gc configuration. The branch requires `XLEN !> 32 and in rv64gc, `XLEN is 64.

3) tests/coverage/ifu.S
- Added 4 tests to cover 4 previously uncovered branches/instructions (c.fsd, c.fldsp, c.fsdsp, an illegal instruction)

4) tests/coverage/fpu.S
- Added 6 directed tests to cover All False branch for 6 different sets of cases. 

The ifu and fpu now have full branch coverage. My next step will be improving the conditional coverage.
