### PR TITLE
Added test coverage for reads to HPM counters and coverage exclusions

### DIFF
--- a/src/privileged/csrsr.sv
+++ b/src/privileged/csrsr.sv
@@ -198,9 +198,12 @@ module csrsr (
         STATUS_UBE <= #1 CSRWriteValM[6]  & `U_SUPPORTED & `BIGENDIAN_SUPPORTED;
         STATUS_MBE <= #1 nextMBE;
         STATUS_SBE <= #1 nextSBE;
+      // coverage off
+      // MSTATUSH only exists in 32-bit configurations, will not be hit on rv64gc
       end else if (WriteMSTATUSHM) begin
         STATUS_MBE <= #1 CSRWriteValM[5] & `BIGENDIAN_SUPPORTED;
         STATUS_SBE <= #1 CSRWriteValM[4] & `S_SUPPORTED & `BIGENDIAN_SUPPORTED;
+      // coverage on
       end else if (WriteSSTATUSM) begin // write a subset of the STATUS bits
         STATUS_MXR_INT <= #1 CSRWriteValM[19];
         STATUS_SUM_INT <= #1 CSRWriteValM[18];

--- a/src/privileged/trap.sv
+++ b/src/privileged/trap.sv
@@ -81,11 +81,14 @@ module trap (
   ///////////////////////////////////////////
   
   assign BothInstrAccessFaultM = InstrAccessFaultM | HPTWInstrAccessFaultM;
+  // coverage off -item e 1 -fecexprrow 2
+  // excludes InstrMisalignedFaultM from coverage of this line, since misaligned instructions cannot occur in rv64gc.
   assign ExceptionM = InstrMisalignedFaultM | BothInstrAccessFaultM | IllegalInstrFaultM |
                       LoadMisalignedFaultM | StoreAmoMisalignedFaultM |
                       InstrPageFaultM | LoadPageFaultM | StoreAmoPageFaultM |
                       BreakpointFaultM | EcallFaultM |
                       LoadAccessFaultM | StoreAmoAccessFaultM;
+  // coverage on
   assign TrapM = ExceptionM | InterruptM; 
   assign RetM = mretM | sretM;
 

--- a/tests/coverage/priv.S
+++ b/tests/coverage/priv.S
@@ -142,6 +142,65 @@ main:
     # Test writes to floating point CSRs
     csrw frm, t0
     csrw fflags, t0
+    
+    # CSRC MCOUNTEREN Register
+    # Go to machine mode
+    li a0, 3
+    ecall
+    # Activate HPM3
+    li t0, -1
+    csrw mcounteren, t0
+    csrw scounteren, t0
+
+    # Go to supervisor
+    li a0, 1
+    ecall
+    #try to write to HPMs
+    csrw 333, t0
+    #go to user mode
+    li a0, 0
+    ecall
+    csrr t0, hpmcounter22
+
+    # setting registers bits to 0
+    li a0, 3 # back to machine mode
+    ecall
+    li t0, 0
+    csrw mcounteren, t0
+    csrw scounteren, t0
+
+    # Write to satp when status.TVM is 1 from machine mode
+    bseti t0, zero, 20 
+    csrs mstatus, t0
+
+    csrw satp, t0
+
+
+
+    # Test checking privilege for reading counters (using counter 22 as an example)
+
+    # Go to machine mode
+    li a0, 3
+    ecall
+
+    # Set SCOUNTEREN to all 0s, MCOUNTEREN to all 1s
+    li t0, 0
+    csrw scounteren, t0
+    li t1, -1
+    csrw mcounteren, t1
+
+    # Go to supervisor mode
+    li a0, 1
+    ecall
+
+    # try to read from HPM22
+    csrr t0, hpmcounter22
+
+    # go to user mode
+    li a0, 0
+    ecall
+
+    csrr t0, hpmcounter22
 
     j done
 


### PR DESCRIPTION
Hi all,

This PR contains coverage exclusions for:
1. Misaligned instructions, as they are impossible in rv64gc
2. MSTATUSH, as that register will only be used in 32-bit configurations 

In addition, we added some tests to write to HPM counters from different privileged modes with different conditions of the SCOUNTEREN and MCOUNTEREN registers. 

Thanks!