### PR TITLE
Full I$ coverage 

### DIFF
--- a/sim/GetLineNum.do
+++ b/sim/GetLineNum.do
@@ -1,0 +1,18 @@
+# Alec Vercruysse
+# 2023-04-12
+# Note that the target string is regex, and needs to be double-escaped.
+# e.g. to match a (, you need \\(.
+proc GetLineNum {fname target} {
+    set f [open $fname]
+    set linectr 1
+    while {[gets $f line] != -1} {
+         if {[regexp $target $line]} {
+             close $f
+             return $linectr
+         }
+         incr linectr
+     }
+    close $f
+    return -code error \
+         "target string not found"
+}

--- a/sim/coverage-exclusions-rv64gc.do
+++ b/sim/coverage-exclusions-rv64gc.do
@@ -62,6 +62,17 @@ coverage exclude -scope /dut/core/ifu/bus/icache/icache/cachefsm -linerange $sta
 coverage exclude -scope /dut/core/ifu/bus/icache/icache/cachefsm -linerange [GetLineNum ../src/cache/cachefsm.sv "exclusion-tag: icache CacheBusW"]
 coverage exclude -scope /dut/core/ifu/bus/icache/icache/cachefsm -linerange [GetLineNum ../src/cache/cachefsm.sv "exclusion-tag: icache SelAdrCauses"] -item e 1 -fecexprrow 4 10
 coverage exclude -scope /dut/core/ifu/bus/icache/icache/cachefsm -linerange [GetLineNum ../src/cache/cachefsm.sv "exclusion-tag: icache CacheBusRCauses"] -item e 1 -fecexprrow 1-2 12
+# cache.sv AdrSelMux and CacheBusAdrMux, excluding unhit Flush branch
+coverage exclude -scope /dut/core/ifu/bus/icache/icache/AdrSelMux -linerange [GetLineNum ../src/generic/mux.sv "exclusion-tag: mux3"] -item b 1
+coverage exclude -scope /dut/core/ifu/bus/icache/icache/CacheBusAdrMux -linerange [GetLineNum ../src/generic/mux.sv "exclusion-tag: mux3"] -item b 1 3
+# CacheWay Dirty logic. -scope does not accept wildcards.
+set numcacheways 4
+for {set i 0} {$i < $numcacheways} {incr i} {
+    coverage exclude -scope /dut/core/ifu/bus/icache/icache/CacheWays[$i] -linerange [GetLineNum ../src/cache/cacheway.sv "exclusion-tag: icache SetDirtyWay"] -item e 1
+    coverage exclude -scope /dut/core/ifu/bus/icache/icache/CacheWays[$i] -linerange [GetLineNum ../src/cache/cacheway.sv "exclusion-tag: icache SelectedWiteWordEn"] -item e 1 -fecexprrow 4 6
+    # below: flushD can't go high during an icache write b/c of pipeline stall
+    coverage exclude -scope /dut/core/ifu/bus/icache/icache/CacheWays[$i] -linerange [GetLineNum ../src/cache/cacheway.sv "exclusion-tag: icache SetValidEN"] -item e 1 -fecexprrow 4
+}
 
 ######################
 # Toggle exclusions

--- a/sim/coverage-exclusions-rv64gc.do
+++ b/sim/coverage-exclusions-rv64gc.do
@@ -32,6 +32,12 @@
 # This is ugly to exlcude the whole file - is there a better option?  // coverage off isn't working
 coverage exclude -srcfile lzc.sv 
 
+# Exclude D$ states from coverage in the I$ instance of cachefsm.
+# This is cleaner than trying to set an I$-specific pragma in cachefsm.sv
+# Also exclude the write line to ready transition for the I$ since we can't get a flush
+# during this operation.
+coverage exclude -scope /dut/core/ifu/bus/icache/icache/cachefsm -fstate CurrState STATE_FLUSH STATE_FLUSH_WRITEBACK STATE_FLUSH_WRITEBACK
+coverage exclude -scope /dut/core/ifu/bus/icache/icache/cachefsm -ftrans CurrState STATE_WRITE_LINE->STATE_READY
 
 ######################
 # Toggle exclusions

--- a/sim/coverage-exclusions-rv64gc.do
+++ b/sim/coverage-exclusions-rv64gc.do
@@ -27,17 +27,41 @@
 # This file should be a last resort.  It's preferable to put 
 # // coverage off 
 # statements inline with the code whenever possible.
+# a hack to describe coverage exclusions without hardcoding linenumbers:
+do GetLineNum.do
 
 # LZA (i<64) statement confuses coverage tool 
 # This is ugly to exlcude the whole file - is there a better option?  // coverage off isn't working
 coverage exclude -srcfile lzc.sv 
 
