### PR TITLE
Progress toward DC synthesis

### DIFF
--- a/src/fpu/fdivsqrt/fdivsqrtqsel4cmp.sv
+++ b/src/fpu/fdivsqrt/fdivsqrtqsel4cmp.sv
@@ -81,9 +81,9 @@ module fdivsqrtqsel4cmp (
  
   // Compare residual W to selection constants to choose digit
   always_comb 
-    if ($signed(Wmsbs) >= $signed(mk2)) udigit = 4'b1000; // choose 2
-    else if ($signed(Wmsbs) >= $signed(mk1)) udigit = 4'b0100; // choose 1
-    else if ($signed(Wmsbs) >= $signed(mk0)) udigit = 4'b0000; // choose 0
+    if      ($signed(Wmsbs) >= $signed(mk2))  udigit = 4'b1000; // choose 2
+    else if ($signed(Wmsbs) >= $signed(mk1))  udigit = 4'b0100; // choose 1
+    else if ($signed(Wmsbs) >= $signed(mk0))  udigit = 4'b0000; // choose 0
     else if ($signed(Wmsbs) >= $signed(mkm1)) udigit = 4'b0010; // choose -1
-    else udigit = 4'b0001; // choose -2  
+    else                                      udigit = 4'b0001; // choose -2  
 endmodule

--- a/synthDC/Makefile
+++ b/synthDC/Makefile
@@ -44,7 +44,7 @@ DIRS = $(DIRS32) $(DIRS64)
 # bpred:
 # 	@$(foreach kval, $(k), rm -rf $(CONFIGDIR)/rv64gc_bpred_$(kval);)
 # 	@$(foreach kval, $(k), cp -r $(CONFIGDIR)/rv64gc $(CONFIGDIR)/rv64gc_bpred_$(kval);)
-# 	@$(foreach kval, $(k), sed -i 's/BPRED_SIZE.*/BPRED_SIZE $(kval)/g' $(CONFIGDIR)/rv64gc_bpred_$(kval)/wally-config.vh;)
+# 	@$(foreach kval, $(k), sed -i 's/BPRED_SIZE.*/BPRED_SIZE $(kval)/g' $(CONFIGDIR)/rv64gc_bpred_$(kval)/config.vh;)
 # 	@$(foreach kval, $(k), make synth DESIGN=wallypipelinedcore CONFIG=rv64gc_bpred_$(kval) TECH=sky90 FREQ=500 MAXCORES=4 --jobs;)
 
 configs: $(CONFIG)
@@ -55,11 +55,11 @@ $(CONFIG):
 
 # adjust DTIM and IROM to reasonable values depending on config	
 ifneq ($(filter $(CONFIG), $(DIRS32)),)
-	sed -i "s/DTIM_RANGE.*/DTIM_RANGE	 34\'h01FF/g" $(CONFIGDIR)/wally-config.vh
-	sed -i "s/IROM_RANGE.*/IROM_RANGE	 34\'h01FF/g" $(CONFIGDIR)/wally-config.vh
+	sed -i "s/DTIM_RANGE.*/DTIM_RANGE	 34\'h01FF/g" $(CONFIGDIR)/config.vh
+	sed -i "s/IROM_RANGE.*/IROM_RANGE	 34\'h01FF/g" $(CONFIGDIR)/config.vh
 else ifneq ($(filter $(CONFIG), $(DIRS64)),)
-	sed -i "s/DTIM_RANGE.*/DTIM_RANGE	 56\'h01FF/g" $(CONFIGDIR)/wally-config.vh
-	sed -i "s/IROM_RANGE.*/IROM_RANGE	 56\'h01FF/g" $(CONFIGDIR)/wally-config.vh
+	sed -i "s/DTIM_RANGE.*/DTIM_RANGE	 56\'h01FF/g" $(CONFIGDIR)/config.vh
+	sed -i "s/IROM_RANGE.*/IROM_RANGE	 56\'h01FF/g" $(CONFIGDIR)/config.vh
 else 
     $(info $(CONFIG) does not exist in $(DIRS32) or $(DIRS64))
     @echo "Config not in list, RAM_RANGE will be unmodified"
@@ -67,18 +67,18 @@ endif
 
 # if USESRAM = 1, set that in the config file, otherwise reduce sizes
 ifeq ($(USESRAM), 1)
-	sed -i 's/USE_SRAM.*/USE_SRAM 1/g' $(CONFIGDIR)/wally-config.vh
+	sed -i 's/USE_SRAM.*/USE_SRAM 1/g' $(CONFIGDIR)/config.vh
 else
-	sed -i 's/WAYSIZEINBYTES.*/WAYSIZEINBYTES 512/g' $(CONFIGDIR)/wally-config.vh
-	sed -i 's/NUMWAYS.*/NUMWAYS 1/g' $(CONFIGDIR)/wally-config.vh
-	sed -i 's/BPRED_SIZE.*/BPRED_SIZE 5/g' $(CONFIGDIR)/wally-config.vh
-	sed -i 's/BTB_SIZE.*/BTB_SIZE 5/g' $(CONFIGDIR)/wally-config.vh
+	sed -i 's/WAYSIZEINBYTES.*/WAYSIZEINBYTES 512/g' $(CONFIGDIR)/config.vh
+	sed -i 's/NUMWAYS.*/NUMWAYS 1/g' $(CONFIGDIR)/config.vh
+	sed -i 's/BPRED_SIZE.*/BPRED_SIZE 5/g' $(CONFIGDIR)/config.vh
+	sed -i 's/BTB_SIZE.*/BTB_SIZE 5/g' $(CONFIGDIR)/config.vh
 ifneq ($(filter $(CONFIG), $(DIRS32)),)
-	sed -i "s/BOOTROM_RANGE.*/BOOTROM_RANGE	 34\'h01FF/g" $(CONFIGDIR)/wally-config.vh
-	sed -i "s/UNCORE_RAM_RANGE.*/UNCORE_RAM_RANGE	 34\'h01FF/g" $(CONFIGDIR)/wally-config.vh
+	sed -i "s/BOOTROM_RANGE.*/BOOTROM_RANGE	 34\'h01FF/g" $(CONFIGDIR)/config.vh
+	sed -i "s/UNCORE_RAM_RANGE.*/UNCORE_RAM_RANGE	 34\'h01FF/g" $(CONFIGDIR)/config.vh
 else ifneq ($(filter $(CONFIG), $(DIRS64)),)
-	sed -i "s/BOOTROM_RANGE.*/BOOTROM_RANGE	 56\'h01FF/g" $(CONFIGDIR)/wally-config.vh
-	sed -i "s/UNCORE_RAM_RANGE.*/UNCORE_RAM_RANGE	 56\'h01FF/g" $(CONFIGDIR)/wally-config.vh
+	sed -i "s/BOOTROM_RANGE.*/BOOTROM_RANGE	 56\'h01FF/g" $(CONFIGDIR)/config.vh
+	sed -i "s/UNCORE_RAM_RANGE.*/UNCORE_RAM_RANGE	 56\'h01FF/g" $(CONFIGDIR)/config.vh
 endif
 endif
 	
@@ -94,20 +94,20 @@ endif
 
 ifneq ($(MOD), orig)
 	# PMP 0
-	sed -i 's/PMP_ENTRIES \(64\|16\|0\)/PMP_ENTRIES 0/' $(CONFIGDIR)/wally-config.vh
+	sed -i 's/PMP_ENTRIES \(64\|16\|0\)/PMP_ENTRIES 0/' $(CONFIGDIR)/config.vh
 ifneq ($(MOD), PMP0)
 	# no priv
-	sed -i 's/ZICSR_SUPPORTED *1/ZICSR_SUPPORTED 0/' $(CONFIGDIR)/wally-config.vh
+	sed -i 's/ZICSR_SUPPORTED *1/ZICSR_SUPPORTED 0/' $(CONFIGDIR)/config.vh
 ifneq ($(MOD), noPriv)
 	# turn off FPU 
-	sed -i 's/1 *<< *3/0 << 3/' $(CONFIGDIR)/wally-config.vh
-	sed -i 's/1 *<< *5/0 << 5/' $(CONFIGDIR)/wally-config.vh
+	sed -i 's/1 *<< *3/0 << 3/' $(CONFIGDIR)/config.vh
+	sed -i 's/1 *<< *5/0 << 5/' $(CONFIGDIR)/config.vh
 ifneq ($(MOD), noFPU)
 	# no muldiv
-	sed -i 's/1 *<< *12/0 << 12/' $(CONFIGDIR)/wally-config.vh
+	sed -i 's/1 *<< *12/0 << 12/' $(CONFIGDIR)/config.vh
 ifneq ($(MOD), noMulDiv)
 	# no atomic
-	sed -i 's/1 *<< *0/0 << 0/' $(CONFIGDIR)/wally-config.vh
+	sed -i 's/1 *<< *0/0 << 0/' $(CONFIGDIR)/config.vh
 endif
 endif
 endif

--- a/synthDC/scripts/synth.tcl
+++ b/synthDC/scripts/synth.tcl
@@ -25,6 +25,7 @@ set maxopt $::env(MAXOPT)
 set drive $::env(DRIVE)
 
 eval file copy -force [glob ${cfg}/*.vh] {$outputDir/hdl/}
+eval file copy -force [glob ${hdl_src}/*.sv] {$outputDir/hdl/}
 eval file copy -force [glob ${hdl_src}/*/*.sv] {$outputDir/hdl/}
 eval file copy -force [glob ${hdl_src}/*/*/*.sv] {$outputDir/hdl/}
 
@@ -37,7 +38,7 @@ if { $saifpower == 1 } {
 }
 
 # Verilog files
-set my_verilog_files [glob $outputDir/hdl/*]
+set my_verilog_files [glob $outputDir/hdl/cvw.sv $outputDir/hdl/*.sv]
 
 # Set toplevel
 set my_toplevel $::env(DESIGN)


### PR DESCRIPTION
Fixed some of synth.tcl to use parameterized design.  However, synth is still failing with

make synth DESIGN=wallypipelinedcore TECH=sky90 CONFIG=rv32e FREQ=1000

...
elaborate $my_toplevel -lib WORK 
Loading db file '/cad/synopsys/SYN/libraries/syn/gtech.db'
Loading db file '/cad/synopsys/SYN/libraries/syn/standard.sldb'
  Loading link library 'scc9gena_tt_1.2v_25C'
  Loading link library 'gtech'
Running PRESTO HDLC
Error:  Module or interface 'wallypipelinedcore' was not elaborated because no default or override values were provided for parameter(s) 'P'. (ELAB-2041)
*** Presto compilation terminated with 1 errors. ***


