### PR TITLE
Add pmpcfg test cases increasing IFU coverage

### DIFF
--- a/tests/coverage/pmpcfg.S
+++ b/tests/coverage/pmpcfg.S
@@ -1,10 +1,52 @@
 // pmpcfg part 1
 // Kevin Wan, kewan@hmc.edu, 4/18/2023
+// Liam Chalk, lchalk@hmc.edu, 4/19/2023
 // locks each pmpXcfg bit field in order, from X = 15 to X = 0, with the A[1:0] field set to TOR. 
 // See the next part in pmpcfg1.S
 
 #include "WALLY-init-lib.h" 
 main: 
+
+    li t0, 0x90000000
+    csrw pmpaddr0, t0
+    li t0, 0x00000017
+    csrw pmpcfg0, t0
+
+    li t0, 0x90000000
+    csrw pmpaddr2, t0
+    li t0, 0x00000017
+    csrw pmpcfg2, t0
+
+    li t0, 0x90000000
+    csrw pmpaddr0, t0
+    li t0, 0x00000017
+    csrw pmpcfg1, t0
+
+    li t0, 0x90000000
+    csrw pmpaddr0, t0
+    li t0, 0x00000017
+    csrw pmpcfg2, t0
+
+    li t0, 0x90000000
+    csrw pmpaddr0, t0
+    li t0, 0x00000017
+    csrw pmpcfg3, t0
+
+    li t0, 0x90000000
+    csrw pmpaddr1, t0
+    li t0, 0x00000017
+    csrw pmpcfg1, t0
+
+    li t0, 0x90000000
+    csrw pmpaddr1, t0
+    li t0, 0x00000017
+    csrw pmpcfg2, t0
+
+    li t0, 0x90000000
+    csrw pmpaddr1, t0
+    li t0, 0x00000017
+    csrw pmpcfg3, t0
+
     li t0, 0x8800000000000000
     csrw pmpcfg2, t0
     li t0, 0x88000000000000
@@ -36,6 +78,4 @@ main:
     li t0, 0x8800
     csrw pmpcfg0, t0
 
-
     j done
-


### PR DESCRIPTION
Added test cases to pmpcfg.S to increase IFU coverage from 83.15% to 83.30%.
Write to pmpaddr0 and pmpaddr2.