### PR TITLE
Decoder improvements

### DIFF
--- a/src/fpu/fctrl.sv
+++ b/src/fpu/fctrl.sv
@@ -101,13 +101,13 @@ module fctrl import cvw::*;  #(parameter cvw_t P) (
       /* verilator lint_off CASEINCOMPLETE */   // default value above has priority so no other default needed
       case(OpD)
         7'b0000111: case(Funct3D)
-                      3'b010:                      ControlsD = `FCTRLW'b1_0_10_00_0xx_0_0_0; // flw
+                      3'b010:                       ControlsD = `FCTRLW'b1_0_10_00_0xx_0_0_0; // flw
                       3'b011:  if (P.D_SUPPORTED)   ControlsD = `FCTRLW'b1_0_10_00_0xx_0_0_0; // fld
                       3'b100:  if (P.Q_SUPPORTED)   ControlsD = `FCTRLW'b1_0_10_00_0xx_0_0_0; // flq
                       3'b001:  if (P.ZFH_SUPPORTED) ControlsD = `FCTRLW'b1_0_10_00_0xx_0_0_0; // flh
                     endcase
         7'b0100111: case(Funct3D)
-                      3'b010:                      ControlsD = `FCTRLW'b0_0_10_00_0xx_0_0_0; // fsw
+                      3'b010:                       ControlsD = `FCTRLW'b0_0_10_00_0xx_0_0_0; // fsw
                       3'b011:  if (P.D_SUPPORTED)   ControlsD = `FCTRLW'b0_0_10_00_0xx_0_0_0; // fsd
                       3'b100:  if (P.Q_SUPPORTED)   ControlsD = `FCTRLW'b0_0_10_00_0xx_0_0_0; // fsq
                       3'b001:  if (P.ZFH_SUPPORTED) ControlsD = `FCTRLW'b0_0_10_00_0xx_0_0_0; // fsh

--- a/src/fpu/fdivsqrt/fdivsqrt.sv
+++ b/src/fpu/fdivsqrt/fdivsqrt.sv
@@ -27,24 +27,24 @@
 ////////////////////////////////////////////////////////////////////////////////////////////////
 
 module fdivsqrt import cvw::*;  #(parameter cvw_t P) (
-  input  logic                clk, 
-  input  logic                reset, 
+  input  logic                 clk, 
+  input  logic                 reset, 
   input  logic [P.FMTBITS-1:0] FmtE,
-  input  logic                XsE,
+  input  logic                 XsE,
   input  logic [P.NF:0]        XmE, YmE,
   input  logic [P.NE-1:0]      XeE, YeE,
-  input  logic                XInfE, YInfE, 
-  input  logic                XZeroE, YZeroE, 
-  input  logic                XNaNE, YNaNE, 
-  input  logic                FDivStartE, IDivStartE,
-  input  logic                StallM,
-  input  logic                FlushE,
-  input  logic                SqrtE, SqrtM,
+  input  logic                 XInfE, YInfE, 
+  input  logic                 XZeroE, YZeroE, 
+  input  logic                 XNaNE, YNaNE, 
+  input  logic                 FDivStartE, IDivStartE,
+  input  logic                 StallM,
+  input  logic                 FlushE,
+  input  logic                 SqrtE, SqrtM,
   input  logic [P.XLEN-1:0]    ForwardedSrcAE, ForwardedSrcBE, // these are the src outputs before the mux choosing between them and PCE to put in srcA/B
-  input  logic [2:0]          Funct3E, Funct3M,
-  input  logic                IntDivE, W64E,
-  output logic                DivStickyM,
-  output logic                FDivBusyE, IFDivStartE, FDivDoneE,
+  input  logic [2:0]           Funct3E, Funct3M,
+  input  logic                 IntDivE, W64E,
+  output logic                 DivStickyM,
+  output logic                 FDivBusyE, IFDivStartE, FDivDoneE,
   output logic [P.NE+1:0]      QeM,
   output logic [P.DIVb:0]      QmM,
   output logic [P.XLEN-1:0]    FIntDivResultM
@@ -58,19 +58,19 @@ module fdivsqrt import cvw::*;  #(parameter cvw_t P) (
   logic [P.DIVb+3:0]           D;                            // Iterator Divisor
   logic [P.DIVb:0]             FirstU, FirstUM;              // Intermediate result values
   logic [P.DIVb+1:0]           FirstC;                       // Step tracker
-  logic                       Firstun;                      // Quotient selection
-  logic                       WZeroE;                       // Early termination flag
+  logic                        Firstun;                      // Quotient selection
+  logic                        WZeroE;                       // Early termination flag
   logic [P.DURLEN-1:0]         CyclesE;                      // FSM cycles
-  logic                       SpecialCaseM;                 // Divide by zero, square root of negative, etc.
-  logic                       DivStartE;                    // Enable signal for flops during stall
+  logic                        SpecialCaseM;                 // Divide by zero, square root of negative, etc.
+  logic                        DivStartE;                    // Enable signal for flops during stall
                                                             
   // Integer div/rem signals                                
-  logic                       BZeroM;                       // Denominator is zero
-  logic                       IntDivM;                      // Integer operation
+  logic                        BZeroM;                       // Denominator is zero
+  logic                        IntDivM;                      // Integer operation
   logic [P.DIVBLEN:0]          nM, mM;                       // Shift amounts
-  logic                       NegQuotM, ALTBM, AsM, W64M;   // Special handling for postprocessor
+  logic                        NegQuotM, ALTBM, AsM, W64M;   // Special handling for postprocessor
   logic [P.XLEN-1:0]           AM;                           // Original Numerator for postprocessor
-  logic                       ISpecialCaseE;                // Integer div/remainder special cases
+  logic                        ISpecialCaseE;                // Integer div/remainder special cases
 
   fdivsqrtpreproc #(P) fdivsqrtpreproc(                          // Preprocessor
     .clk, .IFDivStartE, .Xm(XmE), .Ym(YmE), .Xe(XeE), .Ye(YeE),

--- a/src/fpu/fdivsqrt/fdivsqrtcycles.sv
+++ b/src/fpu/fdivsqrt/fdivsqrtcycles.sv
@@ -28,8 +28,8 @@
 
 module fdivsqrtcycles import cvw::*;  #(parameter cvw_t P) (
   input  logic [P.FMTBITS-1:0] FmtE,
-  input  logic                SqrtE,
-  input  logic                IntDivE,
+  input  logic                 SqrtE,
+  input  logic                 IntDivE,
   input  logic [P.DIVBLEN:0]   nE,
   output logic [P.DURLEN-1:0]  CyclesE
 );

--- a/src/fpu/fdivsqrt/fdivsqrtexpcalc.sv
+++ b/src/fpu/fdivsqrt/fdivsqrtexpcalc.sv
@@ -29,8 +29,8 @@
 module fdivsqrtexpcalc import cvw::*;  #(parameter cvw_t P) (
   input  logic [P.FMTBITS-1:0] Fmt,
   input  logic [P.NE-1:0]      Xe, Ye,
-  input  logic                Sqrt,
-  input  logic                XZero, 
+  input  logic                 Sqrt,
+  input  logic                 XZero, 
   input  logic [P.DIVBLEN:0]   ell, m,
   output logic [P.NE+1:0]      Qe
   );

--- a/src/fpu/fdivsqrt/fdivsqrtfgen2.sv
+++ b/src/fpu/fdivsqrt/fdivsqrtfgen2.sv
@@ -27,17 +27,16 @@
 ////////////////////////////////////////////////////////////////////////////////////////////////
 
 module fdivsqrtfgen2 import cvw::*;  #(parameter cvw_t P) (
-  input  logic             up, uz,
+  input  logic              up, uz,
   input  logic [P.DIVb+3:0] C, U, UM,
   output logic [P.DIVb+3:0] F
 );
-  logic [P.DIVb+3:0] FP, FN, FZ;
+  logic [P.DIVb+3:0]        FP, FN, FZ;
 
   // Generate for both positive and negative bits
   assign FP = ~(U << 1) & C;
   assign FN = (UM << 1) | (C & ~(C << 2));
   assign FZ = '0;
-
 
   always_comb     // Choose which adder input will be used
     if (up)       F = FP;

--- a/src/fpu/fdivsqrt/fdivsqrtfgen4.sv
+++ b/src/fpu/fdivsqrt/fdivsqrtfgen4.sv
@@ -27,11 +27,11 @@
 ////////////////////////////////////////////////////////////////////////////////////////////////
 
 module fdivsqrtfgen4 import cvw::*;  #(parameter cvw_t P) (
