### PR TITLE
Removed redundent expression to increase coverage

### DIFF
--- a/src/fpu/postproc/round.sv
+++ b/src/fpu/postproc/round.sv
@@ -111,7 +111,7 @@ module round(
 
 
   // determine what format the final result is in: int or fp
-  assign IntRes = CvtOp & ToInt;
+  assign IntRes = ToInt;
   assign FpRes = ~IntRes;
 
   // sticky bit calculation


### PR DESCRIPTION
CvtOp is always 1 when ToInt is 1, so CvtOp is redundant and can be removed to increase coverage in round.