-# Exclude D$ states from coverage in the I$ instance of cachefsm.
-# This is cleaner than trying to set an I$-specific pragma in cachefsm.sv
-# Also exclude the write line to ready transition for the I$ since we can't get a flush
-# during this operation.
-coverage exclude -scope /dut/core/ifu/bus/icache/icache/cachefsm -fstate CurrState STATE_FLUSH STATE_FLUSH_WRITEBACK STATE_FLUSH_WRITEBACK
+### Exclude D$ states and logic for the I$ instance
+# This is cleaner than trying to set an I$-specific pragma in cachefsm.sv (which would exclude it for the D$ instance too)
+# Also exclude the write line to ready transition for the I$ since we can't get a flush during this operation.
+coverage exclude -scope /dut/core/ifu/bus/icache/icache/cachefsm -fstate CurrState STATE_FLUSH STATE_FLUSH_WRITEBACK STATE_FLUSH_WRITEBACK STATE_WRITEBACK
 coverage exclude -scope /dut/core/ifu/bus/icache/icache/cachefsm -ftrans CurrState STATE_WRITE_LINE->STATE_READY
+# exclude unused transitions from case statement. Unfortunately the whole branch needs to be excluded I think. Expression coverage should still work.
+coverage exclude -scope /dut/core/ifu/bus/icache/icache/cachefsm -linerange [GetLineNum ../src/cache/cachefsm.sv "exclusion-tag: icache state-case"] -item b 1
+# exclude branch/condition coverage: LineDirty if statement
+coverage exclude -scope /dut/core/ifu/bus/icache/icache/cachefsm -linerange [GetLineNum ../src/cache/cachefsm.sv "exclusion-tag: icache FETCHStatement"] -item bc 1
+# exclude the unreachable logic
+set start [GetLineNum ../src/cache/cachefsm.sv "exclusion-tag-start: icache case"]
+set end [GetLineNum ../src/cache/cachefsm.sv "exclusion-tag-end: icache case"]
+coverage exclude -scope /dut/core/ifu/bus/icache/icache/cachefsm -linerange $start-$end
+coverage exclude -scope /dut/core/ifu/bus/icache/icache/cachefsm -linerange [GetLineNum ../src/cache/cachefsm.sv "exclusion-tag: icache WRITEBACKStatement"]
+# exclude Atomic Operation logic
+coverage exclude -scope /dut/core/ifu/bus/icache/icache/cachefsm -linerange [GetLineNum ../src/cache/cachefsm.sv "exclusion-tag: icache storeAMO"] -item e 1 -fecexprrow 6
+coverage exclude -scope /dut/core/ifu/bus/icache/icache/cachefsm -linerange [GetLineNum ../src/cache/cachefsm.sv "exclusion-tag: icache storeAMO1"] -item e 1 -fecexprrow 2-4
+coverage exclude -scope /dut/core/ifu/bus/icache/icache/cachefsm -linerange [GetLineNum ../src/cache/cachefsm.sv "exclusion-tag: icache AnyUpdateHit"] -item e 1 -fecexprrow 2
+# cache write logic
+coverage exclude -scope /dut/core/ifu/bus/icache/icache/cachefsm -linerange [GetLineNum ../src/cache/cachefsm.sv "exclusion-tag: icache CacheW"] -item e 1 -fecexprrow 4
+# output signal logic
+coverage exclude -scope /dut/core/ifu/bus/icache/icache/cachefsm -linerange [GetLineNum ../src/cache/cachefsm.sv "exclusion-tag: icache StallStates"] -item e 1 -fecexprrow 8 12 14
+set start [GetLineNum ../src/cache/cachefsm.sv "exclusion-tag-start: icache flushdirtycontrols"]
+set end [GetLineNum ../src/cache/cachefsm.sv "exclusion-tag-end: icache flushdirtycontrols"]
+coverage exclude -scope /dut/core/ifu/bus/icache/icache/cachefsm -linerange $start-$end
+coverage exclude -scope /dut/core/ifu/bus/icache/icache/cachefsm -linerange [GetLineNum ../src/cache/cachefsm.sv "exclusion-tag: icache CacheBusW"]
+coverage exclude -scope /dut/core/ifu/bus/icache/icache/cachefsm -linerange [GetLineNum ../src/cache/cachefsm.sv "exclusion-tag: icache SelAdrCauses"] -item e 1 -fecexprrow 4 10
+coverage exclude -scope /dut/core/ifu/bus/icache/icache/cachefsm -linerange [GetLineNum ../src/cache/cachefsm.sv "exclusion-tag: icache CacheBusRCauses"] -item e 1 -fecexprrow 1-2 12
 
 ######################
 # Toggle exclusions

--- a/src/cache/cache.sv
+++ b/src/cache/cache.sv
@@ -129,7 +129,7 @@ module cache #(parameter LINELEN,  NUMLINES,  NUMWAYS, LOGBWPL, WORDLEN, MUXINTE
   // Select victim way for associative caches
   if(NUMWAYS > 1) begin:vict
     cacheLRU #(NUMWAYS, SETLEN, OFFSETLEN, NUMLINES) cacheLRU(