-  input  logic [3:0]       udigit,
+  input  logic [3:0]        udigit,
   input  logic [P.DIVb+3:0] C, U, UM,
   output logic [P.DIVb+3:0] F
 );
-  logic [P.DIVb+3:0] F2, F1, F0, FN1, FN2;
+  logic [P.DIVb+3:0]        F2, F1, F0, FN1, FN2;
   
   // Generate for both positive and negative bits
   assign F2  = (~U << 2) & (C << 2);

--- a/src/fpu/fdivsqrt/fdivsqrtfsm.sv
+++ b/src/fpu/fdivsqrt/fdivsqrtfsm.sv
@@ -27,20 +27,20 @@
 ////////////////////////////////////////////////////////////////////////////////////////////////
 
 module fdivsqrtfsm import cvw::*;  #(parameter cvw_t P) (
-  input  logic               clk, reset, 
-  input  logic               XInfE, YInfE, 
-  input  logic               XZeroE, YZeroE, 
-  input  logic               XNaNE, YNaNE, 
-  input  logic               FDivStartE, IDivStartE,
-  input  logic               XsE, WZeroE,
-  input  logic               SqrtE,
-  input  logic               StallM, FlushE,
-  input  logic               IntDivE,
-  input  logic               ISpecialCaseE,
+  input  logic                clk, reset, 
+  input  logic                XInfE, YInfE, 
+  input  logic                XZeroE, YZeroE, 
+  input  logic                XNaNE, YNaNE, 
+  input  logic                FDivStartE, IDivStartE,
+  input  logic                XsE, WZeroE,
+  input  logic                SqrtE,
+  input  logic                StallM, FlushE,
+  input  logic                IntDivE,
+  input  logic                ISpecialCaseE,
   input  logic [P.DURLEN-1:0] CyclesE,
-  output logic               IFDivStartE,
-  output logic               FDivBusyE, FDivDoneE,
-  output logic               SpecialCaseM
+  output logic                IFDivStartE,
+  output logic                FDivBusyE, FDivDoneE,
+  output logic                SpecialCaseM
 );
   
   typedef enum logic [1:0] {IDLE, BUSY, DONE} statetype;

--- a/src/fpu/fdivsqrt/fdivsqrtiter.sv
+++ b/src/fpu/fdivsqrt/fdivsqrtiter.sv
@@ -27,14 +27,14 @@
 ////////////////////////////////////////////////////////////////////////////////////////////////
 
 module fdivsqrtiter import cvw::*;  #(parameter cvw_t P) (
-  input  logic             clk,
-  input  logic             IFDivStartE, 
-  input  logic             FDivBusyE, 
-  input  logic             SqrtE,
+  input  logic              clk,
+  input  logic              IFDivStartE, 
+  input  logic              FDivBusyE, 
+  input  logic              SqrtE,
   input  logic [P.DIVb+3:0] X, D,
   output logic [P.DIVb:0]   FirstU, FirstUM,
   output logic [P.DIVb+1:0] FirstC,
-  output logic             Firstun,
+  output logic              Firstun,
   output logic [P.DIVb+3:0] FirstWS, FirstWC
 );
 
@@ -48,11 +48,11 @@ module fdivsqrtiter import cvw::*;  #(parameter cvw_t P) (
   logic [P.DIVb:0]        UNext[P.DIVCOPIES-1:0];  // U1.b
   logic [P.DIVb:0]        UMNext[P.DIVCOPIES-1:0]; // U1.b
   logic [P.DIVb+1:0]      C[P.DIVCOPIES:0];        // Q2.b
-  logic [P.DIVb+1:0]      initC;                  // Q2.b
+  logic [P.DIVb+1:0]      initC;                   // Q2.b
   logic [P.DIVCOPIES-1:0] un; 
 
-  logic [P.DIVb+3:0]      WSN, WCN;               // Q4.b
-  logic [P.DIVb+3:0]      DBar, D2, DBar2;        // Q4.b
+  logic [P.DIVb+3:0]      WSN, WCN;                // Q4.b
+  logic [P.DIVb+3:0]      DBar, D2, DBar2;         // Q4.b
   logic [P.DIVb+1:0]      NextC;
   logic [P.DIVb:0]        UMux, UMMux;
   logic [P.DIVb:0]        initU, initUM;

--- a/src/fpu/fdivsqrt/fdivsqrtiter.sv
+++ b/src/fpu/fdivsqrt/fdivsqrtiter.sv
@@ -63,7 +63,7 @@ module fdivsqrtiter import cvw::*;  #(parameter cvw_t P) (
   // Otherwise, the divisor is retained and the residual and result
   // are fed back for the next iteration.
  
-  // Residual WS/SC registers/initializaiton mux
+  // Residual WS/SC registers/initialization mux
   mux2   #(P.DIVb+4) wsmux(WS[P.DIVCOPIES], X, IFDivStartE, WSN);
   mux2   #(P.DIVb+4) wcmux(WC[P.DIVCOPIES], '0, IFDivStartE, WCN);
   flopen #(P.DIVb+4) wsreg(clk, FDivBusyE, WSN, WS[0]);

--- a/src/fpu/fdivsqrt/fdivsqrtpostproc.sv
+++ b/src/fpu/fdivsqrt/fdivsqrtpostproc.sv
@@ -27,27 +27,27 @@
 ////////////////////////////////////////////////////////////////////////////////////////////////
 
 module fdivsqrtpostproc import cvw::*;  #(parameter cvw_t P) (
-  input  logic              clk, reset,
-  input  logic              StallM,
+  input  logic               clk, reset,
+  input  logic               StallM,
   input  logic [P.DIVb+3:0]  WS, WC,
   input  logic [P.DIVb+3:0]  D, 
   input  logic [P.DIVb:0]    FirstU, FirstUM, 
   input  logic [P.DIVb+1:0]  FirstC,
-  input  logic              SqrtE,
-  input  logic              Firstun, SqrtM, SpecialCaseM, NegQuotM,
+  input  logic               SqrtE,
+  input  logic               Firstun, SqrtM, SpecialCaseM, NegQuotM,
   input  logic [P.XLEN-1:0]  AM,
-  input  logic              RemOpM, ALTBM, BZeroM, AsM, W64M,
+  input  logic               RemOpM, ALTBM, BZeroM, AsM, W64M,
   input  logic [P.DIVBLEN:0] nM, mM,
   output logic [P.DIVb:0]    QmM, 
-  output logic              WZeroE,
-  output logic              DivStickyM,
+  output logic               WZeroE,
+  output logic               DivStickyM,
   output logic [P.XLEN-1:0]  FIntDivResultM
 );
   
   logic [P.DIVb+3:0]         W, Sum;
   logic [P.DIVb:0]           PreQmM;
-  logic                     NegStickyM;
-  logic                     weq0E, WZeroM;
+  logic                      NegStickyM;
+  logic                      weq0E, WZeroM;
   logic [P.XLEN-1:0]         IntDivResultM;
 
   //////////////////////////

--- a/src/fpu/fdivsqrt/fdivsqrtpreproc.sv
+++ b/src/fpu/fdivsqrt/fdivsqrtpreproc.sv
@@ -27,24 +27,24 @@
 ////////////////////////////////////////////////////////////////////////////////////////////////
 
 module fdivsqrtpreproc import cvw::*;  #(parameter cvw_t P) (
-  input  logic                clk,
-  input  logic                IFDivStartE, 
+  input  logic                 clk,
+  input  logic                 IFDivStartE, 
   input  logic [P.NF:0]        Xm, Ym,
   input  logic [P.NE-1:0]      Xe, Ye,
   input  logic [P.FMTBITS-1:0] FmtE,
-  input  logic                SqrtE,
-  input  logic                XZeroE,
-  input  logic [2:0]          Funct3E,
+  input  logic                 SqrtE,
+  input  logic                 XZeroE,
+  input  logic [2:0]           Funct3E,
   output logic [P.NE+1:0]      QeM,
   output logic [P.DIVb+3:0]    X, D,
   // Int-specific
   input  logic [P.XLEN-1:0]    ForwardedSrcAE, ForwardedSrcBE, // *** these are the src outputs before the mux choosing between them and PCE to put in srcA/B
