### PR TITLE
fixes issue #487

### DIFF
--- a/src/lsu/lsu.sv
+++ b/src/lsu/lsu.sv
@@ -158,7 +158,7 @@ module lsu import cvw::*;  #(parameter cvw_t P) (
     logic [P.XLEN-1:0] IEUAdrSpillE, IEUAdrSpillM;
     align #(P) align(.clk, .reset, .StallM, .FlushM, .IEUAdrE, .IEUAdrM, .Funct3M,
                      .MemRWM, .CacheableM,
-                     .DCacheReadDataWordM, .CacheBusHPWTStall, .DTLBMissM, .DataUpdateDAM,
+                     .DCacheReadDataWordM, .CacheBusHPWTStall, .DTLBMissM, .DataUpdateDAM, .SelHPTW,
                      .ByteMaskM, .ByteMaskExtendedM, .LSUWriteDataM, .ByteMaskSpillM, .LSUWriteDataSpillM,
                      .IEUAdrSpillE, .IEUAdrSpillM, .SelSpillE, .MemRWSpillM, .DCacheReadDataWordSpillM, .SpillStallM,
                      .SelStoreDelay);


### PR DESCRIPTION
- begin implemenation of Zicclsm.
- Progress on misaligned load/stores.
- Added file.
- The misaligned load alignment lints.
- Addec ZICCLSM to config files and started on lsu instance.
- At least have the aligner integrated, but not tested.
- Passes lint with some exceptions.  Still need to add misaligned store support.
- Progress.
- Finally lints cleanly.
- Aligner is integrated and enabled in rv64gc and passes the regression test; however, there are no new tests.
- rv32gc now also works with the alignment module. Still not tested with misligned access.
- Preemptively fixed the bytemask bug before testing.
- Updated mmu to not generate trap on cacheable misaligned access when supported. Updated tests with David's help.
- First stab at the misaligned test.
- Fixed bugs in misaligned test.
- Progress
- Working through issues with the psill logic.
- Finally the d$ spill works. At least until the next bug.  Definitely needs a lot of cleanup.
- Progress. I think the remaining bugs are in the regression test's signature.
- Doesn't yet fully work. Thomas is going to finish debugging while I'm on the RISCV summit next week.
- Enabled Zicclsm in rv64gc.
- Fixed bug which broke the non Zicclsm configs.
- Missed tests.vh.
- Fixed bug in the misaligned access test.
- Fixed spill bugs in the aligner.
- Fixed bug in the Zicclsm test.
- Fixed some more bugs in the Zicclsm signature.
- Fixed all the bugs associated with the signature and the store side of misaligned access. Load misaligned is still causing some issues.
- Found another bug in the RTL's Zicclsm alignment.
- Yay! Zicclsm passes my regression test now.
- Simplification.
- Cleanup.
- Updated buildroot to use kernel 6.6 and added dedicated qemu emulation script.
- Updates to linux config files for sdc.
- Cleanup. Linux makefile wally tracer.  probably reduce some complexity here.
- Commented out the arch64priv misaligned load/store tests since we added Zicclsm to the rv64gc config.
- Cleanup and optimization of Zicclsm.
- Fixed bug in uncore updates which broke SDC.
- Reduced Arty A7 clock speed to 20Mhz to support Zicclsm.
- Towards removing the FPGA config file.
- Modified the fpga build script to generate it's own config file rather than use the one in config/fpga.
- Removed fpga config. No longer needed.
- Fixed bugs in the updated fpga synthe script.
- Fixed another bug in the updated script changes.
- Added cbop to to rv32gc.
- Fixed the imperas testbench to be compatible with the config changes.
- Modified the device trees to include all the minor extensions.
- Patched up linux imperas testbench.
- Fixed bug in the btb branch logging. We were only logging branch instructions not all control flow instructions which dramatically skewed the results for sim_bp.
- Fixed second bug in the logger script when branch logging enabled but counter logger not.
- Extended SeparateBranch to support both just branches and all control flow instructions.
- Added btb reference data.
- Updates to btb logger processing.
- Removed the size opt tests from the branch predictor analysis.
- Fixed testbench so it runs with BPRED_LOGGER but not PrintHPMCounters.
- Fixed bugs in paraseHPMC.py
- bpred-sim only simulates 12 jobs at once.
- Fixed Zicclsm bug.  Misalignment and spill detection were not masked by access type.  Therefore a page table walk which always aligned could have had an IEUAdrM misaligned which erroneously caused a shift in the read data.
