### PR TITLE
Fixed issue #412 The root cause was DTLB miss leads to page fault exception with concurrent I$ miss.  The HPTW hits all entries in the D$ and quickly faults.  However the I$ is still waiting on the main memory. The trap then interrupts the atomimicity of the bus fetch and breaks the next several instructions.

### DIFF
--- a/src/privileged/trap.sv
+++ b/src/privileged/trap.sv
@@ -87,7 +87,7 @@ module trap import cvw::*;  #(parameter cvw_t P) (
                       BreakpointFaultM | EcallFaultM |
                       LoadAccessFaultM | StoreAmoAccessFaultM;
   // coverage on
-  assign TrapM = ExceptionM | InterruptM; 
+  assign TrapM = (ExceptionM & ~CommittedF) | InterruptM; // *** RT: review this additional ~CommittedF with DH and update priv chapter.
   assign RetM  = mretM | sretM;
 
   ///////////////////////////////////////////


### PR DESCRIPTION
The simplest solution is to use CommittedF to delay Exceptions like with Interrupts.  Note this cannot happen with CommittedM.  If the ITLB misses and the D$ also need to fetch a from the bus an ITLB page fault exception will not trigger the trap until a few stages later.