-  input  logic                IntDivE, W64E,
-  output logic                ISpecialCaseE,
+  input  logic                 IntDivE, W64E,
+  output logic                 ISpecialCaseE,
   output logic [P.DURLEN-1:0]  CyclesE,
   output logic [P.DIVBLEN:0]   nM, mM,
-  output logic                NegQuotM, ALTBM, IntDivM, W64M,
-  output logic                AsM, BZeroM,
+  output logic                 NegQuotM, ALTBM, IntDivM, W64M,
+  output logic                 AsM, BZeroM,
   output logic [P.XLEN-1:0]    AM
 );
 
@@ -54,11 +54,11 @@ module fdivsqrtpreproc import cvw::*;  #(parameter cvw_t P) (
   logic [P.NE+1:0]             QeE;                                 // Quotient Exponent (FP only)
   logic [P.DIVb-1:0]           IFX, IFD;                            // Correctly-sized inputs for iterator, selected from int or fp input
   logic [P.DIVBLEN:0]          mE, nE, ell;                         // Leading zeros of inputs
-  logic                       NumerZeroE;                          // Numerator is zero (X or A)
-  logic                       AZeroE, BZeroE;                      // A or B is Zero for integer division
-  logic                       SignedDivE;                          // signed division
-  logic                       NegQuotE;                            // Integer quotient is negative
-  logic                       AsE, BsE;                            // Signs of integer inputs
+  logic                        NumerZeroE;                          // Numerator is zero (X or A)
+  logic                        AZeroE, BZeroE;                      // A or B is Zero for integer division
+  logic                        SignedDivE;                          // signed division
+  logic                        NegQuotE;                            // Integer quotient is negative
+  logic                        AsE, BsE;                            // Signs of integer inputs
   logic [P.XLEN-1:0]           AE;                                  // input A after W64 adjustment
   logic  ALTBE;
 
@@ -166,7 +166,7 @@ module fdivsqrtpreproc import cvw::*;  #(parameter cvw_t P) (
 
   // Sqrt is initialized on step one as R(X-1), so depends on Radix
   mux2 #(P.DIVb+1) sqrtxmux({~XZeroE, Xfract}, {1'b0, ~XZeroE, Xfract[P.DIVb-1:1]}, (Xe[0] ^ ell[0]), PreSqrtX);
-  if (P.RADIX == 2)  assign SqrtX = {3'b111, PreSqrtX};
+  if (P.RADIX == 2) assign SqrtX = {3'b111, PreSqrtX};
   else              assign SqrtX = {2'b11, PreSqrtX, 1'b0};
   mux2 #(P.DIVb+4) prexmux(DivX, SqrtX, SqrtE, PreShiftX);
   

--- a/src/ieu/datapath.sv
+++ b/src/ieu/datapath.sv
@@ -98,7 +98,7 @@ module datapath import cvw::*;  #(parameter cvw_t P) (
   assign Rs2D      = InstrD[24:20];
   assign RdD       = InstrD[11:7];
   regfile #(P.XLEN, P.E_SUPPORTED) regf(clk, reset, RegWriteW, Rs1D, Rs2D, RdW, ResultW, R1D, R2D);
-  extend  #(P.XLEN, P.A_SUPPORTED) ext(.InstrD(InstrD[31:7]), .ImmSrcD, .ImmExtD);
+  extend #(P)        ext(.InstrD(InstrD[31:7]), .ImmSrcD, .ImmExtD);
  
   // Execute stage pipeline register and logic
   flopenrc #(P.XLEN) RD1EReg(clk, reset, FlushE, ~StallE, R1D, R1E);

--- a/src/ieu/extend.sv
+++ b/src/ieu/extend.sv
@@ -27,28 +27,29 @@
 // and limitations under the License.
 ////////////////////////////////////////////////////////////////////////////////////////////////
 
-module extend #(parameter XLEN, A_SUPPORTED) (
-  input  logic [31:7]       InstrD,      // All instruction bits except opcode (lower 7 bits)
-  input  logic [2:0]        ImmSrcD,     // Select what kind of extension to perform
-  output logic [XLEN-1:0]   ImmExtD);    // Extended immediate
+module extend import cvw::*;  #(parameter cvw_t P) (
+  input  logic [31:7]       InstrD,       // All instruction bits except opcode (lower 7 bits)
+  input  logic [2:0]        ImmSrcD,      // Select what kind of extension to perform
+  output logic [P.XLEN-1:0] ImmExtD);     // Extended immediate
 
-  localparam [XLEN-1:0] undefined = {(XLEN){1'bx}}; // could change to 0 after debug
+  localparam [P.XLEN-1:0] undefined = {(P.XLEN){1'bx}}; // could change to 0 after debug
  
   always_comb
-    case(ImmSrcD) 
+    case (ImmSrcD) 
       // I-type 
-      3'b000:   ImmExtD = {{(XLEN-12){InstrD[31]}}, InstrD[31:20]};  
+      3'b000:   ImmExtD = {{(P.XLEN-12){InstrD[31]}}, InstrD[31:20]};  
       // S-type (stores)
-      3'b001:   ImmExtD = {{(XLEN-12){InstrD[31]}}, InstrD[31:25], InstrD[11:7]}; 
+      3'b001:   ImmExtD = {{(P.XLEN-12){InstrD[31]}}, InstrD[31:25], InstrD[11:7]};
       // B-type (branches)
-      3'b010:   ImmExtD = {{(XLEN-12){InstrD[31]}}, InstrD[7], InstrD[30:25], InstrD[11:8], 1'b0}; 
+      3'b010:   ImmExtD = {{(P.XLEN-12){InstrD[31]}}, InstrD[7], InstrD[30:25], InstrD[11:8], 1'b0}; 
       // J-type (jal)
-      3'b011:   ImmExtD = {{(XLEN-20){InstrD[31]}}, InstrD[19:12], InstrD[20], InstrD[30:21], 1'b0}; 
+      3'b011:   ImmExtD = {{(P.XLEN-20){InstrD[31]}}, InstrD[19:12], InstrD[20], InstrD[30:21], 1'b0}; 
       // U-type (lui, auipc)
-      3'b100:   ImmExtD = {{(XLEN-31){InstrD[31]}}, InstrD[30:12], 12'b0}; 
+      3'b100:   ImmExtD = {{(P.XLEN-31){InstrD[31]}}, InstrD[30:12], 12'b0}; 
       // Store Conditional: zero offset
-      3'b101:  if (A_SUPPORTED) ImmExtD = 0;
+      3'b101:  if (P.A_SUPPORTED) ImmExtD = 0;
                else             ImmExtD = undefined;
       default: ImmExtD = undefined; // undefined
     endcase  
+
 endmodule

--- a/src/ieu/ieu.sv
+++ b/src/ieu/ieu.sv
@@ -45,7 +45,7 @@ module ieu import cvw::*;  #(parameter cvw_t P) (
   output logic [P.XLEN-1:0] ForwardedSrcAE, ForwardedSrcBE,  // ALU src inputs before the mux choosing between them and PCE to put in srcA/B
   output logic [4:0]        RdE,                             // Destination register
   output logic              MDUActiveE,                      // Mul/Div instruction being executed
-  output logic              CMOE,                            // Cache management instruction being executed
+  output logic [3:0]        CMOpE,                           // 1: cbo.inval; 2: cbo.flush; 4: cbo.clean; 8: cbo.zero
   // Memory stage signals
   input  logic              SquashSCW,                       // Squash store conditional, from LSU
   output logic [1:0]        MemRWM,                          // Read/write control goes to LSU
@@ -104,7 +104,7 @@ module ieu import cvw::*;  #(parameter cvw_t P) (
     .IllegalIEUFPUInstrD, .IllegalBaseInstrD, .StallE, .FlushE, .FlagsE, .FWriteIntE,
     .PCSrcE, .ALUSrcAE, .ALUSrcBE, .ALUResultSrcE, .ALUSelectE, .MemReadE, .CSRReadE, 
     .Funct3E, .IntDivE, .MDUE, .W64E, .SubArithE, .BranchD, .BranchE, .JumpD, .JumpE, .SCE, 
