### PR TITLE
pmpaddr0 and pmpaddr2 test cases

### DIFF
--- a/tests/coverage/pmpcfg.S
+++ b/tests/coverage/pmpcfg.S
@@ -1,6 +1,6 @@
 // pmpcfg part 1
 // Kevin Wan, kewan@hmc.edu, 4/18/2023
-// Liam Chalk, lchalk@hmc.edu, 4/21/2023
+// Liam Chalk, lchalk@hmc.edu, 4/25/2023
 // locks each pmpXcfg bit field in order, from X = 15 to X = 0, with the A[1:0] field set to TOR. 
 // See the next part in pmpcfg1.S
 
@@ -51,6 +51,26 @@ main:
     csrw pmpaddr3, t0
     li t0, 0x00001700
     csrw pmpcfg3, t0
+
+    li t0, 0x90000000
+    csrw pmpaddr0, t0
+    li t0, 0x00170000
+    csrw pmpcfg0, t0
+
+    li t0, 0x90000000
+    csrw pmpaddr2, t0
+    li t0, 0x00170000
+    csrw pmpcfg2, t0
+
+    li t0, 0x90000000
+    csrw pmpaddr0, t0
+    li t0, 0x17000000
+    csrw pmpcfg0, t0
+
+    li t0, 0x90000000
+    csrw pmpaddr2, t0
+    li t0, 0x17000000
+    csrw pmpcfg2, t0
 
     li t0, 0x8800000000000000
     csrw pmpcfg2, t0


### PR DESCRIPTION
Writing 0x00170000 and 0x17000000 to pmpaddr0 and pmpaddr2.
Increased IFU coverage from 83.53% to 83.68% and LSU coverage from 93.29% to 93.45%.