### PR TITLE
Excluded and added coverage for WFI test case.

### DIFF
--- a/src/privileged/privdec.sv
+++ b/src/privileged/privdec.sv
@@ -70,7 +70,7 @@ module privdec (
     assign WFICountPlus1 = WFICount + 1;
     floprc #(`WFI_TIMEOUT_BIT+1) wficountreg(clk, reset, ~wfiM, WFICountPlus1, WFICount);  // count while in WFI
   // coverage off -item e 1 -fecexprrow 1
-  // Excluding test case where we need to test WFI in a condition where it will never trap    
+  // WFI Timout trap will not occur when STATUS_TW is low while in supervisor mode, so the system gets stuck waiting for an interrupt and triggers a watchdog timeout.
     assign WFITimeoutM = ((STATUS_TW & PrivilegeModeW != `M_MODE) | (`S_SUPPORTED & PrivilegeModeW == `U_MODE)) & WFICount[`WFI_TIMEOUT_BIT]; 
   // coverage on
   end else assign WFITimeoutM = 0;

--- a/src/privileged/privdec.sv
+++ b/src/privileged/privdec.sv
@@ -69,7 +69,10 @@ module privdec (
     logic [`WFI_TIMEOUT_BIT:0] WFICount, WFICountPlus1;
     assign WFICountPlus1 = WFICount + 1;
     floprc #(`WFI_TIMEOUT_BIT+1) wficountreg(clk, reset, ~wfiM, WFICountPlus1, WFICount);  // count while in WFI
+  // coverage off -item e 1 -fecexprrow 1
+  // Excluding test case where we need to test WFI in a condition where it will never trap    
     assign WFITimeoutM = ((STATUS_TW & PrivilegeModeW != `M_MODE) | (`S_SUPPORTED & PrivilegeModeW == `U_MODE)) & WFICount[`WFI_TIMEOUT_BIT]; 
+  // coverage on
   end else assign WFITimeoutM = 0;
 
   ///////////////////////////////////////////

--- a/tests/coverage/priv.S
+++ b/tests/coverage/priv.S
@@ -169,6 +169,24 @@ main:
     csrw mcounteren, t0
     csrw scounteren, t0
 
+    #getting the remainder of PMD instructions
+
+    #go to user mode
+    li a0, 0
+    ecall
+    #set status TVM to 0 by writing to bit 20 of mstatus as 0
+    #bseti t0, zero, 20 
+    sfence.vma zero, zero
+
+    # Go to supervisor mode
+    li a0, 1
+    ecall
+
+    sfence.vma zero, zero
+
+    li a0, 3
+    ecall
+
     # Write to satp when status.TVM is 1 from machine mode
     bseti t0, zero, 20 
     csrs mstatus, t0
@@ -202,6 +220,30 @@ main:
     ecall
 
     csrr t0, hpmcounter22
+
+    #getting the mpp and mstatus Mpriv condition met
+    #go to machine mode
+    li a0, 3
+    ecall
+    # set bit 17 of mstatus to enable STATUS_MPRV
+    bseti t1, zero, 17
+    csrs mstatus, t1
+
+    li a0, 3
+    ecall
+
+    # set bit 21 of mstatus to 0 to disable STATUS_TW
+    csrr t1, mstatus
+    bseti t2, zero, 21
+    not t2, t2
+    and t1, t1, t2
+    csrs mstatus, t1
+
+    # go to user mode
+    li a0, 0
+    ecall
+
+    wfi
 
     j done
 


### PR DESCRIPTION
Removed coverage for a test case involving the WFI. This case involved testing a case where the WFI is not supposed to trap, therefore causing a watchdog timeout. This PR also includes test cases for a similar case where it is supposed to trap. This brings priv coverage from 99.75% to 100%!