-    .BranchSignedE, .BSelectE, .ZBBSelectE, .BALUControlE, .BMUActiveE, .MDUActiveE, .CMOE,
+    .BranchSignedE, .BSelectE, .ZBBSelectE, .BALUControlE, .BMUActiveE, .MDUActiveE, .CMOpE,
     .StallM, .FlushM, .MemRWM, .CSRReadM, .CSRWriteM, .PrivilegedM, .AtomicM, .Funct3M,
     .RegWriteM, .FlushDCacheM, .InstrValidM, .InstrValidE, .InstrValidD, .FWriteIntM,
     .StallW, .FlushW, .RegWriteW, .IntDivW, .ResultSrcW, .CSRWriteFenceM, .InvalidateICacheM, .StoreStallD);

--- a/src/ieu/ieu.sv
+++ b/src/ieu/ieu.sv
@@ -31,6 +31,7 @@ module ieu import cvw::*;  #(parameter cvw_t P) (
   // Decode stage signals
   input  logic [31:0]       InstrD,                          // Instruction
   input  logic [1:0]        STATUS_FS,                       // is FPU enabled?
+  input  logic [3:0]        ENVCFG_CBE,                      // Cache block operation enables
   input  logic              IllegalIEUFPUInstrD,             // Illegal instruction
   output logic              IllegalBaseInstrD,               // Illegal I-type instruction, or illegal RV32 access to upper 16 registers
   // Execute stage signals
@@ -99,7 +100,7 @@ module ieu import cvw::*;  #(parameter cvw_t P) (
   logic       BMUActiveE;                                    // Bit manipulation instruction being executed
            
   controller #(P) c(
-    .clk, .reset, .StallD, .FlushD, .InstrD, .STATUS_FS, .ImmSrcD,
+    .clk, .reset, .StallD, .FlushD, .InstrD, .STATUS_FS, .ENVCFG_CBE, .ImmSrcD,
     .IllegalIEUFPUInstrD, .IllegalBaseInstrD, .StallE, .FlushE, .FlagsE, .FWriteIntE,
     .PCSrcE, .ALUSrcAE, .ALUSrcBE, .ALUResultSrcE, .ALUSelectE, .MemReadE, .CSRReadE, 
     .Funct3E, .IntDivE, .MDUE, .W64E, .SubArithE, .BranchD, .BranchE, .JumpD, .JumpE, .SCE, 

--- a/src/ieu/ieu.sv
+++ b/src/ieu/ieu.sv
@@ -46,6 +46,7 @@ module ieu import cvw::*;  #(parameter cvw_t P) (
   output logic [4:0]        RdE,                             // Destination register
   output logic              MDUActiveE,                      // Mul/Div instruction being executed
   output logic [3:0]        CMOpE,                           // 1: cbo.inval; 2: cbo.flush; 4: cbo.clean; 8: cbo.zero
+  output logic [2:0]        PrefetchE,                       // which prefetch instruction 1: prefetch.i, 2: prefetch.r, 4: prefetch.w
   // Memory stage signals
   input  logic              SquashSCW,                       // Squash store conditional, from LSU
   output logic [1:0]        MemRWM,                          // Read/write control goes to LSU
@@ -104,7 +105,7 @@ module ieu import cvw::*;  #(parameter cvw_t P) (
     .IllegalIEUFPUInstrD, .IllegalBaseInstrD, .StallE, .FlushE, .FlagsE, .FWriteIntE,
     .PCSrcE, .ALUSrcAE, .ALUSrcBE, .ALUResultSrcE, .ALUSelectE, .MemReadE, .CSRReadE, 
     .Funct3E, .IntDivE, .MDUE, .W64E, .SubArithE, .BranchD, .BranchE, .JumpD, .JumpE, .SCE, 
-    .BranchSignedE, .BSelectE, .ZBBSelectE, .BALUControlE, .BMUActiveE, .MDUActiveE, .CMOpE,
+    .BranchSignedE, .BSelectE, .ZBBSelectE, .BALUControlE, .BMUActiveE, .MDUActiveE, .CMOpE, .PrefetchE,
     .StallM, .FlushM, .MemRWM, .CSRReadM, .CSRWriteM, .PrivilegedM, .AtomicM, .Funct3M,
     .RegWriteM, .FlushDCacheM, .InstrValidM, .InstrValidE, .InstrValidD, .FWriteIntM,
     .StallW, .FlushW, .RegWriteW, .IntDivW, .ResultSrcW, .CSRWriteFenceM, .InvalidateICacheM, .StoreStallD);

--- a/src/ieu/ieu.sv
+++ b/src/ieu/ieu.sv
@@ -30,6 +30,7 @@ module ieu import cvw::*;  #(parameter cvw_t P) (
   input  logic              clk, reset,
   // Decode stage signals
   input  logic [31:0]       InstrD,                          // Instruction
+  input  logic [1:0]        STATUS_FS,                       // is FPU enabled?
   input  logic              IllegalIEUFPUInstrD,             // Illegal instruction
   output logic              IllegalBaseInstrD,               // Illegal I-type instruction, or illegal RV32 access to upper 16 registers
   // Execute stage signals
@@ -43,6 +44,7 @@ module ieu import cvw::*;  #(parameter cvw_t P) (
   output logic [P.XLEN-1:0] ForwardedSrcAE, ForwardedSrcBE,  // ALU src inputs before the mux choosing between them and PCE to put in srcA/B
   output logic [4:0]        RdE,                             // Destination register
   output logic              MDUActiveE,                      // Mul/Div instruction being executed
+  output logic              CMOE,                            // Cache management instruction being executed
   // Memory stage signals
   input  logic              SquashSCW,                       // Squash store conditional, from LSU
   output logic [1:0]        MemRWM,                          // Read/write control goes to LSU
@@ -97,11 +99,11 @@ module ieu import cvw::*;  #(parameter cvw_t P) (
   logic       BMUActiveE;                                    // Bit manipulation instruction being executed
            
   controller #(P) c(
-    .clk, .reset, .StallD, .FlushD, .InstrD, .ImmSrcD,
+    .clk, .reset, .StallD, .FlushD, .InstrD, .STATUS_FS, .ImmSrcD,
     .IllegalIEUFPUInstrD, .IllegalBaseInstrD, .StallE, .FlushE, .FlagsE, .FWriteIntE,
     .PCSrcE, .ALUSrcAE, .ALUSrcBE, .ALUResultSrcE, .ALUSelectE, .MemReadE, .CSRReadE, 
     .Funct3E, .IntDivE, .MDUE, .W64E, .SubArithE, .BranchD, .BranchE, .JumpD, .JumpE, .SCE, 
-    .BranchSignedE, .BSelectE, .ZBBSelectE, .BALUControlE, .BMUActiveE, .MDUActiveE,
+    .BranchSignedE, .BSelectE, .ZBBSelectE, .BALUControlE, .BMUActiveE, .MDUActiveE, .CMOE,
     .StallM, .FlushM, .MemRWM, .CSRReadM, .CSRWriteM, .PrivilegedM, .AtomicM, .Funct3M,
     .RegWriteM, .FlushDCacheM, .InstrValidM, .InstrValidE, .InstrValidD, .FWriteIntM,
     .StallW, .FlushW, .RegWriteW, .IntDivW, .ResultSrcW, .CSRWriteFenceM, .InvalidateICacheM, .StoreStallD);

--- a/src/ieu/ieu.sv
+++ b/src/ieu/ieu.sv
@@ -45,8 +45,9 @@ module ieu import cvw::*;  #(parameter cvw_t P) (
   output logic [P.XLEN-1:0] ForwardedSrcAE, ForwardedSrcBE,  // ALU src inputs before the mux choosing between them and PCE to put in srcA/B
   output logic [4:0]        RdE,                             // Destination register
   output logic              MDUActiveE,                      // Mul/Div instruction being executed
-  output logic [3:0]        CMOpE,                           // 1: cbo.inval; 2: cbo.flush; 4: cbo.clean; 8: cbo.zero
-  output logic [2:0]        PrefetchE,                       // which prefetch instruction 1: prefetch.i, 2: prefetch.r, 4: prefetch.w
+  output logic [3:0]        CMOpM,                           // 1: cbo.inval; 2: cbo.flush; 4: cbo.clean; 8: cbo.zero
+  output logic              IFUPrefetchE,                    // instruction prefetch
+  output logic              LSUPrefetchM,                    // datata prefetch
   // Memory stage signals
   input  logic              SquashSCW,                       // Squash store conditional, from LSU
   output logic [1:0]        MemRWM,                          // Read/write control goes to LSU
