### PR TITLE
Excluded coverage for misaligned instructions

### DIFF
--- a/src/privileged/csrc.sv
+++ b/src/privileged/csrc.sv
@@ -117,7 +117,10 @@ module csrc #(parameter
     assign CounterEvent[21] = sfencevmaM & InstrValidNotFlushedM;                       // sfence.vma
     assign CounterEvent[22] = InterruptM;                                               // interrupt, InstrValidNotFlushedM will be low
     assign CounterEvent[23] = ExceptionM;                                               // exceptions, InstrValidNotFlushedM will be low
+    // coverage off
+    // DivBusyE will never be assert high since this configuration uses the FPU to do integer division
     assign CounterEvent[24] = DivBusyE | FDivBusyE;                                     // division cycles *** RT: might need to be delay until the next cycle
+    // coverage on
     assign CounterEvent[`COUNTERS-1:25] = 0; // eventually give these sources, including FP instructions, I$/D$ misses, branches and mispredictions
   end
   

--- a/src/privileged/trap.sv
+++ b/src/privileged/trap.sv
@@ -105,7 +105,10 @@ module trap (
     else if (InstrPageFaultM)          CauseM = 12;
     else if (BothInstrAccessFaultM)    CauseM = 1;
     else if (IllegalInstrFaultM)       CauseM = 2;
+    // coverage off
+    // Misaligned instructions cannot occur in rv64gc
     else if (InstrMisalignedFaultM)    CauseM = 0;
+    // coverage on
     else if (BreakpointFaultM)         CauseM = 3;
     else if (EcallFaultM)              CauseM = {2'b10, PrivilegeModeW};
     else if (LoadMisalignedFaultM)     CauseM = 4;


### PR DESCRIPTION
Excluded coverage for misaligned instructions, which cannot occur in rv64gc.