### PR TITLE
Add Coverage for TLB, MP, Global, ASID and Match

### DIFF
--- a/testbench/tests.vh
+++ b/testbench/tests.vh
@@ -60,6 +60,7 @@ string tvpaths[] = '{
     "pmpcfg2",
     "tlbKP",
     "tlbMP",
+    "tlbM3",
     "tlbASID",
     "tlbGLB",
     "ifuCamlineWrite"

--- a/testbench/tests.vh
+++ b/testbench/tests.vh
@@ -59,6 +59,9 @@ string tvpaths[] = '{
     "pmpcfg1",
     "pmpcfg2",
     "tlbKP",
+    "tlbMP",
+    "tlbASID",
+    "tlbGLB",
     "ifuCamlineWrite"
   };
 

--- a/tests/coverage/tlbASID.S
+++ b/tests/coverage/tlbASID.S
@@ -1,0 +1,133 @@
+///////////////////////////////////////////
+// tlbASID.S
+//
+// Written: mmendozamanriquez@hmc.edu 4 April 2023
+//          nlimpert@hmc.edu
+//
+// Purpose: Test coverage for LSU
+//
+// A component of the CORE-V-WALLY configurable RISC-V project.
+// 
+// Copyright (C) 2021-23 Harvey Mudd College & Oklahoma State University
+//
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+//
+// Licensed under the Solderpad Hardware License v 2.1 (the “License”); you may not use this file 
+// except in compliance with the License, or, at your option, the Apache License version 2.0. You 
+// may obtain a copy of the License at
+//
+// https://solderpad.org/licenses/SHL-2.1/
+//
+// Unless required by applicable law or agreed to in writing, any work distributed under the 
+// License is distributed on an “AS IS” BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, 
+// either express or implied. See the License for the specific language governing permissions 
+// and limitations under the License.
+////////////////////////////////////////////////////////////////////////////////////////////////
+
+// load code to initalize stack, handle interrupts, terminate
+
+#include "WALLY-init-lib.h"
+
+# run-elf.bash find this in project description
+main:
+    # Page table root address at 0x80010000
+    li t5, 0x9000000000080080 // try making asid = 0. 
+    csrw satp, t5
+
+    # sfence.vma x0, x0
+
+    # switch to supervisor mode
+    li a0, 1   
+    ecall
+
+    li t0, 0xC0000000
+
+    li t2, 0             # i = 0
+    li t5, 0            # j = 0 // now use as a counter for new asid loop 
+    li t3, 32     # Max amount of Loops = 32
+
+loop: bge t2, t3, nASID   # exit loop if i >= loops
+    lw t1, 0(t0)
+    li t4, 0x1000
+    add t0, t0, t4
+    addi t2, t2, 1
+    j loop
+
+nASID: bne t5, zero, finished
+    li a0, 3   // go
+    ecall
+    li t5, 0x9000100000080080 // try making asid = 1 
+    csrw satp, t5
+    li a0, 1   
+    ecall
+    li t2, 0
+    li t0, 0xC0000000
+    li t5, 1 // make this not zero. 
+    j loop
+
+
+finished:
+    j done
+
+.data
+.align 19
+# level 3 Page table situated at 0x8008 0000, should point to 8008,1000
+pagetable: 
+    .8byte 0x200204C1
+    
+.align 12 // level 2 page table, contains direction to a gigapageg
+    .8byte 0x0
+    .8byte 0x0
+    .8byte 0x200000CF // gigapage that starts at 8000 0000 goes to C000 0000
+    .8byte 0x200208C1 // pointer to next page table entry at 8008 2000
+
+.align 12 // level 1 page table, points to level 0 page table
+    .8byte 0x20020CC1
+
+.align 12 // level 0 page table, points to address C000 0000 // FOR NOW ALL OF THESE GO TO 8 instead of C cause they start with 2
+    .8byte 0x200000CF // access xC000 0000
+    .8byte 0x200004CF // access xC000 1000
+    .8byte 0x200008CF // access xC000 2000
+    .8byte 0x20000CCF // access xC000 3000
+
+    .8byte 0x200010CF // access xC000 4000
+    .8byte 0x200014CF
+    .8byte 0x200018CF
+    .8byte 0x20001CCF
+
+    .8byte 0x200020CF // access xC000 8000
+    .8byte 0x200024CF
+    .8byte 0x200028CF
+    .8byte 0x20002CCF
+
+    .8byte 0x200030CF // access xC000 C000
+    .8byte 0x200034CF
+    .8byte 0x200038CF
+    .8byte 0x20003CCF
+
+    .8byte 0x200040CF // access xC001 0000
+    .8byte 0x200044CF
+    .8byte 0x200048CF
+    .8byte 0x20004CCF
+
+    .8byte 0x200050CF // access xC001 4000
+    .8byte 0x200054CF
+    .8byte 0x200058CF
+    .8byte 0x20005CCF
+
+    .8byte 0x200060CF // access xC001 8000
+    .8byte 0x200064CF
+    .8byte 0x200068CF
+    .8byte 0x20006CCF
+
+    .8byte 0x200070CF // access xC001 C000
+    .8byte 0x200074CF
+    .8byte 0x200078CF
+    .8byte 0x20007CCF
+
+    .8byte 0x200080CF // access xC002 0000
+    .8byte 0x200084CF
+    .8byte 0x200088CF
+    .8byte 0x20008CCF
+
+    