@@ -105,7 +106,7 @@ module ieu import cvw::*;  #(parameter cvw_t P) (
     .IllegalIEUFPUInstrD, .IllegalBaseInstrD, .StallE, .FlushE, .FlagsE, .FWriteIntE,
     .PCSrcE, .ALUSrcAE, .ALUSrcBE, .ALUResultSrcE, .ALUSelectE, .MemReadE, .CSRReadE, 
     .Funct3E, .IntDivE, .MDUE, .W64E, .SubArithE, .BranchD, .BranchE, .JumpD, .JumpE, .SCE, 
-    .BranchSignedE, .BSelectE, .ZBBSelectE, .BALUControlE, .BMUActiveE, .MDUActiveE, .CMOpE, .PrefetchE,
+    .BranchSignedE, .BSelectE, .ZBBSelectE, .BALUControlE, .BMUActiveE, .MDUActiveE, .CMOpM, .IFUPrefetchE, .LSUPrefetchM,
     .StallM, .FlushM, .MemRWM, .CSRReadM, .CSRWriteM, .PrivilegedM, .AtomicM, .Funct3M,
     .RegWriteM, .FlushDCacheM, .InstrValidM, .InstrValidE, .InstrValidD, .FWriteIntM,
     .StallW, .FlushW, .RegWriteW, .IntDivW, .ResultSrcW, .CSRWriteFenceM, .InvalidateICacheM, .StoreStallD);

--- a/src/privileged/csr.sv
+++ b/src/privileged/csr.sv
@@ -294,17 +294,11 @@ module csr import cvw::*;  #(parameter cvw_t P) (
   assign ENVCFG_PBMTE = MENVCFG_REGW[62]; // page-based memory types enable
   assign ENVCFG_CBE =   (PrivilegeModeW == P.M_MODE) ? 4'b1111 : 
                         (PrivilegeModeW == P.S_MODE | !P.S_SUPPORTED) ? MENVCFG_REGW[7:4] : 
-                                                                       (MSENVCFG_REGW[7:4] & SENVCFG_REGW[7:4]);
+                                                                       (MENVCFG_REGW[7:4] & SENVCFG_REGW[7:4]);
   // FIOM presently doesn't do anything because Wally fences don't do anything
   assign ENVCFG_FIOM =  (PrivilegeModeW == P.M_MODE) ? 1'b1 : 
                         (PrivilegeModeW == P.S_MODE | !P.S_SUPPORTED) ? MENVCFG_REGW[0] : 
                                                                        (MENVCFG_REGW[0] & SENVCFG_REGW[0]);
-
-if (((priv_mode != M) && (menvcfg.CBIE == 00)) ||
-      ((priv_mode == U) && (senvcfg.CBIE == 00)))
-  {
-    <raise illegal instruction exception>
-  }
 
   // merge CSR Reads
   assign CSRReadValM = CSRUReadValM | CSRSReadValM | CSRMReadValM | CSRCReadValM; 

--- a/src/privileged/csr.sv
+++ b/src/privileged/csr.sv
@@ -293,9 +293,18 @@ module csr import cvw::*;  #(parameter cvw_t P) (
   assign ENVCFG_STCE =  MENVCFG_REGW[63]; // supervisor timer counter enable
   assign ENVCFG_PBMTE = MENVCFG_REGW[62]; // page-based memory types enable
   assign ENVCFG_CBE =   (PrivilegeModeW == P.M_MODE) ? 4'b1111 : 
-                        (PrivilegeModeW == P.S_MODE | !P.S_SUPPORTED) ? MENVCFG_REGW[7:4] : SENVCFG_REGW[7:4];
+                        (PrivilegeModeW == P.S_MODE | !P.S_SUPPORTED) ? MENVCFG_REGW[7:4] : 
+                                                                       (MSENVCFG_REGW[7:4] & SENVCFG_REGW[7:4]);
+  // FIOM presently doesn't do anything because Wally fences don't do anything
   assign ENVCFG_FIOM =  (PrivilegeModeW == P.M_MODE) ? 1'b1 : 
-                        (PrivilegeModeW == P.S_MODE | !P.S_SUPPORTED) ? MENVCFG_REGW[0] : SENVCFG_REGW[0];
+                        (PrivilegeModeW == P.S_MODE | !P.S_SUPPORTED) ? MENVCFG_REGW[0] : 
+                                                                       (MENVCFG_REGW[0] & SENVCFG_REGW[0]);
+
+if (((priv_mode != M) && (menvcfg.CBIE == 00)) ||
+      ((priv_mode == U) && (senvcfg.CBIE == 00)))
+  {
+    <raise illegal instruction exception>
+  }
 
   // merge CSR Reads
   assign CSRReadValM = CSRUReadValM | CSRSReadValM | CSRMReadValM | CSRCReadValM; 

--- a/src/privileged/csr.sv
+++ b/src/privileged/csr.sv
@@ -84,6 +84,7 @@ module csr import cvw::*;  #(parameter cvw_t P) (
   output var logic [7:0]           PMPCFG_ARRAY_REGW[P.PMP_ENTRIES-1:0],
   output var logic [P.PA_BITS-3:0] PMPADDR_ARRAY_REGW[P.PMP_ENTRIES-1:0],
   output logic [2:0]               FRM_REGW, 
+  output logic [3:0]               ENVCFG_CBE,
   //
   output logic [P.XLEN-1:0]        CSRReadValW,               // value read from CSR
   output logic [P.XLEN-1:0]        UnalignedPCNextF,          // Next PC, accounting for traps and returns
@@ -123,7 +124,11 @@ module csr import cvw::*;  #(parameter cvw_t P) (
   logic [P.XLEN-1:0]       TVecAlignedM;
   logic                    InstrValidNotFlushedM;
   logic                    STimerInt;
-  logic                    MENVCFG_STCE;
+  logic [63:0]             MENVCFG_REGW;
+  logic [P.XLEN-1:0]       SENVCFG_REGW;
+  logic                    ENVCFG_STCE; // supervisor timer counter enable
+  logic                    ENVCFG_PBMTE; // page-based memory types enable
+  logic                    ENVCFG_FIOM; // fence implies io (presently not used)
 
   // only valid unflushed instructions can access CSRs
   assign InstrValidNotFlushedM = InstrValidM & ~StallW & ~FlushW;
@@ -214,7 +219,7 @@ module csr import cvw::*;  #(parameter cvw_t P) (
   csri #(P) csri(.clk, .reset,  
     .CSRMWriteM, .CSRSWriteM, .CSRWriteValM, .CSRAdrM, 
     .MExtInt, .SExtInt, .MTimerInt, .STimerInt, .MSwInt,
-    .MIDELEG_REGW, .MENVCFG_STCE, .MIP_REGW, .MIE_REGW, .MIP_REGW_writeable);
+    .MIDELEG_REGW, .ENVCFG_STCE, .MIP_REGW, .MIE_REGW, .MIP_REGW_writeable);
 
   csrsr #(P) csrsr(.clk, .reset, .StallW, 
     .WriteMSTATUSM, .WriteMSTATUSHM, .WriteSSTATUSM, 
@@ -233,10 +238,12 @@ module csr import cvw::*;  #(parameter cvw_t P) (
     .MEDELEG_REGW, .MIDELEG_REGW,.PMPCFG_ARRAY_REGW, .PMPADDR_ARRAY_REGW,
     .MIP_REGW, .MIE_REGW, .WriteMSTATUSM, .WriteMSTATUSHM,
     .IllegalCSRMAccessM, .IllegalCSRMWriteReadonlyM,
-    .MENVCFG_STCE);
+    .MENVCFG_REGW);
 
 
   if (P.S_SUPPORTED) begin:csrs
+    logic STCE; 
+    assign STCE = P.SSTC_SUPPORTED & (PrivilegeModeW == P.M_MODE | (MCOUNTEREN_REGW[1] & ENVCFG_STCE));
     csrs #(P) csrs(.clk, .reset,
       .CSRSWriteM, .STrapM, .CSRAdrM,
       .NextEPCM, .NextCauseM, .NextMtvalM, .SSTATUS_REGW, 
@@ -244,8 +251,8 @@ module csr import cvw::*;  #(parameter cvw_t P) (
       .CSRWriteValM, .PrivilegeModeW,
       .CSRSReadValM, .STVEC_REGW, .SEPC_REGW,      
       .SCOUNTEREN_REGW,
