### PR TITLE
i$ coverage improvements

### DIFF
--- a/src/cache/cache.sv
+++ b/src/cache/cache.sv
@@ -76,7 +76,7 @@ module cache #(parameter LINELEN,  NUMLINES,  NUMWAYS, LOGBWPL, WORDLEN, MUXINTE
   logic [1:0]                    AdrSelMuxSel;
   logic [SETLEN-1:0]             CacheSet;
   logic [LINELEN-1:0]            LineWriteData;
-  logic                          ClearValid, ClearDirty, SetDirty, SetValid;
+  logic                          ClearDirty, SetDirty, SetValid;
   logic [LINELEN-1:0]            ReadDataLineWay [NUMWAYS-1:0];
   logic [NUMWAYS-1:0]            HitWay, ValidWay;
   logic                          CacheHit;
@@ -116,7 +116,7 @@ module cache #(parameter LINELEN,  NUMLINES,  NUMWAYS, LOGBWPL, WORDLEN, MUXINTE
   // Array of cache ways, along with victim, hit, dirty, and read merging logic
   cacheway #(NUMLINES, LINELEN, TAGLEN, OFFSETLEN, SETLEN, READ_ONLY_CACHE) CacheWays[NUMWAYS-1:0](
     .clk, .reset, .CacheEn, .CacheSet, .PAdr, .LineWriteData, .LineByteMask,
-    .SetValid, .ClearValid, .SetDirty, .ClearDirty, .SelWriteback, .VictimWay,
+    .SetValid, .SetDirty, .ClearDirty, .SelWriteback, .VictimWay,
     .FlushWay, .SelFlush, .ReadDataLineWay, .HitWay, .ValidWay, .DirtyWay, .TagWay, .FlushStage, .InvalidateCache);
 
   // Select victim way for associative caches
@@ -209,7 +209,7 @@ module cache #(parameter LINELEN,  NUMLINES,  NUMWAYS, LOGBWPL, WORDLEN, MUXINTE
     .FlushStage, .CacheRW, .CacheAtomic, .Stall,
     .CacheHit, .LineDirty, .CacheStall, .CacheCommitted, 
     .CacheMiss, .CacheAccess, .SelAdr, 
-    .ClearValid, .ClearDirty, .SetDirty, .SetValid, .SelWriteback, .SelFlush,
+    .ClearDirty, .SetDirty, .SetValid, .SelWriteback, .SelFlush,
     .FlushAdrCntEn, .FlushWayCntEn, .FlushCntRst,
     .FlushAdrFlag, .FlushWayFlag, .FlushCache, .SelFetchBuffer,
     .InvalidateCache, .CacheEn, .LRUWriteEn);

--- a/src/cache/cacheLRU.sv
+++ b/src/cache/cacheLRU.sv
@@ -67,11 +67,14 @@ module cacheLRU
   assign AllValid = &ValidWay;
 
   ///// Update replacement bits.
+
+  // coverage off: Untestable without varying NUMWAYS.
   function integer log2 (integer value);
     for (log2=0; value>0; log2=log2+1)
       value = value>>1;
     return log2;
   endfunction // log2
+  // coverage on
 
   // On a miss we need to ignore HitWay and derive the new replacement bits with the VictimWay.
   mux2 #(NUMWAYS) WayMux(HitWay, VictimWay, SetValid, Way);

--- a/src/cache/cacheLRU.sv
+++ b/src/cache/cacheLRU.sv
@@ -68,7 +68,8 @@ module cacheLRU
 
   ///// Update replacement bits.
 
-  // coverage off: Untestable without varying NUMWAYS.
+  // coverage off
+  // Excluded from coverage b/c it is untestable without varying NUMWAYS.
   function integer log2 (integer value);
     for (log2=0; value>0; log2=log2+1)
       value = value>>1;

--- a/src/cache/cachefsm.sv
+++ b/src/cache/cachefsm.sv
@@ -55,7 +55,6 @@ module cachefsm #(parameter READ_ONLY_CACHE = 0) (
   input  logic       FlushAdrFlag,      // On last set of a cache flush
   input  logic       FlushWayFlag,      // On the last way for any set of a cache flush
   output logic       SelAdr,            // [0] SRAM reads from NextAdr, [1] SRAM reads from PAdr
