### PR TITLE
Added a test for denormalized FP numbers

### DIFF
--- a/tests/coverage/fpu.S
+++ b/tests/coverage/fpu.S
@@ -31,6 +31,11 @@ main:
     #bseti t0, zero, 14  # turn on FPU
     csrs mstatus, t0
 
+    #Pull denormalized FP number from memory and pass it to fclass.S for coverage
+    la t0, TestData
+    flw ft0, 0(t0)
+    fclass.s t1, ft0
+
     # Test legal instructions not covered elsewhere
     flq ft0, 0(a0)
     flh ft0, 8(a0)
@@ -98,3 +103,7 @@ main:
 
     j done
 
+.section .data
+.align 3
+TestData:
+.int 0x00100000 #Denormalized FP number


### PR DESCRIPTION
I added a test in fpu.S to add coverage for the denormalized numbers in the fclassify.sv file. This test was created in reference to Ross's guidance and was tested to ensure proper compiling and coverage.

I made a mistake in thinking the test couldn't be reached previously however, as is evident by the test it actually can be reached it just wasn't fully covered in the test bench. This test erased the remaining coverage lapses for the fclassify section of the Wally processor.