### PR TITLE
pmpcfg test cases

### DIFF
--- a/tests/coverage/pmpcfg.S
+++ b/tests/coverage/pmpcfg.S
@@ -1,6 +1,6 @@
 // pmpcfg part 1
 // Kevin Wan, kewan@hmc.edu, 4/18/2023
-// Liam Chalk, lchalk@hmc.edu, 4/19/2023
+// Liam Chalk, lchalk@hmc.edu, 4/21/2023
 // locks each pmpXcfg bit field in order, from X = 15 to X = 0, with the A[1:0] field set to TOR. 
 // See the next part in pmpcfg1.S
 
@@ -19,32 +19,37 @@ main:
 
     li t0, 0x90000000
     csrw pmpaddr0, t0
-    li t0, 0x00000017
+    li t0, 0x00001700
+    csrw pmpcfg0, t0
+
+    li t0, 0x90000000
+    csrw pmpaddr0, t0
+    li t0, 0x00001700
     csrw pmpcfg1, t0
 
     li t0, 0x90000000
     csrw pmpaddr0, t0
-    li t0, 0x00000017
+    li t0, 0x00001700
     csrw pmpcfg2, t0
 
     li t0, 0x90000000
     csrw pmpaddr0, t0
-    li t0, 0x00000017
+    li t0, 0x00001700
     csrw pmpcfg3, t0
 
     li t0, 0x90000000
     csrw pmpaddr1, t0
-    li t0, 0x00000017
+    li t0, 0x00001700
     csrw pmpcfg1, t0
 
     li t0, 0x90000000
-    csrw pmpaddr1, t0
-    li t0, 0x00000017
+    csrw pmpaddr2, t0
+    li t0, 0x00001700
     csrw pmpcfg2, t0
 
     li t0, 0x90000000
-    csrw pmpaddr1, t0
-    li t0, 0x00000017
+    csrw pmpaddr3, t0
+    li t0, 0x00001700
     csrw pmpcfg3, t0
 
     li t0, 0x8800000000000000


### PR DESCRIPTION
Writing additional tests for pmpcfg writing 0x00001700 to pmpcfg0 and pmpcfg2.
Increased IFU coverage from 83.37% to 83.53% and LSU coverage from 93.14% to 93.28%.