--- a/tests/coverage/tlbGLB.S
+++ b/tests/coverage/tlbGLB.S
@@ -1,0 +1,134 @@
+///////////////////////////////////////////
+// tlbGLB.S
+//
+// Written: mmendozamanriquez@hmc.edu 4 April 2023
+//          nlimpert@hmc.edu
+//
+// Purpose: coverage for the global check. 
+//
+// A component of the CORE-V-WALLY configurable RISC-V project.
+// 
+// Copyright (C) 2021-23 Harvey Mudd College & Oklahoma State University
+//
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+//
+// Licensed under the Solderpad Hardware License v 2.1 (the “License”); you may not use this file 
+// except in compliance with the License, or, at your option, the Apache License version 2.0. You 
+// may obtain a copy of the License at
+//
+// https://solderpad.org/licenses/SHL-2.1/
+//
+// Unless required by applicable law or agreed to in writing, any work distributed under the 
+// License is distributed on an “AS IS” BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, 
+// either express or implied. See the License for the specific language governing permissions 
+// and limitations under the License.
+////////////////////////////////////////////////////////////////////////////////////////////////
+
+
+// load code to initalize stack, handle interrupts, terminate
+
+#include "WALLY-init-lib.h"
+
+# run-elf.bash find this in project description
+main:
+    # Page table root address at 0x80010000
+    li t5, 0x9000000000080080 // try making asid = 0. 
+    csrw satp, t5
+
+    # sfence.vma x0, x0
+
+    # switch to supervisor mode
+    li a0, 1   
+    ecall
+
+    li t0, 0xC0000000
+
+    li t2, 0             # i = 0
+    li t5, 0            # j = 0 // now use as a counter for new asid loop 
+    li t3, 32     # Max amount of Loops = 32
+
+loop: bge t2, t3, nASID   # exit loop if i >= loops
+    lw t1, 0(t0)
+    li t4, 0x1000
+    add t0, t0, t4
+    addi t2, t2, 1
+    j loop
+
+nASID: bne t5, zero, finished
+    li a0, 3   // go
+    ecall
+    li t5, 0x9000100000080080 // try making asid = 1 
+    csrw satp, t5
+    li a0, 1   
+    ecall
+    li t2, 0
+    li t0, 0xC0000000
+    li t5, 1 // make this not zero. 
+    j loop
+
+
+finished:
+    j done
+
+.data
+.align 19
+# level 3 Page table situated at 0x8008 0000, should point to 8008,1000
+pagetable: 
+    .8byte 0x200204C1
+    
+.align 12 // level 2 page table, contains direction to a gigapageg
+    .8byte 0x0
+    .8byte 0x0
+    .8byte 0x200000CF // gigapage that starts at 8000 0000 goes to C000 0000
+    .8byte 0x200208C1 // pointer to next page table entry at 8008 2000
+
+.align 12 // level 1 page table, points to level 0 page table
+    .8byte 0x20020CE1
+
+.align 12 // level 0 page table, points to address C000 0000 // FOR NOW ALL OF THESE GO TO 8 instead of C cause they start with 2
+    .8byte 0x200000CF // access xC000 0000
+    .8byte 0x200004CF // access xC000 1000
+    .8byte 0x200008CF // access xC000 2000
+    .8byte 0x20000CCF // access xC000 3000
+
+    .8byte 0x200010EF // access xC000 4000
+    .8byte 0x200014EF
+    .8byte 0x200018EF
+    .8byte 0x20001CEF
+
+    .8byte 0x200020EF // access xC000 8000
+    .8byte 0x200024EF
+    .8byte 0x200028EF
+    .8byte 0x20002CEF
+
+    .8byte 0x200030EF // access xC000 C000
+    .8byte 0x200034EF
+    .8byte 0x200038EF
+    .8byte 0x20003CEF
+
+    .8byte 0x200040EF // access xC001 0000
+    .8byte 0x200044EF
+    .8byte 0x200048EF
+    .8byte 0x20004CEF
+
+    .8byte 0x200050EF // access xC001 4000
+    .8byte 0x200054EF
+    .8byte 0x200058EF
+    .8byte 0x20005CEF
+
+    .8byte 0x200060EF // access xC001 8000
+    .8byte 0x200064EF
+    .8byte 0x200068EF
+    .8byte 0x20006CEF
+
+    .8byte 0x200070EF // access xC001 C000
+    .8byte 0x200074eF
+    .8byte 0x200078EF
+    .8byte 0x20007CEF
+
+    .8byte 0x200080EF // access xC002 0000
+    .8byte 0x200084EF
+    .8byte 0x200088EF
+    .8byte 0x20008CEF
+
+    

