### PR TITLE
Fixed issue #368 lint, but not simulation

### DIFF
--- a/src/lsu/lsu.sv
+++ b/src/lsu/lsu.sv
@@ -232,7 +232,7 @@ module lsu import cvw::*;  #(parameter cvw_t P) (
     // **** create config to support DTIM with floating point.
     dtim #(P) dtim(.clk, .ce(~GatedStallW), .MemRWM(DTIMMemRWM),
               .DTIMAdr, .FlushW, .WriteDataM(LSUWriteDataM), 
-              .ReadDataWordM(DTIMReadDataWordM[P.XLEN-1:0]), .ByteMaskM(ByteMaskM[P.XLEN/8-1:0]));
+              .ReadDataWordM(DTIMReadDataWordM[P.LLEN-1:0]), .ByteMaskM(ByteMaskM[P.LLEN/8-1:0]));
   end else begin
   end
   if (P.BUS_SUPPORTED) begin : bus              
@@ -308,11 +308,11 @@ module lsu import cvw::*;  #(parameter cvw_t P) (
 
       ahbinterface #(P.XLEN, 1) ahbinterface(.HCLK(clk), .HRESETn(~reset), .Flush(FlushW), .HREADY(LSUHREADY), 
         .HRDATA(HRDATA), .HTRANS(LSUHTRANS), .HWRITE(LSUHWRITE), .HWDATA(LSUHWDATA),
-        .HWSTRB(LSUHWSTRB), .BusRW, .ByteMask(ByteMaskM), .WriteData(LSUWriteDataM),
+        .HWSTRB(LSUHWSTRB), .BusRW, .ByteMask(ByteMaskM[P.XLEN/8-1:0]), .WriteData(LSUWriteDataM[P.XLEN-1:0]),
         .Stall(GatedStallW), .BusStall, .BusCommitted(BusCommittedM), .FetchBuffer(FetchBuffer));
 
     // Mux between the 2 sources of read data, 0: Bus, 1: DTIM
-      if(P.DTIM_SUPPORTED) mux2 #(P.XLEN) ReadDataMux2(FetchBuffer, DTIMReadDataWordM, SelDTIM, ReadDataWordMuxM);
+      if(P.DTIM_SUPPORTED) mux2 #(P.XLEN) ReadDataMux2(FetchBuffer, DTIMReadDataWordM[P.XLEN-1:0], SelDTIM, ReadDataWordMuxM[P.XLEN-1:0]);
       else assign ReadDataWordMuxM = FetchBuffer[P.XLEN-1:0];
       assign LSUHBURST = 3'b0;
       assign {DCacheStallM, DCacheCommittedM, DCacheMiss, DCacheAccess} = '0;


### PR DESCRIPTION
- Improved timing constraints for arty a7 to push clock speed to 20Mhz.
- Updated arty a7 device clock speed for 20Mhz.
- Removed all old references to the old flash card controller. Added git submodule for the flash card in addins. Replicated flash card top level for our changes into the fpga/src directory.
- Removed old sdc from all configs.
- Updated Arty A7 fpga config and device tree to 256MiB main memory.
- Fixed lint errors for issue #368.  Does not fix simulation errors.  We made a design decision a long time ago to not support DTIM on the rv32gc config because LLEN was greater than XLEN.