-      .clk, .reset, .CacheEn, .FlushStage, .HitWay, .ValidWay, .VictimWay, .CacheSet, .LRUWriteEn,
+      .clk, .reset, .CacheEn, .HitWay, .ValidWay, .VictimWay, .CacheSet, .LRUWriteEn,
       .SetValid, .PAdr(PAdr[SETTOP-1:OFFSETLEN]), .InvalidateCache, .FlushCache);
   end else 
     assign VictimWay = 1'b1; // one hot.

--- a/src/cache/cache.sv
+++ b/src/cache/cache.sv
@@ -122,7 +122,7 @@ module cache #(parameter LINELEN,  NUMLINES,  NUMWAYS, LOGBWPL, WORDLEN, MUXINTE
   // Select victim way for associative caches
   if(NUMWAYS > 1) begin:vict
     cacheLRU #(NUMWAYS, SETLEN, OFFSETLEN, NUMLINES) cacheLRU(
-      .clk, .reset, .CacheEn, .FlushStage, .HitWay, .ValidWay, .VictimWay, .CacheSet, .LRUWriteEn(LRUWriteEn & ~FlushStage),
+      .clk, .reset, .CacheEn, .HitWay, .ValidWay, .VictimWay, .CacheSet, .LRUWriteEn(LRUWriteEn & ~FlushStage),
       .SetValid, .PAdr(PAdr[SETTOP-1:OFFSETLEN]), .InvalidateCache, .FlushCache);
   end else 
     assign VictimWay = 1'b1; // one hot.

--- a/src/cache/cache.sv
+++ b/src/cache/cache.sv
@@ -73,6 +73,7 @@ module cache #(parameter LINELEN,  NUMLINES,  NUMWAYS, LOGBWPL, WORDLEN, MUXINTE
 
 
   logic                          SelAdr;
+  logic [1:0]                    AdrSelMuxSel;
   logic [SETLEN-1:0]             CacheSet;
   logic [LINELEN-1:0]            LineWriteData;
   logic                          ClearDirty, SetDirty, SetValid;
@@ -108,18 +109,10 @@ module cache #(parameter LINELEN,  NUMLINES,  NUMWAYS, LOGBWPL, WORDLEN, MUXINTE
   // and FlushAdr when handling D$ flushes
   // The icache must update to the newest PCNextF on flush as it is probably a trap.  Trap
   // sets PCNextF to XTVEC and the icache must start reading the instruction.
-  if (!READ_ONLY_CACHE) begin
-    logic [1:0]                    AdrSelMuxSel;
-    assign AdrSelMuxSel = {SelFlush, SelAdr | SelHPTW};
-    mux3 #(SETLEN) AdrSelMux(NextSet[SETTOP-1:OFFSETLEN], PAdr[SETTOP-1:OFFSETLEN], FlushAdr,
+  assign AdrSelMuxSel = {SelFlush, ((SelAdr | SelHPTW) & ~((READ_ONLY_CACHE == 1) & FlushStage))};
+  mux3 #(SETLEN) AdrSelMux(NextSet[SETTOP-1:OFFSETLEN], PAdr[SETTOP-1:OFFSETLEN], FlushAdr,
     AdrSelMuxSel, CacheSet);
-  end
-  else begin
-     logic                         AdrSelMuxSel;
-     assign AdrSelMuxSel = ((SelAdr | SelHPTW) & ~FlushStage);
-     mux2 #(SETLEN) AdrSelMux(NextSet[SETTOP-1:OFFSETLEN], PAdr[SETTOP-1:OFFSETLEN],
-    AdrSelMuxSel, CacheSet);
-  end
+
   // Array of cache ways, along with victim, hit, dirty, and read merging logic
   cacheway #(NUMLINES, LINELEN, TAGLEN, OFFSETLEN, SETLEN, READ_ONLY_CACHE) CacheWays[NUMWAYS-1:0](
     .clk, .reset, .CacheEn, .CacheSet, .PAdr, .LineWriteData, .LineByteMask,
@@ -159,14 +152,11 @@ module cache #(parameter LINELEN,  NUMLINES,  NUMWAYS, LOGBWPL, WORDLEN, MUXINTE
     .PAdr(WordOffsetAddr), .ReadDataLine, .ReadDataWord);
   
   // Bus address for fetch, writeback, or flush writeback