--- a/tests/coverage/tlbM3.S
+++ b/tests/coverage/tlbM3.S
@@ -1,0 +1,155 @@
+///////////////////////////////////////////
+// tlbKP.S
+//
+// Written: mmendozamanriquez@hmc.edu 4 April 2023
+//          nlimpert@hmc.edu
+//
+// Purpose: Test coverage for LSU
+//
+// A component of the CORE-V-WALLY configurable RISC-V project.
+// 
+// Copyright (C) 2021-23 Harvey Mudd College & Oklahoma State University
+//
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+//
+// Licensed under the Solderpad Hardware License v 2.1 (the “License”); you may not use this file 
+// except in compliance with the License, or, at your option, the Apache License version 2.0. You 
+// may obtain a copy of the License at
+//
+// https://solderpad.org/licenses/SHL-2.1/
+//
+// Unless required by applicable law or agreed to in writing, any work distributed under the 
+// License is distributed on an “AS IS” BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, 
+// either express or implied. See the License for the specific language governing permissions 
+// and limitations under the License.
+////////////////////////////////////////////////////////////////////////////////////////////////
+
+// load code to initalize stack, handle interrupts, terminate
+
+#include "WALLY-init-lib.h"
+
+# run-elf.bash find this in project description
+main:
+    # Page table root address at 0x80010000
+    li t5, 0x9000000000080010
+    csrw satp, t5
+
+    # sfence.vma x0, x0
+
+    # switch to supervisor mode
+    li a0, 1   
+    ecall
+
+    li t0, 0x1000
+
+    li t2, 0             # i = 0
+    li t3, 64     # Max amount of Loops = 32
+    li t4, 0x1000
+
+loop: bge t2, t3, interim  # exit loop if i >= loops
+    lw t1, 0(t0)
+    # sfence.vma x0, x0
+    add t0, t0, t4
+    addi t2, t2, 1
+    j loop
+
+interim:
+    li t0, 0xFFFFFFFF000
+    li t2, 0             # i = 0
+     
+
+loop2:bge t2, t3, finished  # exit loop if i >= loops
+    lw t1, 0(t0)
+    add t0, t0, t4
+    addi t2, t2, 1
+    j loop2
+
+finished:
+    j done
+
+.data
+
+.align 16
+# Page table situated at 0x80010000
+pagetable: 
+    .8byte 0x200044C1 // old page table was 200040 which just pointed to itself! wrong
+
+.align 12
+    .8byte 0x00000000200048C1
+    .8byte 0x00000000200048C1
+    .8byte 0x00000000200048C1
+    
+
+.align 12
+    .8byte 0x0000000020004CC1
+    //.8byte 0x00000200800CF// ADD IN THE MEGAPAGE should 3 nibbles of zeros be removed?
+
+.align 12
+    #80000000
+    .8byte 0x200000CF
+    .8byte 0x200004CF
+    .8byte 0x200008CF
+    .8byte 0x20000CCF
+
+    .8byte 0x200010CF
+    .8byte 0x200014CF
+    .8byte 0x200018CF
+    .8byte 0x20001CCF
+
+    .8byte 0x200020CF
+    .8byte 0x200024CF
+    .8byte 0x200028CF
+    .8byte 0x20002CCF
+
+    .8byte 0x200030CF
+    .8byte 0x200034CF
+    .8byte 0x200038CF
+    .8byte 0x20003CCF
+
+    .8byte 0x200040CF
+    .8byte 0x200044CF
+    .8byte 0x200048CF
+    .8byte 0x20004CCF
+
+    .8byte 0x200050CF
+    .8byte 0x200054CF
+    .8byte 0x200058CF
+    .8byte 0x20005CCF
+
+    .8byte 0x200060CF
+    .8byte 0x200064CF
+    .8byte 0x200068CF
+    .8byte 0x20006CCF
+
+    .8byte 0x200070CF
+    .8byte 0x200074CF
+    .8byte 0x200078CF
+    .8byte 0x20007CCF
+    
+    .8byte 0x200080CF
+    .8byte 0x200084CF
+    .8byte 0x200088CF
+    .8byte 0x20008CCF
+
+    .8byte 0x200090CF
+    .8byte 0x200094CF
+    .8byte 0x200098CF
+    .8byte 0x20009CCF
+
+    .8byte 0x2000A0CF
+    .8byte 0x2000A4CF
+    .8byte 0x2000A8CF
+    .8byte 0x2000ACCF
+
+    .8byte 0x2000B0CF
+    .8byte 0x2000B4CF
+    .8byte 0x2000B8CF
+    .8byte 0x2000BCCF
+
+    .8byte 0x2000C0CF
+    .8byte 0x2000C4CF
+    .8byte 0x2000C8CF
+    .8byte 0x2000CCCF
+
+    .8byte 0x2000D0CF
+    .8byte 0x2000D4CF

