### PR TITLE
Starting to extend fpu conditional coverage, reformatting ifu test cases.

### DIFF
--- a/tests/coverage/fpu.S
+++ b/tests/coverage/fpu.S
@@ -67,12 +67,18 @@ main:
     # fcvt.w.q a0, ft0
     # fcvt.q.d ft3, ft0
 
+    # Completing branch coverage in fctrl.sv
     .word 0x38007553    // Testing the all False case for 119 - funct7 under, op = 101 0011
     .word 0x40000053    // Line 145 All False Test case - illegal instruction?
     .word 0xd0400053    // Line 156 All False Test case - illegal instruction?
     .word 0xc0400053    // Line 162 All False Test case - illegal instruction?
     .word 0xd2400053    // Line 168 All False Test case - illegal instruction?
     .word 0xc2400053    // Line 174 All False Test case - illegal instruction?
+
+    # Increasing conditional coverage in fctrl.sv
+    .word 0xc5000007    // Attempting to toggle (Op7 != 7) to 0 on line 97 in fctrl, not sure what instruction this works out to
+    .word 0xe0101053    // toggling (Rs2D == 0) to 0 on line 139 in fctrl. Illegal Intsr (like fclass but incorrect rs2)
+    .word 0xe0100053    // toggling (Rs2D == 0) to 0 on line 141 in fctrl. Illegal Intsr (like fmv but incorrect rs2)
 
     # Test illegal instructions are detected
     .word 0x00000007 // illegal floating-point load (bad Funct3)

--- a/tests/coverage/ifu.S
+++ b/tests/coverage/ifu.S
@@ -35,20 +35,12 @@ main:
     //.hword 0x2000 // CL type compressed floating-point ld-->funct3,imm,rs1',imm,rd',op
                         // binary version 0000 0000 0000 0000 0010 0000 0000 0000
     mv s0, sp
-    c.fld fs0, 0(s0)
+    c.fld fs0, 0(s0)    // Previously uncovered instructions
+    c.fsd fs0, 0(s0)    
+    .hword 0x2002      // c.fldsp fs0, 0
+    .hword 0xA002      // c.fsdsp fs0, 0
+    .hword 0x9C41      // line 134 Illegal compressed instruction
 
-    c.fsd fs0, 0(s0)
-
-    // c.fldsp fs0, 0
-    .hword 0x2002
-
-    // c.fsdsp fs0, 0
-    .hword 0xA002
-
-    //# Illegal compressed instruction with op = 01, instr[15:10] = 100111, and 0's everywhere else
-    //.hword 0x9C01
-
-    # Line Illegal compressed instruction 
-    .hword 0x9C41
+    //.hword 0x9C01     //# Illegal compressed instruction with op = 01, instr[15:10] = 100111, and 0's everywhere else
 
     j done


### PR DESCRIPTION
3 directed tests were added to fpu.S for illegal instruction that toggle variables to increase conditional coverage. I reformatted the tests I added previously in ifu.S to make to file cleaner and easier to read.