-      .SATP_REGW, .MIP_REGW, .MIE_REGW, .MIDELEG_REGW, .MTIME_CLINT, .MENVCFG_STCE,
-      .WriteSSTATUSM, .IllegalCSRSAccessM, .STimerInt);
+      .SATP_REGW, .MIP_REGW, .MIE_REGW, .MIDELEG_REGW, .MTIME_CLINT, .STCE,
+      .WriteSSTATUSM, .IllegalCSRSAccessM, .STimerInt, .SENVCFG_REGW);
   end else begin
     assign WriteSSTATUSM = 0;
     assign CSRSReadValM = 0;
@@ -281,6 +288,14 @@ module csr import cvw::*;  #(parameter cvw_t P) (
     assign CSRCReadValM = 0;
     assign IllegalCSRCAccessM = 1; // counters aren't enabled
   end
+
+   // Broadcast appropriate environment configuration based on privilege mode
+  assign ENVCFG_STCE =  MENVCFG_REGW[63]; // supervisor timer counter enable
+  assign ENVCFG_PBMTE = MENVCFG_REGW[62]; // page-based memory types enable
+  assign ENVCFG_CBE =   (PrivilegeModeW == P.M_MODE) ? 4'b1111 : 
+                        (PrivilegeModeW == P.S_MODE | !P.S_SUPPORTED) ? MENVCFG_REGW[7:4] : SENVCFG_REGW[7:4];
+  assign ENVCFG_FIOM =  (PrivilegeModeW == P.M_MODE) ? 1'b1 : 
+                        (PrivilegeModeW == P.S_MODE | !P.S_SUPPORTED) ? MENVCFG_REGW[0] : SENVCFG_REGW[0];
 
   // merge CSR Reads
   assign CSRReadValM = CSRUReadValM | CSRSReadValM | CSRMReadValM | CSRCReadValM; 

--- a/src/privileged/csri.sv
+++ b/src/privileged/csri.sv
@@ -34,7 +34,7 @@ module csri import cvw::*;  #(parameter cvw_t P) (
   input  logic [11:0]       CSRAdrM,
   input  logic              MExtInt, SExtInt, MTimerInt, STimerInt, MSwInt,
   input  logic [11:0]       MIDELEG_REGW,
-  input  logic              MENVCFG_STCE,
+  input  logic              ENVCFG_STCE,
   output logic [11:0]       MIP_REGW, MIE_REGW,
   output logic [11:0]       MIP_REGW_writeable // only SEIP, STIP, SSIP are actually writeable; the rest are hardwired to 0
 );
@@ -61,7 +61,7 @@ module csri import cvw::*;  #(parameter cvw_t P) (
   if (P.S_SUPPORTED) begin:mask
     if (P.SSTC_SUPPORTED) begin
       assign MIP_WRITE_MASK = 12'h202; // SEIP and SSIP are writable, but STIP is not writable when STIMECMP is implemented (see SSTC spec)
-      assign STIP = MENVCFG_STCE ? STimerInt : MIP_REGW_writeable[5];
+      assign STIP = ENVCFG_STCE ? STimerInt : MIP_REGW_writeable[5];
     end else begin
       assign MIP_WRITE_MASK = 12'h222; // SEIP, STIP, SSIP are writeable in MIP (20210108-draft 3.1.9)
       assign STIP = MIP_REGW_writeable[5];

--- a/src/privileged/csrm.sv
+++ b/src/privileged/csrm.sv
@@ -48,12 +48,11 @@ module csrm  import cvw::*;  #(parameter cvw_t P) (
   output var logic [P.PA_BITS-3:0] PMPADDR_ARRAY_REGW [P.PMP_ENTRIES-1:0],
   output logic                     WriteMSTATUSM, WriteMSTATUSHM,
   output logic                     IllegalCSRMAccessM, IllegalCSRMWriteReadonlyM,
-  output logic                     MENVCFG_STCE
+  output logic [63:0]              MENVCFG_REGW
 );
 
   logic [P.XLEN-1:0]               MISA_REGW, MHARTID_REGW;
   logic [P.XLEN-1:0]               MSCRATCH_REGW, MTVAL_REGW, MCAUSE_REGW;
-  logic [63:0]                     MENVCFG_REGW;
   logic [P.XLEN-1:0]               MENVCFGH_REGW;
   logic [63:0]                     MENVCFG_PreWriteValM, MENVCFG_WriteValM;
   logic                            WriteMTVECM, WriteMEDELEGM, WriteMIDELEGM;
@@ -192,15 +191,6 @@ module csrm  import cvw::*;  #(parameter cvw_t P) (
     flopenr #(P.XLEN) MENVCFGHreg(clk, reset, WriteMENVCFGHM, MENVCFG_WriteValM[63:32], MENVCFG_REGW[63:32]);
     assign MENVCFGH_REGW = MENVCFG_REGW[63:32];
   end
-
-  // Extract bit fields
-  assign MENVCFG_STCE =  MENVCFG_REGW[63];
-  // Uncomment these other fields when they are defined
-  // assign MENVCFG_PBMTE = MENVCFG_REGW[62];
-  // assign MENVCFG_CBZE  = MENVCFG_REGW[7];
-  // assign MENVCFG_CBCFE = MENVCFG_REGW[6];
-  // assign MENVCFG_CBIE  = MENVCFG_REGW[5:4];
-  // assign MENVCFG_FIOM  = MENVCFG_REGW[0];
 
   // Read machine mode CSRs
   // verilator lint_off WIDTH

--- a/src/privileged/csrm.sv
+++ b/src/privileged/csrm.sv
@@ -197,10 +197,10 @@ module csrm  import cvw::*;  #(parameter cvw_t P) (
   assign MENVCFG_STCE =  MENVCFG_REGW[63];
   // Uncomment these other fields when they are defined
   // assign MENVCFG_PBMTE = MENVCFG_REGW[62];
-  // assign MENVCFG_CBZE  =  MENVCFG_REGW[7];
+  // assign MENVCFG_CBZE  = MENVCFG_REGW[7];
   // assign MENVCFG_CBCFE = MENVCFG_REGW[6];
-  // assign MENVCFG_CBIE  =  MENVCFG_REGW[5:4];
-  // assign MENVCFG_FIOM  =  MENVCFG_REGW[0];
+  // assign MENVCFG_CBIE  = MENVCFG_REGW[5:4];
+  // assign MENVCFG_FIOM  = MENVCFG_REGW[0];
 
   // Read machine mode CSRs
   // verilator lint_off WIDTH

--- a/src/privileged/privileged.sv
+++ b/src/privileged/privileged.sv
@@ -82,6 +82,7 @@ module privileged import cvw::*;  #(parameter cvw_t P) (
   output var logic [7:0]    PMPCFG_ARRAY_REGW[P.PMP_ENTRIES-1:0],           // PMP configuration entries to MMU
   output var logic [P.PA_BITS-3:0] PMPADDR_ARRAY_REGW [P.PMP_ENTRIES-1:0],  // PMP address entries to MMU
   output logic [2:0]        FRM_REGW,                                       // FPU rounding mode
+  output logic [3:0]        ENVCFG_CBE,                                     // Cache block operation enables
   // PC logic output in privileged unit                                    
   output logic [P.XLEN-1:0] UnalignedPCNextF,                               // Next PC from trap/return PC logic
   // control outputs                                                       
@@ -136,7 +137,7 @@ module privileged import cvw::*;  #(parameter cvw_t P) (
     .STATUS_MIE, .STATUS_SIE, .STATUS_MXR, .STATUS_SUM, .STATUS_MPRV, .STATUS_TW, .STATUS_FS,
     .MEDELEG_REGW, .MIP_REGW, .MIE_REGW, .MIDELEG_REGW,
     .SATP_REGW, .PMPCFG_ARRAY_REGW, .PMPADDR_ARRAY_REGW,
-    .SetFflagsM, .FRM_REGW, 
+    .SetFflagsM, .FRM_REGW, .ENVCFG_CBE,
     .CSRReadValW,.UnalignedPCNextF, .IllegalCSRAccessM, .BigEndianM);
 
   // pipeline early-arriving trap sources

--- a/src/wally/wallypipelinedcore.sv
+++ b/src/wally/wallypipelinedcore.sv
@@ -78,7 +78,7 @@ module wallypipelinedcore import cvw::*; #(parameter cvw_t P) (
   logic                          LoadStallD, StoreStallD, MDUStallD, CSRRdStallD;
   logic                          SquashSCW;
   logic                          MDUActiveE;                      // Mul/Div instruction being executed
