### PR TITLE
Fix extraneous force in testbench which keep btb in reset.

### DIFF
--- a/src/privileged/csrc.sv
+++ b/src/privileged/csrc.sv
@@ -98,7 +98,7 @@ module csrc  import cvw::*;  #(parameter cvw_t P) (
     assign CounterEvent[3] = InstrClassM[0] & InstrValidNotFlushedM;                    // branch instruction
     assign CounterEvent[4] = InstrClassM[1] & ~InstrClassM[2] & InstrValidNotFlushedM;  // jump and not return instructions
     assign CounterEvent[5] = InstrClassM[2] & InstrValidNotFlushedM;                    // return instructions
-  assign CounterEvent[6] = BPWrongM & InstrValidNotFlushedM;                            // branch predictor wrong
+    assign CounterEvent[6] = BPWrongM & InstrValidNotFlushedM;                          // branch predictor wrong
     assign CounterEvent[7] = BPDirPredWrongM & InstrValidNotFlushedM;                   // Branch predictor wrong direction
     assign CounterEvent[8] = BTAWrongM & InstrValidNotFlushedM;                         // branch predictor wrong target
     assign CounterEvent[9] = RASPredPCWrongM & InstrValidNotFlushedM;                   // return address stack wrong address

--- a/testbench/testbench.sv
+++ b/testbench/testbench.sv
@@ -554,7 +554,7 @@ module testbench;
     always @(*) begin
       if(reset) begin
         for(adrindex = 0; adrindex < 2**`BTB_SIZE; adrindex++) begin
-          force dut.core.ifu.bpred.bpred.TargetPredictor.memory.mem[adrindex] = 0;
+          dut.core.ifu.bpred.bpred.TargetPredictor.memory.mem[adrindex] = 0;
         end
         for(adrindex = 0; adrindex < 2**`BPRED_SIZE; adrindex++) begin
           dut.core.ifu.bpred.bpred.Predictor.DirPredictor.PHT.mem[adrindex] = 0;


### PR DESCRIPTION
- Hacked it together, but I think testfloat is working.
- Cleanup parameterization for verilator 5.010.
- Updated source code to be compatible with verilator 5.011 for lint only.
- Oups forgot to include updates to the lint script itself.
- Fixed typo in coremark makefile.
- Found the coremark performance issue.  The testbench was continuously forcing the BTB to all zeros.  Once fixed it resolved the performance problem.