-  output logic       ClearValid,        // Clear the valid bit in the selected way and set
   output logic       SetValid,          // Set the dirty bit in the selected way and set
   output logic       ClearDirty,        // Clear the dirty bit in the selected way and set
   output logic       SetDirty,          // Set the dirty bit in the selected way and set
@@ -146,7 +145,6 @@ module cachefsm #(parameter READ_ONLY_CACHE = 0) (
   assign SetValid = CurrState == STATE_WRITE_LINE;
   assign SetDirty = (CurrState == STATE_READY & AnyUpdateHit) |
                     (CurrState == STATE_WRITE_LINE & (StoreAMO));
-  assign ClearValid = '0;
   assign ClearDirty = (CurrState == STATE_WRITE_LINE & ~(StoreAMO)) |
                       (CurrState == STATE_FLUSH & LineDirty); // This is wrong in a multicore snoop cache protocal.  Dirty must be cleared concurrently and atomically with writeback.  For single core cannot clear after writeback on bus ack and change flushadr.  Clears the wrong set.
   assign LRUWriteEn = (CurrState == STATE_READY & AnyHit) |

--- a/src/cache/cacheway.sv
+++ b/src/cache/cacheway.sv
@@ -128,10 +128,18 @@ module cacheway #(parameter NUMLINES=512, LINELEN = 256, TAGLEN = 26,
   localparam           LOGNUMSRAM = $clog2(NUMSRAM);
   
   for(words = 0; words < NUMSRAM; words++) begin: word
-    ram1p1rwbe #(.DEPTH(NUMLINES), .WIDTH(SRAMLEN)) CacheDataMem(.clk, .ce(CacheEn), .addr(CacheSet),
+    if (!READ_ONLY_CACHE) begin:wordram
+      ram1p1rwbe #(.DEPTH(NUMLINES), .WIDTH(SRAMLEN)) CacheDataMem(.clk, .ce(CacheEn), .addr(CacheSet),
       .dout(ReadDataLine[SRAMLEN*(words+1)-1:SRAMLEN*words]),
       .din(LineWriteData[SRAMLEN*(words+1)-1:SRAMLEN*words]),
       .we(SelectedWriteWordEn), .bwe(FinalByteMask[SRAMLENINBYTES*(words+1)-1:SRAMLENINBYTES*words]));
+    end
+    else begin:wordram // no byte-enable needed for i$.
+      ram1p1rwe #(.DEPTH(NUMLINES), .WIDTH(SRAMLEN)) CacheDataMem(.clk, .ce(CacheEn), .addr(CacheSet),
+      .dout(ReadDataLine[SRAMLEN*(words+1)-1:SRAMLEN*words]),
+      .din(LineWriteData[SRAMLEN*(words+1)-1:SRAMLEN*words]),
+      .we(SelectedWriteWordEn));
+    end
   end
 
   // AND portion of distributed read multiplexers

--- a/src/cache/cacheway.sv
+++ b/src/cache/cacheway.sv
@@ -107,8 +107,8 @@ module cacheway #(parameter NUMLINES=512, LINELEN = 256, TAGLEN = 26,
   // Tag Array
   /////////////////////////////////////////////////////////////////////////////////////////////
 