-  logic                          CMOE;                            // Cache management instruction being executed
+  logic [3:0]                    CMOpE;                           // 1: cbo.inval; 2: cbo.flush; 4: cbo.clean; 8: cbo.zero
   logic [3:0]                    ENVCFG_CBE;                      // Cache block operation enables
 
   // floating point unit signals
@@ -193,7 +193,7 @@ module wallypipelinedcore import cvw::*; #(parameter cvw_t P) (
      .InstrD, .STATUS_FS, .ENVCFG_CBE, .IllegalIEUFPUInstrD, .IllegalBaseInstrD,
      // Execute Stage interface
      .PCE, .PCLinkE, .FWriteIntE, .FCvtIntE, .IEUAdrE, .IntDivE, .W64E,
-     .Funct3E, .ForwardedSrcAE, .ForwardedSrcBE, .MDUActiveE, .CMOE,
+     .Funct3E, .ForwardedSrcAE, .ForwardedSrcBE, .MDUActiveE, .CMOpE,
      // Memory stage interface
      .SquashSCW,  // from LSU
      .MemRWM,     // read/write control goes to LSU

--- a/src/wally/wallypipelinedcore.sv
+++ b/src/wally/wallypipelinedcore.sv
@@ -78,6 +78,7 @@ module wallypipelinedcore import cvw::*; #(parameter cvw_t P) (
   logic                          LoadStallD, StoreStallD, MDUStallD, CSRRdStallD;
   logic                          SquashSCW;
   logic                          MDUActiveE;                      // Mul/Div instruction being executed
+  logic                          CMOE;                            // Cache management instruction being executed
 
   // floating point unit signals
   logic [2:0]                    FRM_REGW;
@@ -188,10 +189,10 @@ module wallypipelinedcore import cvw::*; #(parameter cvw_t P) (
   // integer execution unit: integer register file, datapath and controller
   ieu #(P) ieu(.clk, .reset,
      // Decode Stage interface
-     .InstrD, .IllegalIEUFPUInstrD, .IllegalBaseInstrD,
+     .InstrD, .STATUS_FS, .IllegalIEUFPUInstrD, .IllegalBaseInstrD,
      // Execute Stage interface
      .PCE, .PCLinkE, .FWriteIntE, .FCvtIntE, .IEUAdrE, .IntDivE, .W64E,
-     .Funct3E, .ForwardedSrcAE, .ForwardedSrcBE, .MDUActiveE,
+     .Funct3E, .ForwardedSrcAE, .ForwardedSrcBE, .MDUActiveE, .CMOE,
      // Memory stage interface
      .SquashSCW,  // from LSU
      .MemRWM,     // read/write control goes to LSU

--- a/src/wally/wallypipelinedcore.sv
+++ b/src/wally/wallypipelinedcore.sv
@@ -78,9 +78,9 @@ module wallypipelinedcore import cvw::*; #(parameter cvw_t P) (
   logic                          LoadStallD, StoreStallD, MDUStallD, CSRRdStallD;
   logic                          SquashSCW;
   logic                          MDUActiveE;                      // Mul/Div instruction being executed
-  logic [3:0]                    CMOpE;                           // 1: cbo.inval; 2: cbo.flush; 4: cbo.clean; 8: cbo.zero
-  logic [2:0]                    PrefetchE;                       // 1: prefetch.i, 2: prefetch.r, 4: prefetch.w
-  logic [3:0]                    ENVCFG_CBE;                      // Cache block operation enables
+  logic [3:0]                    ENVCFG_CBE;                      // Cache Block operation enables
+  logic [3:0]                    CMOpM;                           // 1: cbo.inval; 2: cbo.flush; 4: cbo.clean; 8: cbo.zero
+  logic                          IFUPrefetchE, LSUPrefetchM;      // instruction / data prefetch hints
 
   // floating point unit signals
   logic [2:0]                    FRM_REGW;
@@ -194,7 +194,7 @@ module wallypipelinedcore import cvw::*; #(parameter cvw_t P) (
      .InstrD, .STATUS_FS, .ENVCFG_CBE, .IllegalIEUFPUInstrD, .IllegalBaseInstrD,
      // Execute Stage interface
      .PCE, .PCLinkE, .FWriteIntE, .FCvtIntE, .IEUAdrE, .IntDivE, .W64E,
-     .Funct3E, .ForwardedSrcAE, .ForwardedSrcBE, .MDUActiveE, .CMOpE, .PrefetchE,
+     .Funct3E, .ForwardedSrcAE, .ForwardedSrcBE, .MDUActiveE, .CMOpM, .IFUPrefetchE, .LSUPrefetchM,
      // Memory stage interface
      .SquashSCW,  // from LSU
      .MemRWM,     // read/write control goes to LSU
@@ -218,7 +218,7 @@ module wallypipelinedcore import cvw::*; #(parameter cvw_t P) (
     .MemRWM, .Funct3M, .Funct7M(InstrM[31:25]), .AtomicM,
     .CommittedM, .DCacheMiss, .DCacheAccess, .SquashSCW,            
     .FpLoadStoreM, .FWriteDataM, .IEUAdrE, .IEUAdrM, .WriteDataM,
-    .ReadDataW, .FlushDCacheM,
+    .ReadDataW, .FlushDCacheM, .CMOpM, .LSUPrefetchM,
     // connected to ahb (all stay the same)
     .LSUHADDR,  .HRDATA, .LSUHWDATA, .LSUHWSTRB, .LSUHSIZE, 
     .LSUHBURST, .LSUHTRANS, .LSUHWRITE, .LSUHREADY,

--- a/src/wally/wallypipelinedcore.sv
+++ b/src/wally/wallypipelinedcore.sv
@@ -79,6 +79,7 @@ module wallypipelinedcore import cvw::*; #(parameter cvw_t P) (
   logic                          SquashSCW;
   logic                          MDUActiveE;                      // Mul/Div instruction being executed
   logic [3:0]                    CMOpE;                           // 1: cbo.inval; 2: cbo.flush; 4: cbo.clean; 8: cbo.zero
+  logic [2:0]                    PrefetchE;                       // 1: prefetch.i, 2: prefetch.r, 4: prefetch.w
   logic [3:0]                    ENVCFG_CBE;                      // Cache block operation enables
 
   // floating point unit signals
@@ -193,7 +194,7 @@ module wallypipelinedcore import cvw::*; #(parameter cvw_t P) (
      .InstrD, .STATUS_FS, .ENVCFG_CBE, .IllegalIEUFPUInstrD, .IllegalBaseInstrD,
      // Execute Stage interface
      .PCE, .PCLinkE, .FWriteIntE, .FCvtIntE, .IEUAdrE, .IntDivE, .W64E,
-     .Funct3E, .ForwardedSrcAE, .ForwardedSrcBE, .MDUActiveE, .CMOpE,
+     .Funct3E, .ForwardedSrcAE, .ForwardedSrcBE, .MDUActiveE, .CMOpE, .PrefetchE,
      // Memory stage interface
      .SquashSCW,  // from LSU
      .MemRWM,     // read/write control goes to LSU

--- a/src/wally/wallypipelinedcore.sv
+++ b/src/wally/wallypipelinedcore.sv
@@ -79,6 +79,7 @@ module wallypipelinedcore import cvw::*; #(parameter cvw_t P) (
   logic                          SquashSCW;
   logic                          MDUActiveE;                      // Mul/Div instruction being executed
   logic                          CMOE;                            // Cache management instruction being executed
+  logic [3:0]                    ENVCFG_CBE;                      // Cache block operation enables
 
   // floating point unit signals
   logic [2:0]                    FRM_REGW;
@@ -189,7 +190,7 @@ module wallypipelinedcore import cvw::*; #(parameter cvw_t P) (
   // integer execution unit: integer register file, datapath and controller
   ieu #(P) ieu(.clk, .reset,
      // Decode Stage interface
-     .InstrD, .STATUS_FS, .IllegalIEUFPUInstrD, .IllegalBaseInstrD,
+     .InstrD, .STATUS_FS, .ENVCFG_CBE, .IllegalIEUFPUInstrD, .IllegalBaseInstrD,
      // Execute Stage interface
      .PCE, .PCLinkE, .FWriteIntE, .FCvtIntE, .IEUAdrE, .IntDivE, .W64E,
      .Funct3E, .ForwardedSrcAE, .ForwardedSrcBE, .MDUActiveE, .CMOE,