-  if (!READ_ONLY_CACHE)
-    mux3 #(`PA_BITS) CacheBusAdrMux(.d0({PAdr[`PA_BITS-1:OFFSETLEN], {OFFSETLEN{1'b0}}}),
-      .d1({Tag, PAdr[SETTOP-1:OFFSETLEN], {OFFSETLEN{1'b0}}}),
-      .d2({Tag, FlushAdr, {OFFSETLEN{1'b0}}}),
-      .s({SelFlush, SelWriteback}), .y(CacheBusAdr));
-  else
-    assign CacheBusAdr = {PAdr[`PA_BITS-1:OFFSETLEN], {OFFSETLEN{1'b0}}};
-
+  mux3 #(`PA_BITS) CacheBusAdrMux(.d0({PAdr[`PA_BITS-1:OFFSETLEN], {OFFSETLEN{1'b0}}}),
+    .d1({Tag, PAdr[SETTOP-1:OFFSETLEN], {OFFSETLEN{1'b0}}}),
+    .d2({Tag, FlushAdr, {OFFSETLEN{1'b0}}}),
+    .s({SelFlush, SelWriteback}), .y(CacheBusAdr));
+  
   /////////////////////////////////////////////////////////////////////////////////////////////
   // Write Path
   /////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/cache/cacheLRU.sv
+++ b/src/cache/cacheLRU.sv
@@ -32,8 +32,7 @@
 module cacheLRU
   #(parameter NUMWAYS = 4, SETLEN = 9, OFFSETLEN = 5, NUMLINES = 128) (
   input  logic                clk, 
-  input  logic                reset, 
-  input  logic                FlushStage,      // Pipeline flush of second stage (prevent writes and bus operations)
+  input  logic                reset,
   input  logic                CacheEn,         // Enable the cache memory arrays.  Disable hold read data constant
   input  logic [NUMWAYS-1:0]  HitWay,          // Which way is valid and matches PAdr's tag
   input  logic [NUMWAYS-1:0]  ValidWay,        // Which ways for a particular set are valid, ignores tag
@@ -134,11 +133,9 @@ module cacheLRU
   always_ff @(posedge clk) begin
     if (reset) for (int set = 0; set < NUMLINES; set++) LRUMemory[set] <= '0;
     if(CacheEn) begin
-      // if((InvalidateCache | FlushCache) & ~FlushStage) for (int set = 0; set < NUMLINES; set++) LRUMemory[set] <= '0;
-      if (LRUWriteEn & ~FlushStage) begin 
+      if(LRUWriteEn)
         LRUMemory[PAdr] <= NextLRU;
-      end
-      if(LRUWriteEn & ~FlushStage & (PAdr == CacheSet))
+      if(LRUWriteEn & (PAdr == CacheSet))
         CurrLRU <= #1 NextLRU;
       else 
         CurrLRU <= #1 LRUMemory[CacheSet];

--- a/src/cache/cachefsm.sv
+++ b/src/cache/cachefsm.sv
@@ -224,8 +224,9 @@ module cachefsm #(parameter READ_ONLY_CACHE = 0) (
 
   // write enables internal to cache
   assign SetValid = CurrState == STATE_WRITE_LINE;
+  // coverage off -item e 1 -fecexprrow 8
   assign LRUWriteEn = (CurrState == STATE_READY & AnyHit) |
-                      (CurrState == STATE_WRITE_LINE);
+                      (CurrState == STATE_WRITE_LINE) & ~FlushStage;
   assign SelFetchBuffer = CurrState == STATE_WRITE_LINE | CurrState == STATE_READ_HOLD;
                        
 endmodule // cachefsm

--- a/src/cache/cachefsm.sv
+++ b/src/cache/cachefsm.sv
@@ -86,17 +86,24 @@ module cachefsm #(parameter READ_ONLY_CACHE = 0) (
 
   statetype CurrState, NextState;
 
-  assign AMO = CacheAtomic[1] & (&CacheRW);
-  assign StoreAMO = AMO | CacheRW[0];
+  // no atomic operations on i$
+  if (!READ_ONLY_CACHE) begin
+    assign AMO = CacheAtomic[1] & (&CacheRW);
+    assign StoreAMO = AMO | CacheRW[0];
+    assign AnyMiss = (StoreAMO | CacheRW[1]) & ~CacheHit & ~InvalidateCache;
+    assign AnyUpdateHit = StoreAMO & CacheHit;
+    assign AnyHit = AnyUpdateHit | (CacheRW[1] & CacheHit);  
+    assign CacheAccess = (AMO | CacheRW[1] | CacheRW[0]) & CurrState == STATE_READY; // for performance counter
+  end
+  else begin
+    assign AnyMiss = CacheRW[1] & ~CacheHit & ~InvalidateCache;
+    assign AnyUpdateHit = 0; // todo clear all RO cache of usage of this logic
+    assign AnyHit = CacheRW[1] & CacheHit;  
+    assign CacheAccess = CacheRW[1] & CurrState == STATE_READY; // for performance counter
+  end 
 
-  assign AnyMiss = (StoreAMO | CacheRW[1]) & ~CacheHit & ~InvalidateCache;
-  assign AnyUpdateHit = (StoreAMO) & CacheHit;
-  assign AnyHit = AnyUpdateHit | (CacheRW[1] & CacheHit);  
+  assign CacheMiss = CacheAccess & ~CacheHit; // for performance counter
   assign FlushFlag = FlushAdrFlag & FlushWayFlag;
-
-  // outputs for the performance counters.
-  assign CacheAccess = (AMO | CacheRW[1] | CacheRW[0]) & CurrState == STATE_READY;
-  assign CacheMiss = CacheAccess & ~CacheHit;
 
   // special case on reset. When the fsm first exists reset the
   // PCNextF will no longer be pointing to the correct address.
@@ -106,77 +113,119 @@ module cachefsm #(parameter READ_ONLY_CACHE = 0) (
   always_ff @(posedge clk)
     if (reset | FlushStage)    CurrState <= #1 STATE_READY;
     else CurrState <= #1 NextState;  
-  
-  always_comb begin
-    NextState = STATE_READY;
-    case (CurrState)
-      STATE_READY:           if(InvalidateCache)                               NextState = STATE_READY;
-                             else if(FlushCache & ~READ_ONLY_CACHE)            NextState = STATE_FLUSH;
-                             else if(AnyMiss & (READ_ONLY_CACHE | ~LineDirty)) NextState = STATE_FETCH;
-                             else if(AnyMiss & LineDirty)                      NextState = STATE_WRITEBACK;
-                             else                                              NextState = STATE_READY;
-      STATE_FETCH:           if(CacheBusAck)                                   NextState = STATE_WRITE_LINE;
-                             else                                              NextState = STATE_FETCH;
-      STATE_WRITE_LINE:                                                        NextState = STATE_READ_HOLD;
-      STATE_READ_HOLD:       if(Stall)                                         NextState = STATE_READ_HOLD;
-                             else                                              NextState = STATE_READY;
-      STATE_WRITEBACK:       if(CacheBusAck)                                   NextState = STATE_FETCH;
-                             else                                              NextState = STATE_WRITEBACK;
-      // eviction needs a delay as the bus fsm does not correctly handle sending the write command at the same time as getting back the bus ack.
-      STATE_FLUSH:           if(LineDirty)                                     NextState = STATE_FLUSH_WRITEBACK;
-                             else if (FlushFlag)                               NextState = STATE_READ_HOLD;
-                             else                                              NextState = STATE_FLUSH;
-      STATE_FLUSH_WRITEBACK: if(CacheBusAck & ~FlushFlag)                      NextState = STATE_FLUSH;
-                             else if(CacheBusAck)                              NextState = STATE_READ_HOLD;
-                             else                                              NextState = STATE_FLUSH_WRITEBACK;
-      default:                                                                 NextState = STATE_READY;
-    endcase
-  end
+
+  // seperating NextState logic by ro vs rw cache results in code duplication but this is needed to hit coverage.
+  if (!READ_ONLY_CACHE)
+    always_comb begin
+       NextState = STATE_READY;
+       case (CurrState)
+         STATE_READY:           if(InvalidateCache)                               NextState = STATE_READY;
+                                else if(FlushCache)                               NextState = STATE_FLUSH;
+                                else if(AnyMiss & ~LineDirty)                     NextState = STATE_FETCH;
+                                else if(AnyMiss & LineDirty)                      NextState = STATE_WRITEBACK;
+                                else                                              NextState = STATE_READY;
+         STATE_FETCH:           if(CacheBusAck)                                   NextState = STATE_WRITE_LINE;
+                                else                                              NextState = STATE_FETCH;
+         STATE_WRITE_LINE:                                                        NextState = STATE_READ_HOLD;
+         STATE_READ_HOLD:       if(Stall)                                         NextState = STATE_READ_HOLD;
+                                else                                              NextState = STATE_READY;
+         STATE_WRITEBACK:       if(CacheBusAck)                                   NextState = STATE_FETCH;
+                                else                                              NextState = STATE_WRITEBACK;
+         // eviction needs a delay as the bus fsm does not correctly handle sending the write command at the same 
+         // time as getting back the bus ack.
+         STATE_FLUSH:           if(LineDirty)                                     NextState = STATE_FLUSH_WRITEBACK;
+                                else if (FlushFlag)                               NextState = STATE_READ_HOLD;
+                                else                                              NextState = STATE_FLUSH;
+         STATE_FLUSH_WRITEBACK: if(CacheBusAck & ~FlushFlag)                      NextState = STATE_FLUSH;
+                                else if(CacheBusAck)                              NextState = STATE_READ_HOLD;
+                                else                                              NextState = STATE_FLUSH_WRITEBACK;
+         default:                                                                 NextState = STATE_READY;
+       endcase
+    end // always_comb
+  else // READ_ONLY_CACHE
+    always_comb begin  
+       NextState = STATE_READY;
+       case (CurrState)
+         STATE_READY:           if(InvalidateCache)                               NextState = STATE_READY;
+                                else if(AnyMiss)                                  NextState = STATE_FETCH;
+                                else                                              NextState = STATE_READY;
+         STATE_FETCH:           if(CacheBusAck)                                   NextState = STATE_WRITE_LINE;
+                                else                                              NextState = STATE_FETCH;
+         STATE_WRITE_LINE:                                                        NextState = STATE_READ_HOLD;
+         STATE_READ_HOLD:       if(Stall)                                         NextState = STATE_READ_HOLD;
+                                else                                              NextState = STATE_READY;
+         default:                                                                 NextState = STATE_READY;
+       endcase // case (CurrState)
+    end // always_comb
 
   // com back to CPU
-  assign CacheCommitted = (CurrState != STATE_READY) & ~(READ_ONLY_CACHE & CurrState == STATE_READ_HOLD);
-  assign CacheStall = (CurrState == STATE_READY & (FlushCache | AnyMiss)) | 
-                      (CurrState == STATE_FETCH) |
-                      (CurrState == STATE_WRITEBACK) |
-                      (CurrState == STATE_WRITE_LINE) |  // this cycle writes the sram, must keep stalling so the next cycle can read the next hit/miss unless its a write.
-                      (CurrState == STATE_FLUSH) |
+  if (!READ_ONLY_CACHE) begin
+    assign CacheStall = (CurrState == STATE_READY & (FlushCache | AnyMiss)) | 
+                        (CurrState == STATE_FETCH) |
+                        (CurrState == STATE_WRITEBACK) |
+                        (CurrState == STATE_WRITE_LINE) |  // this cycle writes the sram, must keep stalling so the next cycle can read the next hit/miss unless its a write.
+                        (CurrState == STATE_FLUSH) |
+                        (CurrState == STATE_FLUSH_WRITEBACK);
+    assign CacheCommitted = CurrState != STATE_READY;
+    assign SelAdr = (CurrState == STATE_READY & (StoreAMO | AnyMiss)) | // changes if store delay hazard removed
+                    (CurrState == STATE_FETCH) |
+                    (CurrState == STATE_WRITEBACK) |
+                    (CurrState == STATE_WRITE_LINE) |
+                    resetDelay;
+    assign SetDirty = (CurrState == STATE_READY & AnyUpdateHit) |
+                      (CurrState == STATE_WRITE_LINE & (StoreAMO));
+    assign ClearDirty = (CurrState == STATE_WRITE_LINE & ~(StoreAMO)) |
+                        (CurrState == STATE_FLUSH & LineDirty); // This is wrong in a multicore snoop cache protocal.  Dirty must be cleared concurrently and atomically with writeback.  For single core cannot clear after writeback on bus ack and change flushadr.  Clears the wrong set.
+
+    // Flush and eviction controls
+    assign SelWriteback = (CurrState == STATE_WRITEBACK & ~CacheBusAck) |
+                          (CurrState == STATE_READY & AnyMiss & LineDirty);
+    
+    assign SelFlush = (CurrState == STATE_READY & FlushCache) |
+                      (CurrState == STATE_FLUSH) | 
                       (CurrState == STATE_FLUSH_WRITEBACK);
+    assign FlushAdrCntEn = (CurrState == STATE_FLUSH_WRITEBACK & FlushWayFlag & CacheBusAck) |
+                           (CurrState == STATE_FLUSH & FlushWayFlag & ~LineDirty);
+    assign FlushWayCntEn = (CurrState == STATE_FLUSH & ~LineDirty) |
+                           (CurrState == STATE_FLUSH_WRITEBACK & CacheBusAck);
+    assign FlushCntRst = (CurrState == STATE_FLUSH & FlushFlag & ~LineDirty) |
+                         (CurrState == STATE_FLUSH_WRITEBACK & FlushFlag & CacheBusAck);
+    // Bus interface controls
+    assign CacheBusRW[1] = (CurrState == STATE_READY & AnyMiss & ~LineDirty) | 
+                           (CurrState == STATE_FETCH & ~CacheBusAck) | 
+                           (CurrState == STATE_WRITEBACK & CacheBusAck);
+    assign CacheBusRW[0] = (CurrState == STATE_READY & AnyMiss & LineDirty) |
+                           (CurrState == STATE_WRITEBACK & ~CacheBusAck) |
+                           (CurrState == STATE_FLUSH_WRITEBACK & ~CacheBusAck);
+    // write enable internal to cache
+    assign CacheEn = (~Stall | FlushCache | AnyMiss) | (CurrState != STATE_READY) | reset | InvalidateCache;
+  end
+  else begin
+    assign CacheStall = (CurrState == STATE_READY & (FlushCache | AnyMiss)) | 
+                        (CurrState == STATE_FETCH) |
+                        (CurrState == STATE_WRITE_LINE); // this cycle writes the sram, must keep stalling so the next cycle can read the next hit/miss unless its a write.
+    assign CacheCommitted = (CurrState != STATE_READY) & ~(CurrState == STATE_READ_HOLD);
+    assign SelAdr = (CurrState == STATE_READY & AnyMiss) | // changes if store delay hazard removed
+                    (CurrState == STATE_FETCH) |
+                    (CurrState == STATE_WRITE_LINE) |
+                    resetDelay;
+    assign SetDirty = 0;
+    assign ClearDirty = 0;
+    assign SelWriteback  = 0;
+    assign SelFlush      = 0;
+    assign FlushAdrCntEn = 0;
+    assign FlushWayCntEn = 0;
+    assign FlushCntRst   = 0;
+    assign CacheBusRW[1] = (CurrState == STATE_READY & AnyMiss) | 
+                           (CurrState == STATE_FETCH & ~CacheBusAck);
+    assign CacheBusRW[0] = 0;
+    assign CacheEn = (~Stall | AnyMiss) | (CurrState != STATE_READY) | reset | InvalidateCache;
+  end // else: (READ_ONLY_CACHE)
+
   // write enables internal to cache
   assign SetValid = CurrState == STATE_WRITE_LINE;
-  assign SetDirty = (CurrState == STATE_READY & AnyUpdateHit) |
-                    (CurrState == STATE_WRITE_LINE & (StoreAMO));
-  assign ClearDirty = (CurrState == STATE_WRITE_LINE & ~(StoreAMO)) |
-                      (CurrState == STATE_FLUSH & LineDirty); // This is wrong in a multicore snoop cache protocal.  Dirty must be cleared concurrently and atomically with writeback.  For single core cannot clear after writeback on bus ack and change flushadr.  Clears the wrong set.
   assign LRUWriteEn = (CurrState == STATE_READY & AnyHit) |
                       (CurrState == STATE_WRITE_LINE);
-  // Flush and eviction controls
-  assign SelWriteback = (CurrState == STATE_WRITEBACK & ~CacheBusAck) |
-                    (CurrState == STATE_READY & AnyMiss & LineDirty);
-
-  assign SelFlush = (CurrState == STATE_READY & FlushCache) |
-          (CurrState == STATE_FLUSH) | 
-          (CurrState == STATE_FLUSH_WRITEBACK);
-  assign FlushAdrCntEn = (CurrState == STATE_FLUSH_WRITEBACK & FlushWayFlag & CacheBusAck) |
-             (CurrState == STATE_FLUSH & FlushWayFlag & ~LineDirty);
-  assign FlushWayCntEn = (CurrState == STATE_FLUSH & ~LineDirty) |
-             (CurrState == STATE_FLUSH_WRITEBACK & CacheBusAck);
-  assign FlushCntRst = (CurrState == STATE_FLUSH & FlushFlag & ~LineDirty) |
-              (CurrState == STATE_FLUSH_WRITEBACK & FlushFlag & CacheBusAck);
-  // Bus interface controls
-  assign CacheBusRW[1] = (CurrState == STATE_READY & AnyMiss & ~LineDirty) | 
-                         (CurrState == STATE_FETCH & ~CacheBusAck) | 
-                         (CurrState == STATE_WRITEBACK & CacheBusAck);
-  assign CacheBusRW[0] = (CurrState == STATE_READY & AnyMiss & LineDirty) |
-                          (CurrState == STATE_WRITEBACK & ~CacheBusAck) |
-                     (CurrState == STATE_FLUSH_WRITEBACK & ~CacheBusAck);
-
-  assign SelAdr = (CurrState == STATE_READY & (StoreAMO | AnyMiss)) | // changes if store delay hazard removed
-                  (CurrState == STATE_FETCH) |
-                  (CurrState == STATE_WRITEBACK) |
-                  (CurrState == STATE_WRITE_LINE) |
-                  resetDelay;
-
   assign SelFetchBuffer = CurrState == STATE_WRITE_LINE | CurrState == STATE_READ_HOLD;
-  assign CacheEn = (~Stall | FlushCache | AnyMiss) | (CurrState != STATE_READY) | reset | InvalidateCache;
                        
 endmodule // cachefsm

--- a/src/cache/cacheway.sv
+++ b/src/cache/cacheway.sv
@@ -97,9 +97,9 @@ module cacheway #(parameter NUMLINES=512, LINELEN = 256, TAGLEN = 26,
   /////////////////////////////////////////////////////////////////////////////////////////////
 
   assign SetValidWay = SetValid & SelData;
-  assign ClearDirtyWay = ClearDirty & SelData;
   if (!READ_ONLY_CACHE) begin
     assign SetDirtyWay = SetDirty & SelData;
+    assign ClearDirtyWay = ClearDirty & SelData;
     assign SelectedWriteWordEn = (SetValidWay | SetDirtyWay) & ~FlushStage;
     assign SetValidEN = SetValidWay & ~FlushStage;
   end

--- a/src/cache/cacheway.sv
+++ b/src/cache/cacheway.sv
@@ -97,22 +97,10 @@ module cacheway #(parameter NUMLINES=512, LINELEN = 256, TAGLEN = 26,
   /////////////////////////////////////////////////////////////////////////////////////////////
 
   assign SetValidWay = SetValid & SelData;
-  if (!READ_ONLY_CACHE) begin
-    assign SetDirtyWay = SetDirty & SelData;
-    assign ClearDirtyWay = ClearDirty & SelData;
-    assign SelectedWriteWordEn = (SetValidWay | SetDirtyWay) & ~FlushStage;
-    assign SetValidEN = SetValidWay & ~FlushStage;
-  end
-  else begin
-    // Don't cover FlushStage assertion during SetValidWay.
-    // it's not explicitely gated anywhere, but for read-only caches,
-    // there's no way that a FlushD can happen during the write stage
-    // of a fetch.
-    // coverage off -item e 1 -fecexprrow 4
-    assign SelectedWriteWordEn = SetValidWay & ~FlushStage;
-    // coverage off -item e 1 -fecexprrow 4
-    assign SetValidEN = SetValidWay & ~FlushStage;
-  end
+  assign SetDirtyWay = SetDirty & SelData;                                 // exclusion-tag: icache SetDirtyWay
+  assign ClearDirtyWay = ClearDirty & SelData;
+  assign SelectedWriteWordEn = (SetValidWay | SetDirtyWay) & ~FlushStage;  // exclusion-tag: icache SelectedWiteWordEn
+  assign SetValidEN = SetValidWay & ~FlushStage;                           // exclusion-tag: icache SetValidEN
 
   // If writing the whole line set all write enables to 1, else only set the correct word.
   assign FinalByteMask = SetValidWay ? '1 : LineByteMask; // OR

--- a/src/cache/cacheway.sv
+++ b/src/cache/cacheway.sv
@@ -101,14 +101,21 @@ module cacheway #(parameter NUMLINES=512, LINELEN = 256, TAGLEN = 26,
   if (!READ_ONLY_CACHE) begin
     assign SetDirtyWay = SetDirty & SelData;
     assign SelectedWriteWordEn = (SetValidWay | SetDirtyWay) & ~FlushStage;
+    assign SetValidEN = SetValidWay & ~FlushStage;
   end
   else begin
+    // Don't cover FlushStage assertion during SetValidWay.
+    // it's not explicitely gated anywhere, but for read-only caches,
+    // there's no way that a FlushD can happen during the write stage
+    // of a fetch.
+    // coverage off -item e 1 -fecexprrow 4
     assign SelectedWriteWordEn = SetValidWay & ~FlushStage;
+    // coverage off -item e 1 -fecexprrow 4
+    assign SetValidEN = SetValidWay & ~FlushStage;
   end
 
   // If writing the whole line set all write enables to 1, else only set the correct word.
   assign FinalByteMask = SetValidWay ? '1 : LineByteMask; // OR
-  assign SetValidEN = SetValidWay & ~FlushStage;
 
   /////////////////////////////////////////////////////////////////////////////////////////////
   // Tag Array

--- a/src/generic/mux.sv
+++ b/src/generic/mux.sv
@@ -40,7 +40,7 @@ module mux3 #(parameter WIDTH = 8) (
   input  logic [1:0]       s, 
   output logic [WIDTH-1:0] y);
 
-  assign y = s[1] ? d2 : (s[0] ? d1 : d0); 
+  assign y = s[1] ? d2 : (s[0] ? d1 : d0); // exclusion-tag: mux3
 endmodule
 
 module mux4 #(parameter WIDTH = 8) (


### PR DESCRIPTION
This PR should bring the i$ coverage up to 100%.

Big changes include
 - a big refactor of the cachefsm.
 - Excluding from coverage the potential case where `FlushStage` (`FlushD`) asserts simultaneously as a write (`SetValidWay`) for the read-only cache. My reasoning is in the commit message (3fc6bb0c), but in short, I think it's impossible to hit.
 - Changing some adress Muxes from mux3 to mux2 for read-only caches.
 - Fixing last LRUUpdate coverage issues, and changing some genvar names to improve readability. Note that the textbook's description of LRU has some outdated signal names as well. 

Note that the rv64gc_wally64priv test failed for me, but it failed for me on [2f6ed64](https://github.com/openhwgroup/cvw/commit/2f6ed64e26ef2940f1627c7e9266f04f158b0303) (the current upstream/main) as well. Please let me know if this is something unique to me!