### PR TITLE
Update Top Level Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,8 @@
 
 all:
 	make install
-	make testfloat	
-	make riscof
+	make riscof	
+	make testfloat
 	make verify
 	make coverage
 	make benchmarks


### PR DESCRIPTION
"make riscof" and "make testfloat" were run in backward order (in the top level makefile), leading to some of the make issues when a user is setting up for the very first time.