### PR TITLE
Change to testbench-fp.sv

### DIFF
--- a/sim/wave-fpu.do
+++ b/sim/wave-fpu.do
@@ -7,6 +7,7 @@ add wave -noupdate /testbenchfp/Y
 add wave -noupdate /testbenchfp/Z
 add wave -noupdate /testbenchfp/Res
 add wave -noupdate /testbenchfp/Ans
+add wave -noupdate /testbenchfp/reset
 add wave -noupdate /testbenchfp/DivStart
 add wave -noupdate /testbenchfp/FDivBusyE
 add wave -noupdate /testbenchfp/CheckNow

--- a/testbench/testbench-fp.sv
+++ b/testbench/testbench-fp.sv
@@ -121,7 +121,8 @@ module testbenchfp;
    logic 			ResMatch;                   // Check if result match
    logic 			FlagMatch;                  // Check if IEEE flags match
    logic 			CheckNow;                   // Final check
-
+   logic 			FMAop;                      // Is this a FMA operation?   
+   
    ///////////////////////////////////////////////////////////////////////////////////////////////
 
    //     ||||||||| |||||||| ||||||| |||||||||   ||||||| |||||||| |||
@@ -944,13 +945,15 @@ module testbenchfp;
       assign ResMatch = ((Res === Ans) | NaNGood | (NaNGood === 1'bx));
       assign FlagMatch = ((ResFlg === AnsFlg) | (AnsFlg === 5'bx));
       assign divsqrtop = (OpCtrlVal == `SQRT_OPCTRL) | (OpCtrlVal == `DIV_OPCTRL);
+      assign FMAop = (OpCtrlVal == `FMAUNIT);  
       assign DivDone = OldFDivBusyE & ~FDivBusyE;
 
-      assign CheckNow = (DivDone | ~divsqrtop) & (UnitVal !== `CVTINTUNIT) & (UnitVal !== `CMPUNIT);
+      // Maybe change OpCtrl but for now just look at TEST for fma test
+      assign CheckNow = ((DivDone | ~divsqrtop) | (TEST == "add" | TEST == "fma" | TEST == "sub")) & (UnitVal !== `CVTINTUNIT) & (UnitVal !== `CMPUNIT);
       if (~(ResMatch & FlagMatch) & CheckNow) begin
 	 errors += 1;
-	 $display("TestNum %d OpCtrl %d", TestNum, OpCtrl[TestNum]);
-	 $display("Error in %s", Tests[TestNum]);
+	 $display("\nError in %s", Tests[TestNum]);
+	 $display("TestNum %d OpCtrl %d", TestNum, OpCtrl[TestNum]);	 
 	 $display("inputs: %h %h %h\nSrcA: %h\n Res: %h %h\n Expected: %h %h", X, Y, Z, SrcA, Res, ResFlg, Ans, AnsFlg);
 	 $stop;
       end


### PR DESCRIPTION
Change to testbench-fp.sv to allow fma to see errors.  Right now, fma or anything related (e.g., add, sub) will not error out on an issue.