@@ -290,9 +291,9 @@ module wallypipelinedcore import cvw::*; #(parameter cvw_t P) (
       .MTIME_CLINT, .IEUAdrM, .SetFflagsM,
       .InstrAccessFaultF, .HPTWInstrAccessFaultF, .LoadAccessFaultM, .StoreAmoAccessFaultM, .SelHPTW,
       .PrivilegeModeW, .SATP_REGW,
-      .STATUS_MXR, .STATUS_SUM, .STATUS_MPRV, .STATUS_MPP, .STATUS_FS,
+      .STATUS_MXR, .STATUS_SUM, .STATUS_MPRV, .STATUS_MPP, .STATUS_FS, 
       .PMPCFG_ARRAY_REGW, .PMPADDR_ARRAY_REGW, 
-      .FRM_REGW,.BreakpointFaultM, .EcallFaultM, .wfiM, .IntPendingM, .BigEndianM);
+      .FRM_REGW, .ENVCFG_CBE, .BreakpointFaultM, .EcallFaultM, .wfiM, .IntPendingM, .BigEndianM);
   end else begin
     assign CSRReadValW      = 0;
     assign UnalignedPCNextF = PC2NextF;

--- a/testbench/common/instrNameDecTB.sv
+++ b/testbench/common/instrNameDecTB.sv
@@ -30,13 +30,14 @@ module instrNameDecTB(
   logic [2:0] funct3;
   logic [6:0] funct7;
   logic [11:0] imm;
-  logic [4:0] rs2;
+  logic [4:0] rs2, rd;
 
   assign op = instr[6:0];
   assign funct3 = instr[14:12];
   assign funct7 = instr[31:25];
   assign imm = instr[31:20];
   assign rs2 = instr[24:20];
+  assign rd = instr[11:7];
 
   // it would be nice to add the operands to the name 
   // create another variable called decoded
@@ -77,7 +78,10 @@ module instrNameDecTB(
                        else if (funct7[6:1] == 6'b010010) name = "BEXTI";
                        else if (funct7 == 7'b0010100 & rs2 == 5'b00111) name = "ORC.B";
                        else                           name = "ILLEGAL"; 
-      10'b0010011_110: name = "ORI";
+      10'b0010011_110: if      (rd == 0 & rs2 == 0) name = "PREFETCH.I";
+                       else if (rd == 0 & rs2 == 1) name = "PREFETCH.R";
+                       else if (rd == 0 & rs2 == 3) name = "PREFETCH.W";
+                       else                         name = "ORI";
       10'b0010011_111: name = "ANDI";
       10'b0010111_???: name = "AUIPC";
       10'b0100011_000: name = "SB";
@@ -215,7 +219,13 @@ module instrNameDecTB(
                        else if (funct7[6:2] == 5'b11000) name = "AMOMINU.D";
                        else if (funct7[6:2] == 5'b11100) name = "AMOMAXU.D";
                        else                              name = "ILLEGAL";
-      10'b0001111_???: name = "FENCE";
+      10'b0001111_000: name = "FENCE";
+      10'b0001111_001: name = "FENCE.I";
+      10'b0001111_010: if      (instr[31:20] == 12'd0) name = "CBO.INVAL";
+                       else if (instr[31:20] == 12'd1) name = "CBO.CLEAN";
+                       else if (instr[31:20] == 12'd2) name = "CBO.FLUSH";
+                       else if (instr[31:20] == 12'd4) name = "CBO.ZERO";    
+                       else                            name = "ILLEGAL";                   
       10'b1000011_???: name = "FMADD";
       10'b1000111_???: name = "FMSUB";
       10'b1001011_???: name = "FNMSUB";

--- a/testbench/common/ramxdetector.sv
+++ b/testbench/common/ramxdetector.sv
@@ -1,0 +1,45 @@
+///////////////////////////////////////////
+// ramxdetector.sv
+//
+// Written: David_Harris@hmc.edu
+// Modified: 2 July 2023
+//
+// Purpose: Detects if the processor is attempting to read unitialized RAM
+// 
+// A component of the Wally configurable RISC-V project.
+// 
+// Copyright (C) 2021 Harvey Mudd College & Oklahoma State University
+//
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+//
+// Licensed under the Solderpad Hardware License v 2.1 (the “License”); you may not use this file 
+// except in compliance with the License, or, at your option, the Apache License version 2.0. You 
+// may obtain a copy of the License at
+//
+// https://solderpad.org/licenses/SHL-2.1/
+//
+// Unless required by applicable law or agreed to in writing, any work distributed under the 
+// License is distributed on an “AS IS” BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, 
+// either express or implied. See the License for the specific language governing permissions 
+// and limitations under the License.
+////////////////////////////////////////////////////////////////////////////////////////////////
+
+module ramxdetector #(parameter XLEN, LLEN) (
+  input  logic            clk,
+  input  logic            MemReadM,
+  input  logic            LSULoadAccessFaultM,
+  input  logic [LLEN-1:0] ReadDataM,
+  input  logic [XLEN-1:0] PCM,
+  input  logic [31:0]     InstrM,
+  input  logic [XLEN-1:0] IEUAdrM,
+  input  string           InstrMName
+);
+
+  always_ff @(posedge clk)
+    if (MemReadM & ~LSULoadAccessFaultM & (ReadDataM === 'bx)) begin
+      $display("WARNING: Attempting to read from unitialized RAM.  Processor may go haywire if it uses x value. But this is normal in WALLY-mmu tests.");
+      $display("  PCM = %x InstrM = %x (%s), IEUAdrM = %x", PCM, InstrM, InstrMName, IEUAdrM);
+      //$stop;
+    end
+  
+endmodule

--- a/testbench/common/riscvassertions.sv
+++ b/testbench/common/riscvassertions.sv
@@ -58,6 +58,9 @@ module riscvassertions import cvw::*; #(parameter cvw_t P);
     assert ((P.ZMMUL_SUPPORTED == 0) || (P.M_SUPPORTED ==0)) else $error("At most one of ZMMUL_SUPPORTED and M_SUPPORTED can be enabled");
     assert ((P.ZICNTR_SUPPORTED == 0) || (P.ZICSR_SUPPORTED == 1)) else $error("ZICNTR_SUPPORTED requires ZICSR_SUPPORTED");
     assert ((P.ZIHPM_SUPPORTED == 0) || (P.ZICNTR_SUPPORTED == 1)) else $error("ZIPHM_SUPPORTED requires ZICNTR_SUPPORTED");
+    assert ((P.ZICBOM_SUPPORTED == 0) || (P.DCACHE_SUPPORTED == 1)) else $error("ZICBOM required DCACHE_SUPPORTED");
+    assert ((P.ZICBOZ_SUPPORTED == 0) || (P.DCACHE_SUPPORTED == 1)) else $error("ZICBOZ required DCACHE_SUPPORTED");
+    assert ((P.ZICBOP_SUPPORTED == 0) || (P.DCACHE_SUPPORTED == 1)) else $error("ZICBOP required DCACHE_SUPPORTED");
   end
 
 endmodule

--- a/testbench/tests.vh
+++ b/testbench/tests.vh
@@ -2031,8 +2031,8 @@ string arch64zbs[] = '{
     "rv32i_m/privilege/src/WALLY-mie-01.S",
     "rv32i_m/privilege/src/WALLY-minfo-01.S",
     "rv32i_m/privilege/src/WALLY-misa-01.S",
-//    "rv32i_m/privilege/src/WALLY-mmu-sv32-01.S",
-    "rv32i_m/privilege/src/WALLY-mmu-sv32-svadu-01.S",
+    // "rv32i_m/privilege/src/WALLY-mmu-sv32-01.S",    // run this if SVADU_SUPPORTED = 0
+    "rv32i_m/privilege/src/WALLY-mmu-sv32-svadu-01.S", // run this if SVADU_SUPPORTED = 1
     "rv32i_m/privilege/src/WALLY-mtvec-01.S",
     "rv32i_m/privilege/src/WALLY-pma-01.S",
     "rv32i_m/privilege/src/WALLY-pmp-01.S",


### PR DESCRIPTION
Significantly improved detection of illegal instructions, including unsupported Cache Management Operations instructions (per Imperas bug report)

Added initial support for CMOE coming out of the IEU.  Ross can use these to implement CMO.  Cache needs to look at Instr[22:20] to determine which type of CMO instruction.