### PR TITLE
initial spill logic improvement

### DIFF
--- a/benchmarks/embench/Makefile
+++ b/benchmarks/embench/Makefile
@@ -5,7 +5,7 @@
 embench_dir = ../../addins/embench-iot
 
 all: build 
-run: size sim
+run: build size sim
 
 allClean: clean all
 

--- a/src/ifu/ifu.sv
+++ b/src/ifu/ifu.sv
@@ -144,8 +144,8 @@ module ifu import cvw::*;  #(parameter cvw_t P) (
   /////////////////////////////////////////////////////////////////////////////////////////////
 
   if(P.C_SUPPORTED) begin : Spill
-    spill #(P) spill(.clk, .reset, .StallD, .FlushD, .PCF, .PCPlus4F, .PCNextF, .InstrRawF,
-      .InstrUpdateDAF, .IFUCacheBusStallF, .ITLBMissF, .PCSpillNextF, .PCSpillF, .SelSpillNextF, .PostSpillInstrRawF, .CompressedF);
+    spill #(P) spill(.clk, .reset, .StallD, .FlushD, .PCF, .PCPlus4F, .PCNextF, .InstrRawF, .InstrUpdateDAF, .CacheableF, 
+      .IFUCacheBusStallF, .ITLBMissF, .PCSpillNextF, .PCSpillF, .SelSpillNextF, .PostSpillInstrRawF, .CompressedF);
   end else begin : NoSpill
     assign PCSpillNextF = PCNextF;
     assign PCSpillF = PCF;


### PR DESCRIPTION
This fix uses a variable number of address bits in the spill logic depending on whether the access is cashable.

passes regression but still hangs on coverage64gc tlbNAPOT.

Presumably still seeing Issue 405, but the issue may be more complex than I thought.

Also, it raises two possible areas of optimization.  One is that RV64 fetches 64 bits from main memory even when uncacheable.  We should be able to exploit this to only spill from the last 16 bits, not from the first three.  Another is that if there is time, we could look at the 2 lsbs of the fetched instruction to determine whether the instruction is 16 bits and a spill isn't actually needed.

@ross144 maybe you have some ideas?


