### PR TITLE
synth wrapper generation bug fix

### DIFF
--- a/synthDC/scripts/wrapperGen.py
+++ b/synthDC/scripts/wrapperGen.py
@@ -43,7 +43,7 @@ index=0
 
 # string copy logic
 for l in lines:
-    if l.find("module") == 0:
+    if l.lstrip().find("module") == 0:
         lineModuleStart = index
         moduleName = l.split()[1]
         writeBuf = True
@@ -51,7 +51,7 @@ for l in lines:
         continue
     if (writeBuf):
         buf += l
-    if l.find (");") == 0:
+    if l.lstrip().find (");") == 0:
         lineModuleEnd = index
         break
     index+=1
@@ -64,6 +64,7 @@ wrapperPath = f"{os.getenv('WALLY')}/synthDC/wrappers/{moduleName}wrapper.sv"
 
 # clear wrappers directory 
 os.system(f"rm {os.getenv('WALLY')}/synthDC/wrappers/*")
+os.system(f"mkdir {os.getenv('WALLY')}/synthDC/wrappers")
 
 fout = open(wrapperPath, "w")
 


### PR DESCRIPTION
- wrapper generation script broke when module declaration and closing ");" were separated from the beginning of the newline by whitespace