### PR TITLE
Excluded coverage for impossible cases in wficountreg and status.MPRV

### DIFF
--- a/sim/coverage-exclusions-rv64gc.do
+++ b/sim/coverage-exclusions-rv64gc.do
@@ -128,3 +128,7 @@ set line [GetLineNum ../src/mmu/pmachecker.sv "WriteAccessM \\| ExecuteAccessF"]
 coverage exclude -scope /dut/core/ifu/immu/immu/pmachecker -linerange $line-$line -item e 1 -fecexprrow 1-5
 set line [GetLineNum ../src/mmu/pmachecker.sv "ReadAccessM \\| ExecuteAccessF"]
 coverage exclude -scope /dut/core/ifu/immu/immu/pmachecker -linerange $line-$line -item e 1 -fecexprrow 1-3
+
+# Excluding reset and clear for impossible case in the wficountreg in privdec
+set line [GetLineNum ../src/generic/flop/floprc.sv "reset \\| clear"]
+coverage exclude -scope /dut/core/priv/priv/pmd/wfi/wficountreg -linerange $line-$line -item c 1 -feccondrow 2

--- a/src/privileged/csrsr.sv
+++ b/src/privileged/csrsr.sv
@@ -122,7 +122,10 @@ module csrsr (
     logic [1:0] EndiannessPrivMode;
     always_comb begin
       if      (SelHPTW)                                  EndiannessPrivMode = `S_MODE;
+      //coverage off -item c 1 -feccondrow 1
+      // status.MPRV always gets reset upon leaving machine mode, so MPRV will never be high when out of machine mode
       else if (PrivilegeModeW == `M_MODE & STATUS_MPRV)  EndiannessPrivMode = STATUS_MPP;
+      //coverage on
       else                                               EndiannessPrivMode = PrivilegeModeW;
 
       case (EndiannessPrivMode) 


### PR DESCRIPTION
Hi all, 

This PR contains exclusions for status.MPRV as well as an impossible case for the wficountreg, where reset and clear will never be high at the same time. Special thanks to @AlecVercruysse for writing the GetLineNum script, allowing us to exclude coverage for a specific flop instead of excluding coverage for all flops system-wide. These changes increase coverage from 98.14% to 99.75% in the privilege unit. 

Thanks!