--- a/tests/coverage/tlbMP.S
+++ b/tests/coverage/tlbMP.S
@@ -1,0 +1,163 @@
+///////////////////////////////////////////
+// tlbMP.S
+//
+// Written: mmendozamanriquez@hmc.edu 4 April 2023
+//          nlimpert@hmc.edu
+//
+// Purpose: Test coverage for LSU
+//
+// A component of the CORE-V-WALLY configurable RISC-V project.
+// 
+// Copyright (C) 2021-23 Harvey Mudd College & Oklahoma State University
+//
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+//
+// Licensed under the Solderpad Hardware License v 2.1 (the “License”); you may not use this file 
+// except in compliance with the License, or, at your option, the Apache License version 2.0. You 
+// may obtain a copy of the License at
+//
+// https://solderpad.org/licenses/SHL-2.1/
+//
+// Unless required by applicable law or agreed to in writing, any work distributed under the 
+// License is distributed on an “AS IS” BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, 
+// either express or implied. See the License for the specific language governing permissions 
+// and limitations under the License.
+////////////////////////////////////////////////////////////////////////////////////////////////
+
+// load code to initalize stack, handle interrupts, terminate
+
+#include "WALLY-init-lib.h"
+
+# run-elf.bash find this in project description
+main:
+    # Page table root address at 0x80010000
+    li t5, 0x9000000000080010
+    csrw satp, t5
+
+    # sfence.vma x0, x0
+
+    # switch to supervisor mode
+    li a0, 1   
+    ecall
+    li t5, 0 
+    li t0, 0x84000000 // go to first megapage
+    li t4, 0x1000 // put this outside the loop.
+    li t2, 0      # i = 0
+    li t3, 32     # Max amount of Loops = 16
+
+loop: bge t2, t3, lKP   # exit loop if i >= loops
+    lw t1, 0(t0)
+    add t0, t0, t4
+    addi t2, t2, 1
+    j loop
+
+lKP: bne t5, zero, finished
+    li t0, 0x80000000 
+    slli t4, t4, 9
+    addi t5, t5, 1
+    li t2, 0
+    j loop
+
+finished:
+    j done
+
+.data
+
+.align 16
+# Page table situated at 0x80010000
+pagetable: 
+    .8byte 0x200044C1
+
+.align 12
+    .8byte 0x00000000200048C1
+    .8byte 0x00000000200048C1
+    .8byte 0x00000000200048C1
+    
+
+.align 12 // megapages starting at 8000 0000 going to 8480 0000  (32*2 MiB beyond that)
+
+    .8byte 0x200000CF // access 8000,0000
+    .8byte 0x200800CF // access 8020,0000 
+    .8byte 0x201000CF // acesss 8040,0000
+    .8byte 0x201800CF // acesss 8060,0000
+
+    .8byte 0x202000CF // access 8080,0000
+    .8byte 0x202800CF // access 80A0,0000
+    .8byte 0x203000CF // access 80C0,0000
+    .8byte 0x203800CF // access 80E0,0000
+
+    .8byte 0x204000CF // access 8100,0000
+    .8byte 0x204800CF 
+    .8byte 0x205000CF 
+    .8byte 0x205800CF 
+
+    .8byte 0x206000CF // access 8180,0000
+    .8byte 0x206800CF 
+    .8byte 0x207000CF 
+    .8byte 0x207800CF 
+
+    .8byte 0x208000CF // access 8200,0000
+    .8byte 0x208800CF 
+    .8byte 0x209000CF 
+    .8byte 0x209800CF 
+
+    .8byte 0x20A000CF // access 8280,0000
+    .8byte 0x20A800CF 
+    .8byte 0x20B000CF 
+    .8byte 0x20B800CF 
+
+    .8byte 0x20C000CF // access 8300,0000
+    .8byte 0x20C800CF 
+    .8byte 0x20D000CF 
+    .8byte 0x20D800CF
+
+    .8byte 0x20E000CF // access 8380,0000
+    .8byte 0x20E800CF 
+    .8byte 0x20F000CF 
+    .8byte 0x20F800CF
+
+    .8byte 0x20004CC1
+     // Kilopage entry, for addresses from 8400, 0000 to 841F, FFFF
+                      // point to ... 
+
+.align 12 // should start at 84000000 
+    .8byte 0x210000CF
+    .8byte 0x210004CF
+    .8byte 0x210008CF
+    .8byte 0x21000CCF
+
+    .8byte 0x210010CF
+    .8byte 0x210014CF
+    .8byte 0x210018CF
+    .8byte 0x21001CCF
+
+    .8byte 0x210020CF
+    .8byte 0x210024CF
+    .8byte 0x210028CF
+    .8byte 0x21002CCF
+
+    .8byte 0x210030CF
+    .8byte 0x210034CF
+    .8byte 0x210038CF
+    .8byte 0x21003CCF
+
+    .8byte 0x210040CF
+    .8byte 0x210044CF
+    .8byte 0x210048CF
+    .8byte 0x21004CCF
+
+    .8byte 0x210050CF
+    .8byte 0x210054CF
+    .8byte 0x210058CF
+    .8byte 0x21005CCF
+
+    .8byte 0x210060CF
+    .8byte 0x210064CF
+    .8byte 0x210068CF
+    .8byte 0x21006CCF
+
+    .8byte 0x210070CF
+    .8byte 0x210074CF
+    .8byte 0x210078CF
+    .8byte 0x21007CCF
+


### PR DESCRIPTION
4 test files are added: 
   "tlbMP"
   "tlbM3"
   "tlbASID"
   "tlbGLB"
MP accesses megapages, adding coverage to pageType >0 
M3 adds coverage to match3 of tlb lines 
ASID switches asid
GLB adds coverage by making pages global and switching asid.