### PR TITLE
fix synth makefile

### DIFF
--- a/synthDC/Makefile
+++ b/synthDC/Makefile
@@ -55,11 +55,11 @@ $(CONFIG):
 
 # adjust DTIM and IROM to reasonable values depending on config	
 ifneq ($(filter $(CONFIG), $(DIRS32)),)
-	sed -i "s/DTIM_RANGE.*/DTIM_RANGE	 34\'h01FF/g" $(CONFIGDIR)/config.vh
-	sed -i "s/IROM_RANGE.*/IROM_RANGE	 34\'h01FF/g" $(CONFIGDIR)/config.vh
+	sed -i "s/DTIM_RANGE.*/DTIM_RANGE	= 34\'h01FF;/g" $(CONFIGDIR)/config.vh
+	sed -i "s/IROM_RANGE.*/IROM_RANGE	= 34\'h01FF;/g" $(CONFIGDIR)/config.vh
 else ifneq ($(filter $(CONFIG), $(DIRS64)),)
-	sed -i "s/DTIM_RANGE.*/DTIM_RANGE	 56\'h01FF/g" $(CONFIGDIR)/config.vh
-	sed -i "s/IROM_RANGE.*/IROM_RANGE	 56\'h01FF/g" $(CONFIGDIR)/config.vh
+	sed -i "s/DTIM_RANGE.*/DTIM_RANGE	= 56\'h01FF;/g" $(CONFIGDIR)/config.vh
+	sed -i "s/IROM_RANGE.*/IROM_RANGE	= 56\'h01FF;/g" $(CONFIGDIR)/config.vh
 else 
     $(info $(CONFIG) does not exist in $(DIRS32) or $(DIRS64))
     @echo "Config not in list, RAM_RANGE will be unmodified"
@@ -67,18 +67,18 @@ endif
 
 # if USESRAM = 1, set that in the config file, otherwise reduce sizes
 ifeq ($(USESRAM), 1)
-	sed -i 's/USE_SRAM.*/USE_SRAM 1/g' $(CONFIGDIR)/config.vh
+	sed -i 's/USE_SRAM.*/USE_SRAM = 1;/g' $(CONFIGDIR)/config.vh
 else
-	sed -i 's/WAYSIZEINBYTES.*/WAYSIZEINBYTES 512/g' $(CONFIGDIR)/config.vh
-	sed -i 's/NUMWAYS.*/NUMWAYS 1/g' $(CONFIGDIR)/config.vh
-	sed -i 's/BPRED_SIZE.*/BPRED_SIZE 5/g' $(CONFIGDIR)/config.vh
-	sed -i 's/BTB_SIZE.*/BTB_SIZE 5/g' $(CONFIGDIR)/config.vh
+	sed -i "s/WAYSIZEINBYTES.*/WAYSIZEINBYTES = 32\'d512;/g" $(CONFIGDIR)/config.vh
+	sed -i "s/NUMWAYS.*/NUMWAYS =32\'d1;/g" $(CONFIGDIR)/config.vh
+	sed -i "s/BPRED_SIZE.*/BPRED_SIZE =32\'d5;/g" $(CONFIGDIR)/config.vh
+	sed -i "s/BTB_SIZE.*/BTB_SIZE = 32\'d5;/g" $(CONFIGDIR)/config.vh
 ifneq ($(filter $(CONFIG), $(DIRS32)),)
-	sed -i "s/BOOTROM_RANGE.*/BOOTROM_RANGE	 34\'h01FF/g" $(CONFIGDIR)/config.vh
-	sed -i "s/UNCORE_RAM_RANGE.*/UNCORE_RAM_RANGE	 34\'h01FF/g" $(CONFIGDIR)/config.vh
+	sed -i "s/BOOTROM_RANGE.*/BOOTROM_RANGE	 = 34\'h01FF;/g" $(CONFIGDIR)/config.vh
+	sed -i "s/UNCORE_RAM_RANGE.*/UNCORE_RAM_RANGE	= 34\'h01FF;/g" $(CONFIGDIR)/config.vh
 else ifneq ($(filter $(CONFIG), $(DIRS64)),)
-	sed -i "s/BOOTROM_RANGE.*/BOOTROM_RANGE	 56\'h01FF/g" $(CONFIGDIR)/config.vh
-	sed -i "s/UNCORE_RAM_RANGE.*/UNCORE_RAM_RANGE	 56\'h01FF/g" $(CONFIGDIR)/config.vh
+	sed -i "s/BOOTROM_RANGE.*/BOOTROM_RANGE	 = 56\'h01FF;/g" $(CONFIGDIR)/config.vh
+	sed -i "s/UNCORE_RAM_RANGE.*/UNCORE_RAM_RANGE	= 56\'h01FF;/g" $(CONFIGDIR)/config.vh
 endif
 endif
 	


### PR DESCRIPTION
Config.vh was updated to use localparam NAME = VALUE; format instead of DEFINE macros. There was a bug in the synth makefile where SED commands on the config files were missing the equals sign and the semicolon. This led to compilation errors when running make synth. 