-  ram1p1rwbe #(.DEPTH(NUMLINES), .WIDTH(TAGLEN)) CacheTagMem(.clk, .ce(CacheEn),
-    .addr(CacheSet), .dout(ReadTag), .bwe('1),
+  ram1p1rwe #(.DEPTH(NUMLINES), .WIDTH(TAGLEN)) CacheTagMem(.clk, .ce(CacheEn),
+    .addr(CacheSet), .dout(ReadTag),
     .din(PAdr[`PA_BITS-1:OFFSETLEN+INDEXLEN]), .we(SetValidEN));
 
   // AND portion of distributed tag multiplexer

--- a/src/cache/cacheway.sv
+++ b/src/cache/cacheway.sv
@@ -39,7 +39,6 @@ module cacheway #(parameter NUMLINES=512, LINELEN = 256, TAGLEN = 26,
   input  logic [`PA_BITS-1:0]         PAdr,           // Physical address 
   input  logic [LINELEN-1:0]          LineWriteData,  // Final data written to cache (D$ only)
   input  logic                        SetValid,       // Set the valid bit in the selected way and set
-  input  logic                        ClearValid,     // Clear the valid bit in the selected way and set
   input  logic                        SetDirty,       // Set the dirty bit in the selected way and set
   input  logic                        ClearDirty,     // Clear the dirty bit in the selected way and set
   input  logic                        SelWriteback,   // Overrides cached tag check to select a specific way and set for writeback
@@ -71,7 +70,6 @@ module cacheway #(parameter NUMLINES=512, LINELEN = 256, TAGLEN = 26,
   logic [LINELEN/8-1:0]               FinalByteMask;
   logic                               SetValidEN;
   logic                               SetValidWay;
-  logic                               ClearValidWay;
   logic                               SetDirtyWay;
   logic                               ClearDirtyWay;
   logic                               SelNonHit;
@@ -94,7 +92,6 @@ module cacheway #(parameter NUMLINES=512, LINELEN = 256, TAGLEN = 26,
   /////////////////////////////////////////////////////////////////////////////////////////////
 
   assign SetValidWay = SetValid & SelData;
-  assign ClearValidWay = ClearValid & SelData;
   assign SetDirtyWay = SetDirty & SelData;
   assign ClearDirtyWay = ClearDirty & SelData;
   
@@ -154,7 +151,7 @@ module cacheway #(parameter NUMLINES=512, LINELEN = 256, TAGLEN = 26,
     if(CacheEn) begin 
     ValidWay <= #1 ValidBits[CacheSet];
     if(InvalidateCache)                    ValidBits <= #1 '0;
-      else if (SetValidEN | (ClearValidWay & ~FlushStage)) ValidBits[CacheSet] <= #1 SetValidWay;
+      else if (SetValidEN) ValidBits[CacheSet] <= #1 SetValidWay;
     end
   end
 

--- a/src/cache/cacheway.sv
+++ b/src/cache/cacheway.sv
@@ -38,7 +38,7 @@ module cacheway #(parameter NUMLINES=512, LINELEN = 256, TAGLEN = 26,
   input  logic [$clog2(NUMLINES)-1:0] CacheSet,           // Cache address, the output of the address select mux, NextAdr, PAdr, or FlushAdr
   input  logic [`PA_BITS-1:0]         PAdr,           // Physical address 
   input  logic [LINELEN-1:0]          LineWriteData,  // Final data written to cache (D$ only)
-  input  logic                        SetValid,       // Set the dirty bit in the selected way and set
+  input  logic                        SetValid,       // Set the valid bit in the selected way and set
   input  logic                        ClearValid,     // Clear the valid bit in the selected way and set
   input  logic                        SetDirty,       // Set the dirty bit in the selected way and set
   input  logic                        ClearDirty,     // Clear the dirty bit in the selected way and set

--- a/src/generic/mem/ram1p1rwe.sv
+++ b/src/generic/mem/ram1p1rwe.sv
@@ -81,14 +81,23 @@ module ram1p1rwe #(parameter DEPTH=64, WIDTH=44) (
     // Questa sim version 2022.3_2 does not allow multiple drivers for RAM when using always_ff.
     // Therefore these always blocks use the older always @(posedge clk) 
     if(WIDTH >= 8) 
-      always @(posedge clk) 
-        if (ce & we) 
+      always @(posedge clk)
+        // coverage off
+        // ce only goes low when cachefsm is in READY state and Flush is asserted.
+        // for read-only caches, we only goes high in the STATE_WRITE_LINE cachefsm state.
+        // so we can never get we=1, ce=0 for I$. Note that turning off coverage here
+        // might miss some cases for D$, however, when we might go high due to a store.
+        if (ce & we)
+        // coverage on
           for(i = 0; i < WIDTH/8; i++) 
             RAM[addr][i*8 +: 8] <= #1 din[i*8 +: 8];
   
     if (WIDTH%8 != 0) // handle msbs if width not a multiple of 8
-      always @(posedge clk) 
+      always @(posedge clk)
+        // coverage off
+        // (see the above explanation)
         if (ce & we)
+        // coverage on
           RAM[addr][WIDTH-1:WIDTH-WIDTH%8] <= #1 din[WIDTH-1:WIDTH-WIDTH%8];
   end
 

--- a/src/generic/mem/ram1p1rwe.sv
+++ b/src/generic/mem/ram1p1rwe.sv
@@ -1,0 +1,95 @@
+///////////////////////////////////////////
+// 1 port sram.
+//
+// Written: avercruysse@hmc.edu (Modified from ram1p1rwbe, by ross1728@gmail.com)
+// Created: 04 April 2023
+//
+// Purpose: ram1p1wre, but without byte-enable. Used for icache data.
+// 
+// Documentation: 
+//
+// A component of the CORE-V-WALLY configurable RISC-V project.
+// 
+// Copyright (C) 2021-23 Harvey Mudd College & Oklahoma State University
+//
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+//
+// Licensed under the Solderpad Hardware License v 2.1 (the “License”); you may not use this file 
+// except in compliance with the License, or, at your option, the Apache License version 2.0. You 
+// may obtain a copy of the License at
+//
+// https://solderpad.org/licenses/SHL-2.1/
+//
+// Unless required by applicable law or agreed to in writing, any work distributed under the 
+// License is distributed on an “AS IS” BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, 
+// either express or implied. See the License for the specific language governing permissions 
+// and limitations under the License.
+////////////////////////////////////////////////////////////////////////////////////////////////
+
+// WIDTH is number of bits in one "word" of the memory, DEPTH is number of such words
+
+`include "wally-config.vh"
+
+module ram1p1rwe #(parameter DEPTH=64, WIDTH=44) (
+  input logic                     clk,
+  input logic                     ce,
+  input logic [$clog2(DEPTH)-1:0] addr,
+  input logic [WIDTH-1:0]         din,
+  input logic                     we,
+  output logic [WIDTH-1:0]        dout
+);
+
+  logic [WIDTH-1:0]               RAM[DEPTH-1:0];
+
+  // ***************************************************************************
+  // TRUE SRAM macro
+  // ***************************************************************************
+  if ((`USE_SRAM == 1) & (WIDTH == 128) & (DEPTH == 64)) begin // Cache data subarray
+    // 64 x 128-bit SRAM
+    ram1p1rwbe_64x128 sram1A (.CLK(clk), .CEB(~ce), .WEB(~we),
+      .A(addr), .D(din), 
+      .BWEB('0), .Q(dout));
+    
+  end else if ((`USE_SRAM == 1) & (WIDTH == 44)  & (DEPTH == 64)) begin // RV64 cache tag
+    // 64 x 44-bit SRAM
+    ram1p1rwbe_64x44 sram1B (.CLK(clk), .CEB(~ce), .WEB(~we),
+      .A(addr), .D(din), 
+      .BWEB('0), .Q(dout));
+
+  end else if ((`USE_SRAM == 1) & (WIDTH == 22)  & (DEPTH == 64)) begin // RV32 cache tag
+    // 64 x 22-bit SRAM
+    ram1p1rwbe_64x22 sram1B (.CLK(clk), .CEB(~ce), .WEB(~we),
+      .A(addr), .D(din), 
+      .BWEB('0), .Q(dout));     
+    
+    // ***************************************************************************
+    // READ first SRAM model
+    // ***************************************************************************
+  end else begin: ram
+    integer i;
+
+    // Read
+    logic [$clog2(DEPTH)-1:0] addrd;
+    flopen #($clog2(DEPTH)) adrreg(clk, ce, addr, addrd);
+    assign dout = RAM[addrd];
+
+    /*      // Read
+     always_ff @(posedge clk) 
+     if(ce) dout <= #1 mem[addr]; */
+
+    // Write divided into part for bytes and part for extra msbs
+    // Questa sim version 2022.3_2 does not allow multiple drivers for RAM when using always_ff.
+    // Therefore these always blocks use the older always @(posedge clk) 
+    if(WIDTH >= 8) 
+      always @(posedge clk) 
+        if (ce & we) 
+          for(i = 0; i < WIDTH/8; i++) 
+            RAM[addr][i*8 +: 8] <= #1 din[i*8 +: 8];
+  
+    if (WIDTH%8 != 0) // handle msbs if width not a multiple of 8
+      always @(posedge clk) 
+        if (ce & we)
+          RAM[addr][WIDTH-1:WIDTH-WIDTH%8] <= #1 din[WIDTH-1:WIDTH-WIDTH%8];
+  end
+
+endmodule

--- a/src/generic/mem/ram1p1rwe.sv
+++ b/src/generic/mem/ram1p1rwe.sv
@@ -5,6 +5,8 @@
 // Created: 04 April 2023
 //
 // Purpose: ram1p1wre, but without byte-enable. Used for icache data.
+//          Be careful using this module, since coverage is turned off for (ce & we).
+//          In read-only caches, we never get (we=1, ce=0), so this waiver is needed.
 // 
 // Documentation: 
 //
@@ -85,8 +87,7 @@ module ram1p1rwe #(parameter DEPTH=64, WIDTH=44) (
         // coverage off
         // ce only goes low when cachefsm is in READY state and Flush is asserted.
         // for read-only caches, we only goes high in the STATE_WRITE_LINE cachefsm state.
-        // so we can never get we=1, ce=0 for I$. Note that turning off coverage here
-        // might miss some cases for D$, however, when we might go high due to a store.
+        // so we can never get we=1, ce=0 for I$.
         if (ce & we)
         // coverage on
           for(i = 0; i < WIDTH/8; i++) 

--- a/testbench/testbench.sv
+++ b/testbench/testbench.sv
@@ -713,7 +713,7 @@ module DCacheFlushFSM
                            // these dirty bit selections would be needed if dirty is moved inside the tag array.
           //.dirty(testbench.dut.core.lsu.bus.dcache.dcache.CacheWays[way].dirty.DirtyMem.RAM[index]),
           //.dirty(testbench.dut.core.lsu.bus.dcache.dcache.CacheWays[way].CacheTagMem.RAM[index][`PA_BITS+tagstart]),
-          .data(testbench.dut.core.lsu.bus.dcache.dcache.CacheWays[way].word[cacheWord].CacheDataMem.RAM[index]),
+          .data(testbench.dut.core.lsu.bus.dcache.dcache.CacheWays[way].word[cacheWord].wordram.CacheDataMem.RAM[index]),
           .index(index),
           .cacheWord(cacheWord),
           .CacheData(CacheData[way][index][cacheWord]),


### PR DESCRIPTION
A lot of I$ coverage issues are due to the fact that the read-only cache and rw-caches are described with the same verilog code. There were many opportunities to make the cache dirty/flush/write logic somehow dependent on READ_ONLY_CACHE to improve coverage.

Another significant change is adding ram1p1rwe, which does not have byte-enables. This is useful for the data memory of read-only cache, as well as the tag array for any caches, both of which always have every byte-enable high. One thing to note, however, is that coverage is disabled for the chip-enable during a write of this new memory.

I've written my reasoning for each change in the commit message for the change (and attempted to separate commits as much as possible). One extra thing to note are that for commit `3867142`, the cachetagmem was also changed to ram1p1rwe for the D$, not just the I$. This makes sense since the byte-enable is not needed for tag memory. Turning off coverage for the chip-enable in ram1p1rwe, however, might adversely exclude coverage for the D$ cachetagmem, since it might be possible that a write could when the chip-enable is pulled low for D$. I would appreciate suggestions for another way to deal with the chip-enable coverage for i$ memories if this is unacceptable.

Thanks!