### PR TITLE
Fixes the issue introduced by the fix for issue 203

### DIFF
--- a/src/mmu/hptw.sv
+++ b/src/mmu/hptw.sv
@@ -288,7 +288,7 @@ module hptw (
       default:                                                        NextWalkerState = IDLE; // should never be reached
     endcase // case (WalkerState)
 
-  assign IgnoreRequestTLB = WalkerState == IDLE & TLBMiss;
+  assign IgnoreRequestTLB = (WalkerState == IDLE & TLBMiss) | (LSUAccessFaultM); // RT : 05 April 2023 if hptw request has pmp/a fault suppress bus access.
   assign SelHPTW = WalkerState != IDLE;
   assign HPTWAccessFaultDelay = HPTWLoadAccessFaultDelay | HPTWStoreAmoAccessFaultDelay | HPTWInstrAccessFaultDelay;
   assign HPTWStall = (WalkerState != IDLE) | (WalkerState == IDLE & TLBMiss & ~(HPTWAccessFaultDelay));


### PR DESCRIPTION
- Progress on bug 203.
- Fixed wally64/32priv test hangup. The fix for the issue 203 had a lingering bug which did not suppress a bus access if the hptw short circuits on a pma/p fault.
