### PR TITLE
Properly gate LRUWriteEn with ~FlushStage

### DIFF
--- a/src/cache/cachefsm.sv
+++ b/src/cache/cachefsm.sv
@@ -172,9 +172,9 @@ module cachefsm import cvw::*; #(parameter cvw_t P,
   assign ClearValid = P.ZICBOM_SUPPORTED & ((CurrState == STATE_READY & CMOp[0] & CacheHit) |
                       (CurrState == STATE_CMO_WRITEBACK & CMOp[2] & CacheBusAck));
   // coverage off -item e 1 -fecexprrow 8
-  assign LRUWriteEn = (CurrState == STATE_READY & (AnyHit | CMOZeroNoEviction)) |
+  assign LRUWriteEn = ((CurrState == STATE_READY & (AnyHit | CMOZeroNoEviction)) |
                       (P.ZICBOZ_SUPPORTED & CurrState == STATE_WRITEBACK & CMOp[3] & CacheBusAck) | 
-                      (CurrState == STATE_WRITE_LINE) & ~FlushStage;
+                      (CurrState == STATE_WRITE_LINE)) & ~FlushStage;
   // exclusion-tag-start: icache flushdirtycontrols
   assign SetDirty = (CurrState == STATE_READY & (AnyUpdateHit | CMOZeroNoEviction)) |         // exclusion-tag: icache SetDirty  
                     (CurrState == STATE_WRITE_LINE & (CacheRW[0])) |


### PR DESCRIPTION
LRUWriteEn is supposed to be gated by ~FlushStage. SystemVerilog's order of operations puts & above |, so the previous version had ~FlushStage and-ed with a single term of the LRUWriteEn expression. Added parentheses to fix this. 

For some difficult-to-divine reason, this also fixes the overlogging for the cache simulator - fixing all non cbo-related discrepancies between Wally's cache and the simulator cache. 