### PR TITLE
Pmpadrdecs test cases changing AdrMode to 2 or 3

### DIFF
--- a/sim/coverage-exclusions-rv64gc.do
+++ b/sim/coverage-exclusions-rv64gc.do
@@ -201,3 +201,5 @@ coverage exclude -scope /dut/core/ifu/immu/immu/tlb/tlb/tlbcontrol -linerange $l
 set line [GetLineNum ../src/generic/flop/floprc.sv "reset \\| clear"]
 coverage exclude -scope /dut/core/priv/priv/pmd/wfi/wficountreg -linerange $line-$line -item c 1 -feccondrow 2
 
+# Excluding pmpadrdecs[0] coverage case for PAgePMPAdrIn being hardwired to 1
+coverage exclude -scope /dut/core/ifu/immu/immu/pmp/pmpchecker/pmp/pmpadrdecs[0] -linerange [GetLineNum ../src/mmu/pmpadrdec.sv "exclusion-tag: PAgePMPAdrIn"] -item e 1 -fecexprrow 1

--- a/src/mmu/pmpadrdec.sv
+++ b/src/mmu/pmpadrdec.sv
@@ -63,7 +63,7 @@ module pmpadrdec (
   assign CurrentAdrFull  = {PMPAdr,  2'b00};
   assign PAltPMPAdr = {1'b0, PhysicalAddress} < {1'b0, CurrentAdrFull}; // unsigned comparison
   assign PAgePMPAdrOut = ~PAltPMPAdr;
-  assign TORMatch = PAgePMPAdrIn & PAltPMPAdr;
+  assign TORMatch = PAgePMPAdrIn & PAltPMPAdr; // exclusion-tag: PAgePMPAdrIn
 
   // Naturally aligned regions
   logic [`PA_BITS-1:0] NAMask, NABase;

--- a/testbench/tests.vh
+++ b/testbench/tests.vh
@@ -58,6 +58,7 @@ string tvpaths[] = '{
     "pmpcfg",
     "pmpcfg1",
     "pmpcfg2",
+    "pmpadrdecs",
     "tlbKP",
     "tlbMP",
     "tlbM3",

--- a/tests/coverage/pmpadrdecs.S
+++ b/tests/coverage/pmpadrdecs.S
@@ -1,0 +1,22 @@
+// pmpadrdecs
+// Liam Chalk, lchalk@hmc.edu, 4/27/2023
+// Setting AdrMode to 2 or 3 for pmpadrdecs[0-4]
+
+#include "WALLY-init-lib.h" 
+main: 
+
+    # Writing values to pmpcfg0 to change AdrMode to 2 or 3
+    # pmpadrdec[0]
+    li t0, 0x0000000010
+    csrw pmpcfg0, t0
+    # pmpadrdec[1]
+    li t0, 0x0000001800
+    csrw pmpcfg0, t0
+    # pmpadrdec[2]
+    li t0, 0x0000180000
+    csrw pmpcfg0, t0
+    # pmpadrdec[4]
+    li t0, 0x1000000000
+    csrw pmpcfg0, t0
+
+    j done


### PR DESCRIPTION
Setting AdrMode to 2 or 3 for pmpadrdecs[0-4] writing values to pmpcfg0 to change AdrMode to 2 or 3.
Also exclusion for pmpadrdecs[0] coverage case for PAgePMPAdrIn being hardwired to 1 in pmpadrdec.sv.