### PR TITLE
Deleted the ~BadNaNBox section in the subnormal FP equation

### DIFF
--- a/src/fpu/unpackinput.sv
+++ b/src/fpu/unpackinput.sv
@@ -305,6 +305,6 @@ module unpackinput (
   assign SNaN = NaN&~Frac[`NF-1]&~BadNaNBox; // is the input a singnaling NaN?
   assign Inf = ExpMax & FracZero &En & ~BadNaNBox; // is the input infinity?
   assign Zero = ~ExpNonZero & FracZero & ~BadNaNBox; // is the input zero?
-  assign Subnorm = ~ExpNonZero & ~FracZero & ~BadNaNBox; // is the input subnormal
+  assign Subnorm = ~ExpNonZero & ~FracZero; // is the input subnormal
 
 endmodule


### PR DESCRIPTION
After removing this section of the equation, the 4 subnormal test case errors were resolved making the fclassify section of the FPU fully covered!