### PR TITLE
cbo optimizations

### DIFF
--- a/src/cache/cache.sv
+++ b/src/cache/cache.sv
@@ -79,8 +79,8 @@ module cache import cvw::*; #(parameter cvw_t P,
   logic [LINELEN-1:0]            ReadDataLineWay [NUMWAYS-1:0];
   logic [NUMWAYS-1:0]            HitWay, ValidWay;
   logic                          CacheHit;
-  logic [NUMWAYS-1:0]            VictimWay, DirtyWay;
-  logic                          LineDirty;
+  logic [NUMWAYS-1:0]            VictimWay, DirtyWay, HitWayDirtyWay;
+  logic                          LineDirty, HitWayLineDirty;
   logic [TAGLEN-1:0]             TagWay [NUMWAYS-1:0];
   logic [TAGLEN-1:0]             Tag;
   logic [SETLEN-1:0]             FlushAdr, NextFlushAdr, FlushAdrP1;
@@ -116,7 +116,7 @@ module cache import cvw::*; #(parameter cvw_t P,
   cacheway #(P, PA_BITS, XLEN, NUMLINES, LINELEN, TAGLEN, OFFSETLEN, SETLEN, READ_ONLY_CACHE) CacheWays[NUMWAYS-1:0](
     .clk, .reset, .CacheEn, .CacheSet, .PAdr, .LineWriteData, .LineByteMask, .SelWay,
     .SetValid, .ClearValid, .SetDirty, .ClearDirty, .VictimWay,
-    .FlushWay, .SelFlush, .ReadDataLineWay, .HitWay, .ValidWay, .DirtyWay, .TagWay, .FlushStage, .InvalidateCache);
+    .FlushWay, .SelFlush, .ReadDataLineWay, .HitWay, .ValidWay, .DirtyWay, .HitWayDirtyWay, .TagWay, .FlushStage, .InvalidateCache);
 
   // Select victim way for associative caches
   if(NUMWAYS > 1) begin:vict
@@ -128,6 +128,7 @@ module cache import cvw::*; #(parameter cvw_t P,
 
   assign CacheHit = |HitWay;
   assign LineDirty = |DirtyWay;
+  assign HitWayLineDirty = |HitWayDirtyWay;
 
   // ReadDataLineWay is a 2d array of cache line len by number of ways.
   // Need to OR together each way in a bitwise manner.
@@ -218,7 +219,7 @@ module cache import cvw::*; #(parameter cvw_t P,
   
   cachefsm #(P, READ_ONLY_CACHE) cachefsm(.clk, .reset, .CacheBusRW, .CacheBusAck, 
     .FlushStage, .CacheRW, .Stall,
-    .CacheHit, .LineDirty, .CacheStall, .CacheCommitted, 
+    .CacheHit, .LineDirty, .HitWayLineDirty, .CacheStall, .CacheCommitted, 
     .CacheMiss, .CacheAccess, .SelAdr, .SelWay,
     .ClearDirty, .SetDirty, .SetValid, .ClearValid, .SelWriteback, .SelFlush,
     .FlushAdrCntEn, .FlushWayCntEn, .FlushCntRst,

--- a/src/cache/cachefsm.sv
+++ b/src/cache/cachefsm.sv
@@ -96,7 +96,6 @@ module cachefsm import cvw::*; #(parameter cvw_t P,
   assign AnyUpdateHit = (CacheRW[0]) & CacheHit;                            // exclusion-tag: icache storeAMO1
   assign AnyHit = AnyUpdateHit | (CacheRW[1] & CacheHit);                  // exclusion-tag: icache AnyUpdateHit
   assign CMOWritebackHit = (CMOp[1] | CMOp[2]) & CacheHit & HitWayLineDirty;
-  //assign CMOWritebackHit = (CMOp[1] | CMOp[2]) & CacheHit; // *** why does this not include dirty?  FIXME
   assign CMOZeroNoEviction = CMOp[3] & ~LineDirty;   // (hit or miss) with no writeback store zeros now
   assign CMOZeroEviction = CMOp[3] & LineDirty;   // (hit or miss) with writeback dirty line
   assign CMOWriteback = CMOWritebackHit | CMOZeroEviction;

--- a/src/cache/cachefsm.sv
+++ b/src/cache/cachefsm.sv
@@ -94,7 +94,7 @@ module cachefsm import cvw::*; #(parameter cvw_t P,
   assign AnyMiss = (CacheRW[0] | CacheRW[1]) & ~CacheHit & ~InvalidateCache; // exclusion-tag: cache AnyMiss
   assign AnyUpdateHit = (CacheRW[0]) & CacheHit;                            // exclusion-tag: icache storeAMO1
   assign AnyHit = AnyUpdateHit | (CacheRW[1] & CacheHit);                  // exclusion-tag: icache AnyUpdateHit
-  assign CMOWritebackHit = (CMOp[1] | CMOp[2]) & CacheHit;
+  assign CMOWritebackHit = (CMOp[1] | CMOp[2]) & CacheHit; // *** why does this not include dirty?
   assign CMOZeroNoEviction = CMOp[3] & ~LineDirty;   // (hit or miss) with no writeback store zeros now
   assign CMOZeroEviction = CMOp[3] & LineDirty;   // (hit or miss) with writeback dirty line
   assign CMOWriteback = CMOWritebackHit | CMOZeroEviction;
@@ -130,7 +130,7 @@ module cachefsm import cvw::*; #(parameter cvw_t P,
                              else                                              NextState = STATE_READY;
       // exclusion-tag-start: icache case
       STATE_WRITEBACK:       if(CacheBusAck & ~(|CMOp[3:1]))                   NextState = STATE_FETCH;
-                             else if(CacheBusAck)                              NextState = STATE_READ_HOLD;
+                             else if(CacheBusAck)                              NextState = STATE_READ_HOLD; // *** why not Ready?
                              else                                              NextState = STATE_WRITEBACK;
       // eviction needs a delay as the bus fsm does not correctly handle sending the write command at the same time as getting back the bus ack.
       STATE_FLUSH:           if(LineDirty)                                     NextState = STATE_FLUSH_WRITEBACK;
@@ -154,24 +154,24 @@ module cachefsm import cvw::*; #(parameter cvw_t P,
                       (CurrState == STATE_FLUSH_WRITEBACK);
   // write enables internal to cache
   assign SetValid = CurrState == STATE_WRITE_LINE | 
-                    (P.ZICBOZ_SUPPORTED & CurrState == STATE_READY & CMOZeroNoEviction) |
-                    (P.ZICBOZ_SUPPORTED & CurrState == STATE_WRITEBACK & CacheBusAck & CMOp[3]); 
-  assign ClearValid = P.ZICBOM_SUPPORTED & ((CurrState == STATE_READY & CMOp[0] & CacheHit) |
-                      (CurrState == STATE_WRITEBACK & CMOp[2] & CacheBusAck));
+                    (CurrState == STATE_READY & CMOZeroNoEviction) |
+                    (CurrState == STATE_WRITEBACK & CacheBusAck & CMOp[3]); 
+  assign ClearValid = (CurrState == STATE_READY & CMOp[0]) |
+                      (CurrState == STATE_WRITEBACK & CMOp[2] & CacheBusAck);
   // coverage off -item e 1 -fecexprrow 8
   assign LRUWriteEn = (((CurrState == STATE_READY & (AnyHit | CMOZeroNoEviction)) |
                        (CurrState == STATE_WRITE_LINE)) & ~FlushStage) |
-                      (P.ZICBOZ_SUPPORTED & CurrState == STATE_WRITEBACK & CMOp[3] & CacheBusAck);
+                      (CurrState == STATE_WRITEBACK & CMOp[3] & CacheBusAck);
   // exclusion-tag-start: icache flushdirtycontrols
   assign SetDirty = (CurrState == STATE_READY & (AnyUpdateHit | CMOZeroNoEviction)) |         // exclusion-tag: icache SetDirty  
                     (CurrState == STATE_WRITE_LINE & (CacheRW[0])) |
-                    (P.ZICBOZ_SUPPORTED & CurrState == STATE_WRITEBACK & (CMOp[3] & CacheBusAck));                    
+                    (CurrState == STATE_WRITEBACK & (CMOp[3] & CacheBusAck));                    
   assign ClearDirty = (CurrState == STATE_WRITE_LINE & ~(CacheRW[0])) |   // exclusion-tag: icache ClearDirty
                       (CurrState == STATE_FLUSH & LineDirty) | // This is wrong in a multicore snoop cache protocal.  Dirty must be cleared concurrently and atomically with writeback.  For single core cannot clear after writeback on bus ack and change flushadr.  Clears the wrong set.
   // Flush and eviction controls
-                      (P.ZICBOM_SUPPORTED & CurrState == STATE_WRITEBACK & (CMOp[1] | CMOp[2]) & CacheBusAck);
-  assign SelWay = (CurrState == STATE_WRITEBACK & ((~CacheBusAck & ~(CMOp[1] | CMOp[2])) | (P.ZICBOZ_SUPPORTED & CacheBusAck & CMOp[3]))) |
-                  (CurrState == STATE_READY & ((AnyMiss & LineDirty) | (P.ZICBOZ_SUPPORTED & CMOZeroNoEviction & ~CacheHit))) | 
+                      CurrState == STATE_WRITEBACK & (CMOp[1] | CMOp[2]) & CacheBusAck;
+  assign SelWay = (CurrState == STATE_WRITEBACK & ((~CacheBusAck & ~(CMOp[1] | CMOp[2])) | (CacheBusAck & CMOp[3]))) |
+                  (CurrState == STATE_READY & ((AnyMiss & LineDirty) | (CMOZeroNoEviction & ~CacheHit))) | 
                   (CurrState == STATE_WRITE_LINE);
   assign SelWriteback = (CurrState == STATE_WRITEBACK & (CMOp[1] | CMOp[2] | ~CacheBusAck)) |
                         (CurrState == STATE_READY & AnyMiss & LineDirty);
@@ -194,7 +194,7 @@ module cachefsm import cvw::*; #(parameter cvw_t P,
   assign CacheBusRW[0] = (CurrState == STATE_READY & AnyMiss & LineDirty) | // exclusion-tag: icache CacheBusW
                          (CurrState == STATE_WRITEBACK & ~CacheBusAck) |
                          (CurrState == STATE_FLUSH_WRITEBACK & ~CacheBusAck) |
-                         (P.ZICBOM_SUPPORTED & CurrState == STATE_WRITEBACK & (CMOp[1] | CMOp[2]) & ~CacheBusAck);
+                         (CurrState == STATE_WRITEBACK & (CMOp[1] | CMOp[2]) & ~CacheBusAck);
 
   assign SelAdr = (CurrState == STATE_READY & (CacheRW[0] | AnyMiss | (|CMOp))) | // exclusion-tag: icache SelAdrCauses // changes if store delay hazard removed
                   (CurrState == STATE_FETCH) |

--- a/src/cache/cachefsm.sv
+++ b/src/cache/cachefsm.sv
@@ -129,7 +129,7 @@ module cachefsm import cvw::*; #(parameter cvw_t P,
       STATE_READ_HOLD:       if(Stall)                                         NextState = STATE_READ_HOLD;
                              else                                              NextState = STATE_READY;
       // exclusion-tag-start: icache case
-      STATE_WRITEBACK:       if(CacheBusAck & ~CMOp[3])                        NextState = STATE_FETCH;
+      STATE_WRITEBACK:       if(CacheBusAck & ~(|CMOp[3:1]))                   NextState = STATE_FETCH;
                              else if(CacheBusAck)                              NextState = STATE_READ_HOLD;
                              else                                              NextState = STATE_WRITEBACK;
       // eviction needs a delay as the bus fsm does not correctly handle sending the write command at the same time as getting back the bus ack.

--- a/src/cache/cacheway.sv
+++ b/src/cache/cacheway.sv
@@ -51,7 +51,8 @@ module cacheway import cvw::*; #(parameter cvw_t P,
   output logic [LINELEN-1:0]          ReadDataLineWay,// This way's read data if valid
   output logic                        HitWay,         // This way hits
   output logic                        ValidWay,       // This way is valid
-  output logic                        DirtyWay,       // This way is dirty
+  output logic                        HitWayDirtyWay, // The hit way is dirty
+  output logic                        DirtyWay   ,    // The selected way is dirty
   output logic [TAGLEN-1:0]           TagWay);        // This way's tag if valid
 
   localparam                          WORDSPERLINE = LINELEN/XLEN;
@@ -117,7 +118,8 @@ module cacheway import cvw::*; #(parameter cvw_t P,
 
   // AND portion of distributed tag multiplexer
   assign TagWay = SelData ? ReadTag : '0; // AND part of AOMux
-  assign DirtyWay = SelDirty & Dirty & ValidWay;
+  assign HitWayDirtyWay = Dirty & ValidWay;
+  assign DirtyWay = SelDirty & HitWayDirtyWay;
   assign HitWay = ValidWay & (ReadTag == PAdr[PA_BITS-1:OFFSETLEN+INDEXLEN]);
 
   /////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/ieu/controller.sv
+++ b/src/ieu/controller.sv
@@ -357,8 +357,10 @@ module controller import cvw::*;  #(parameter cvw_t P) (
   // Cache Management instructions
   always_comb begin
     CMOpD = 4'b0000; // default: not a cbo instruction
-    if ((P.ZICBOM_SUPPORTED | P.ZICBOZ_SUPPORTED) & CMOD) begin
+    if ((P.ZICBOZ_SUPPORTED) & CMOD) begin
       CMOpD[3] = (InstrD[31:20] == 12'd4); // cbo.zero
+    end
+    if ((P.ZICBOM_SUPPORTED) & CMOD) begin
       CMOpD[2] = (InstrD[31:20] == 12'd2); // cbo.clean
       CMOpD[1] = (InstrD[31:20] == 12'd1) | ((InstrD[31:20] == 12'd0) & (ENVCFG_CBE[1:0] == 2'b01)); // cbo.flush 
       CMOpD[0] = (InstrD[31:20] == 12'd0) & (ENVCFG_CBE[1:0] == 2'b11); // cbo.inval
@@ -425,9 +427,5 @@ module controller import cvw::*;  #(parameter cvw_t P) (
   // a cache cannot read or write immediately after a write
   // atomic operations are also detected as MemRWD[1]
   //assign StoreStallD = MemRWE[0] & ((MemRWD[1] | (MemRWD[0] & P.DCACHE_SUPPORTED)));
-  // *** RT: Modify for ZICBOZ
-  logic cboD, cboE;
-  assign cboE = (|CMOpE[2:0] & P.ZICBOM_SUPPORTED) | (CMOpE[3] & P.ZICBOZ_SUPPORTED);
-  assign cboD = (|CMOpD[2:0] & P.ZICBOM_SUPPORTED) | (CMOpD[3] & P.ZICBOZ_SUPPORTED);
-  assign StoreStallD = (MemRWE[0] | cboE) & ((MemRWD[1] | (MemRWD[0] & P.DCACHE_SUPPORTED) | cboD));
+  assign StoreStallD = (MemRWE[0] | (|CMOpE)) & ((MemRWD[1] | (MemRWD[0] & P.DCACHE_SUPPORTED) | (|CMOpD)));
 endmodule

--- a/src/ieu/controller.sv
+++ b/src/ieu/controller.sv
@@ -426,5 +426,8 @@ module controller import cvw::*;  #(parameter cvw_t P) (
   // atomic operations are also detected as MemRWD[1]
   //assign StoreStallD = MemRWE[0] & ((MemRWD[1] | (MemRWD[0] & P.DCACHE_SUPPORTED)));
   // *** RT: Modify for ZICBOZ
-  assign StoreStallD = (MemRWE[0] | (|CMOpE & P.ZICBOM_SUPPORTED)) & ((MemRWD[1] | (MemRWD[0] & P.DCACHE_SUPPORTED) | (|CMOpD & P.ZICBOM_SUPPORTED)));
+  logic cboD, cboE;
+  assign cboE = (|CMOpE[2:0] & P.ZICBOM_SUPPORTED) | (CMOpE[3] & P.ZICBOZ_SUPPORTED);
+  assign cboD = (|CMOpD[2:0] & P.ZICBOM_SUPPORTED) | (CMOpD[3] & P.ZICBOZ_SUPPORTED);
+  assign StoreStallD = (MemRWE[0] | cboE) & ((MemRWD[1] | (MemRWD[0] & P.DCACHE_SUPPORTED) | cboD));
 endmodule

--- a/src/ifu/ifu.sv
+++ b/src/ifu/ifu.sv
@@ -252,7 +252,7 @@ module ifu import cvw::*;  #(parameter cvw_t P) (
       ahbcacheinterface #(P.AHBW, P.LLEN, P.PA_BITS, WORDSPERLINE, LOGBWPL, LINELEN, LLENPOVERAHBW, 1) 
       ahbcacheinterface(.HCLK(clk), .HRESETn(~reset),
             .HRDATA,
-            .Flush(FlushD), .CacheBusRW, .HSIZE(IFUHSIZE), .HBURST(IFUHBURST), .HTRANS(IFUHTRANS), .HWSTRB(),
+            .Flush(FlushD), .CacheBusRW, .BusCMOZero(1'b0), .HSIZE(IFUHSIZE), .HBURST(IFUHBURST), .HTRANS(IFUHTRANS), .HWSTRB(),
             .Funct3(3'b010), .HADDR(IFUHADDR), .HREADY(IFUHREADY), .HWRITE(IFUHWRITE), .CacheBusAdr(ICacheBusAdr),
             .BeatCount(), .Cacheable(CacheableF), .SelBusBeat(), .WriteDataM('0),
             .CacheBusAck(ICacheBusAck), .HWDATA(), .CacheableOrFlushCacheM(1'b0), .CacheReadDataWordM('0),

--- a/src/lsu/align.sv
+++ b/src/lsu/align.sv
@@ -39,8 +39,6 @@ module align import cvw::*;  #(parameter cvw_t P) (
   input logic [1:0]               MemRWM, 
   input logic [P.LLEN*2-1:0]      DCacheReadDataWordM, // Instruction from the IROM, I$, or bus. Used to check if the instruction if compressed
   input logic                     CacheBusHPWTStall, // I$ or bus are stalled. Transition to second fetch of spill after the first is fetched
-  input logic                     DTLBMissM, // ITLB miss, ignore memory request
-  input logic                     DataUpdateDAM, // ITLB miss, ignore memory request
   input logic                     SelHPTW,
 
   input logic [(P.LLEN-1)/8:0]    ByteMaskM,

--- a/src/lsu/align.sv
+++ b/src/lsu/align.sv
@@ -65,22 +65,20 @@ module align import cvw::*;  #(parameter cvw_t P) (
   logic              SpillM;
   logic              SelSpillM;
   logic              SpillSaveM;
-  logic [P.LLEN-1:0]   ReadDataWordFirstHalfM;
+  logic [P.LLEN-1:0] ReadDataWordFirstHalfM;
   logic              ValidMisalignedM, MisalignedM;
   logic [P.LLEN*2-1:0] ReadDataWordSpillAllM;
   logic [P.LLEN*2-1:0] ReadDataWordSpillShiftedM;
 
-  logic [P.XLEN-1:0]     IEUAdrIncrementM;
+  logic [P.XLEN-1:0]   IEUAdrIncrementM;
 
-  logic [(P.LLEN-1)*2/8:0] ByteMaskSaveM;
-  logic [(P.LLEN-1)*2/8:0] ByteMaskMuxM;
-  logic HalfMisalignedM, WordMisalignedM;
+  logic                HalfMisalignedM, WordMisalignedM;
   logic [OFFSET_BIT_POS-1:$clog2(LLENINBYTES)] WordOffsetM;
-  logic [$clog2(LLENINBYTES)-1:0]                 ByteOffsetM;
-  logic                                HalfSpillM, WordSpillM;
-  logic [$clog2(LLENINBYTES)-1:0]      AccessByteOffsetM;
-  logic [$clog2(LLENINBYTES)+2:0]      ShiftAmount;
-  logic                                ValidAccess;
+  logic [$clog2(LLENINBYTES)-1:0]              ByteOffsetM;
+  logic                                        HalfSpillM, WordSpillM;
+  logic [$clog2(LLENINBYTES)-1:0]              AccessByteOffsetM;
+  logic [$clog2(LLENINBYTES)+2:0]              ShiftAmount;
+  logic                                        ValidAccess;
 
   /* verilator lint_off WIDTHEXPAND */
   assign IEUAdrIncrementM = IEUAdrM + LLENINBYTES;
@@ -179,11 +177,9 @@ module align import cvw::*;  #(parameter cvw_t P) (
   assign LSUWriteDataShiftedExtM = {LSUWriteDataM, LSUWriteDataM, LSUWriteDataM} << ShiftAmount;
   assign LSUWriteDataSpillM = LSUWriteDataShiftedExtM[P.LLEN*3-1:P.LLEN];
 
-  mux3 #(2*P.LLEN/8) bytemaskspillmux(ByteMaskMuxM, // no spill
+  mux3 #(2*P.LLEN/8) bytemaskspillmux({ByteMaskExtendedM, ByteMaskM}, // no spill
                                       {{{P.LLEN/8}{1'b0}}, ByteMaskM}, // spill, first half
-                                      {{{P.LLEN/8}{1'b0}}, ByteMaskMuxM[P.LLEN*2/8-1:P.LLEN/8]}, // spill, second half
+                                      {{{P.LLEN/8}{1'b0}}, ByteMaskExtendedM}, // spill, second half
                                       {SelSpillM, SelSpillE}, ByteMaskSpillM);
 
-  flopenr #(P.LLEN*2/8) bytemaskreg(clk, reset, SpillSaveM, {ByteMaskExtendedM, ByteMaskM}, ByteMaskSaveM);
-  mux2 #(P.LLEN*2/8) bytemasksavemux({ByteMaskExtendedM, ByteMaskM}, ByteMaskSaveM, SelSpillM, ByteMaskMuxM);
 endmodule

--- a/src/lsu/align.sv
+++ b/src/lsu/align.sv
@@ -37,7 +37,6 @@ module align import cvw::*;  #(parameter cvw_t P) (
   input logic [P.XLEN-1:0]        IEUAdrE, // The next IEUAdrM
   input logic [2:0]               Funct3M, // Size of memory operation
   input logic [1:0]               MemRWM, 
-  input logic                     CacheableM,
   input logic [P.LLEN*2-1:0]      DCacheReadDataWordM, // Instruction from the IROM, I$, or bus. Used to check if the instruction if compressed
   input logic                     CacheBusHPWTStall, // I$ or bus are stalled. Transition to second fetch of spill after the first is fetched
   input logic                     DTLBMissM, // ITLB miss, ignore memory request
@@ -54,7 +53,6 @@ module align import cvw::*;  #(parameter cvw_t P) (
   output logic [P.XLEN-1:0]       IEUAdrSpillE, // The next PCF for one of the two memory addresses of the spill
   output logic [P.XLEN-1:0]       IEUAdrSpillM, // IEUAdrM for one of the two memory addresses of the spill
   output logic                    SelSpillE, // During the transition between the two spill operations, the IFU should stall the pipeline
-  output logic [1:0]              MemRWSpillM, 
   output logic                    SelStoreDelay, //*** this is bad.  really don't like moving this outside
   output logic [P.LLEN-1:0]       DCacheReadDataWordSpillM, // The final 32 bit instruction after merging the two spilled fetches into 1 instruction
   output logic                    SpillStallM);
@@ -157,7 +155,6 @@ module align import cvw::*;  #(parameter cvw_t P) (
   assign SpillSaveM = (CurrState == STATE_READY) & ValidSpillM & ~FlushM;
   assign SelStoreDelay = (CurrState == STATE_STORE_DELAY);  // *** Can this be merged into the PreLSURWM logic?
   assign SpillStallM = SelSpillE | CurrState == STATE_STORE_DELAY;
-  mux2 #(2) memrwmux(MemRWM, 2'b00, SelStoreDelay, MemRWSpillM);
 
   ////////////////////////////////////////////////////////////////////////////////////////////////////
   // Merge spilled data

--- a/src/lsu/lsu.sv
+++ b/src/lsu/lsu.sv
@@ -160,7 +160,7 @@ module lsu import cvw::*;  #(parameter cvw_t P) (
     logic [P.XLEN-1:0] IEUAdrSpillE, IEUAdrSpillM;
     align #(P) align(.clk, .reset, .StallM, .FlushM, .IEUAdrE, .IEUAdrM, .Funct3M,
                      .MemRWM,
-                     .DCacheReadDataWordM, .CacheBusHPWTStall, .DTLBMissM, .DataUpdateDAM, .SelHPTW,
+                     .DCacheReadDataWordM, .CacheBusHPWTStall, .SelHPTW,
                      .ByteMaskM, .ByteMaskExtendedM, .LSUWriteDataM, .ByteMaskSpillM, .LSUWriteDataSpillM,
                      .IEUAdrSpillE, .IEUAdrSpillM, .SelSpillE, .DCacheReadDataWordSpillM, .SpillStallM,
                      .SelStoreDelay);

--- a/src/lsu/lsu.sv
+++ b/src/lsu/lsu.sv
@@ -159,10 +159,10 @@ module lsu import cvw::*;  #(parameter cvw_t P) (
   if(MISALIGN_SUPPORT) begin : ziccslm_align
     logic [P.XLEN-1:0] IEUAdrSpillE, IEUAdrSpillM;
     align #(P) align(.clk, .reset, .StallM, .FlushM, .IEUAdrE, .IEUAdrM, .Funct3M,
-                     .MemRWM, .CacheableM,
+                     .MemRWM,
                      .DCacheReadDataWordM, .CacheBusHPWTStall, .DTLBMissM, .DataUpdateDAM, .SelHPTW,
                      .ByteMaskM, .ByteMaskExtendedM, .LSUWriteDataM, .ByteMaskSpillM, .LSUWriteDataSpillM,
-                     .IEUAdrSpillE, .IEUAdrSpillM, .SelSpillE, .MemRWSpillM, .DCacheReadDataWordSpillM, .SpillStallM,
+                     .IEUAdrSpillE, .IEUAdrSpillM, .SelSpillE, .DCacheReadDataWordSpillM, .SpillStallM,
                      .SelStoreDelay);
     assign IEUAdrExtM = {2'b00, IEUAdrSpillM}; 
     assign IEUAdrExtE = {2'b00, IEUAdrSpillE};

--- a/src/lsu/lsu.sv
+++ b/src/lsu/lsu.sv
@@ -301,12 +301,14 @@ module lsu import cvw::*;  #(parameter cvw_t P) (
       logic                    FlushDCache;                                      // Suppress d cache flush if there is an ITLB miss.
       logic                    CacheStall;
       logic [1:0]              CacheBusRWTemp;
+      logic                    BusCMOZero;
 
       if(P.ZICBOZ_SUPPORTED) begin 
-        assign BusRW = ~CacheableM & ~SelDTIM ? CMOpM[3] ? 2'b01 : LSURWM : '0;
+        assign BusCMOZero = CMOpM[3] & ~CacheableM;
       end else begin
-        assign BusRW = ~CacheableM & ~SelDTIM ? LSURWM : '0;
+        assign BusCMOZero = '0;
       end
+      assign BusRW = ~CacheableM & ~SelDTIM ? LSURWM : '0;
       assign CacheableOrFlushCacheM = CacheableM | FlushDCacheM;
       assign CacheRWM = CacheableM & ~SelDTIM ? LSURWM : '0;
       assign FlushDCache = FlushDCacheM & ~(SelHPTW);
@@ -332,7 +334,7 @@ module lsu import cvw::*;  #(parameter cvw_t P) (
         .HRDATA, .HWDATA(LSUHWDATA), .HWSTRB(LSUHWSTRB),
         .HSIZE(LSUHSIZE), .HBURST(LSUHBURST), .HTRANS(LSUHTRANS), .HWRITE(LSUHWRITE), .HREADY(LSUHREADY),
         .BeatCount, .SelBusBeat, .CacheReadDataWordM(DCacheReadDataWordM[P.LLEN-1:0]), .WriteDataM(LSUWriteDataM),
-        .Funct3(LSUFunct3M), .HADDR(LSUHADDR), .CacheBusAdr(DCacheBusAdr), .CacheBusRW, .CacheableOrFlushCacheM,
+        .Funct3(LSUFunct3M), .HADDR(LSUHADDR), .CacheBusAdr(DCacheBusAdr), .CacheBusRW, .BusCMOZero, .CacheableOrFlushCacheM,
         .CacheBusAck(DCacheBusAck), .FetchBuffer, .PAdr(PAdrM),
         .Cacheable(CacheableOrFlushCacheM), .BusRW, .Stall(GatedStallW),
         .BusStall, .BusCommitted(BusCommittedM));

--- a/src/mmu/adrdecs.sv
+++ b/src/mmu/adrdecs.sv
@@ -30,18 +30,18 @@
 
 module adrdecs import cvw::*;  #(parameter cvw_t P) (
   input  logic [P.PA_BITS-1:0] PhysicalAddress,
-  input  logic                 AccessRW, AccessRX, AccessRWXZ, AccessRWC, AccessRXC,
+  input  logic                 AccessRW, AccessRX, AccessRWXC,
   input  logic [1:0]           Size,
   output logic [11:0]          SelRegions
 );
 
   localparam logic [3:0]       SUPPORTED_SIZE = (P.LLEN == 32 ? 4'b0111 : 4'b1111);
  // Determine which region of physical memory (if any) is being accessed
-  adrdec #(P.PA_BITS) dtimdec(PhysicalAddress, P.DTIM_BASE[P.PA_BITS-1:0], P.DTIM_RANGE[P.PA_BITS-1:0], P.DTIM_SUPPORTED, AccessRWC, Size, SUPPORTED_SIZE, SelRegions[11]);  
-  adrdec #(P.PA_BITS) iromdec(PhysicalAddress, P.IROM_BASE[P.PA_BITS-1:0], P.IROM_RANGE[P.PA_BITS-1:0], P.IROM_SUPPORTED, AccessRXC, Size, SUPPORTED_SIZE, SelRegions[10]);  
-  adrdec #(P.PA_BITS) ddr4dec(PhysicalAddress, P.EXT_MEM_BASE[P.PA_BITS-1:0], P.EXT_MEM_RANGE[P.PA_BITS-1:0], P.EXT_MEM_SUPPORTED, AccessRWXZ, Size, SUPPORTED_SIZE, SelRegions[9]);  
-  adrdec #(P.PA_BITS) bootromdec(PhysicalAddress, P.BOOTROM_BASE[P.PA_BITS-1:0], P.BOOTROM_RANGE[P.PA_BITS-1:0], P.BOOTROM_SUPPORTED, AccessRXC, Size, SUPPORTED_SIZE, SelRegions[8]);
-  adrdec #(P.PA_BITS) uncoreramdec(PhysicalAddress, P.UNCORE_RAM_BASE[P.PA_BITS-1:0], P.UNCORE_RAM_RANGE[P.PA_BITS-1:0], P.UNCORE_RAM_SUPPORTED, AccessRWXZ, Size, SUPPORTED_SIZE, SelRegions[7]);
+  adrdec #(P.PA_BITS) dtimdec(PhysicalAddress, P.DTIM_BASE[P.PA_BITS-1:0], P.DTIM_RANGE[P.PA_BITS-1:0], P.DTIM_SUPPORTED, AccessRW, Size, SUPPORTED_SIZE, SelRegions[11]);  
+  adrdec #(P.PA_BITS) iromdec(PhysicalAddress, P.IROM_BASE[P.PA_BITS-1:0], P.IROM_RANGE[P.PA_BITS-1:0], P.IROM_SUPPORTED, AccessRX, Size, SUPPORTED_SIZE, SelRegions[10]);  
+  adrdec #(P.PA_BITS) ddr4dec(PhysicalAddress, P.EXT_MEM_BASE[P.PA_BITS-1:0], P.EXT_MEM_RANGE[P.PA_BITS-1:0], P.EXT_MEM_SUPPORTED, AccessRWXC, Size, SUPPORTED_SIZE, SelRegions[9]);  
+  adrdec #(P.PA_BITS) bootromdec(PhysicalAddress, P.BOOTROM_BASE[P.PA_BITS-1:0], P.BOOTROM_RANGE[P.PA_BITS-1:0], P.BOOTROM_SUPPORTED, AccessRX, Size, SUPPORTED_SIZE, SelRegions[8]);
+  adrdec #(P.PA_BITS) uncoreramdec(PhysicalAddress, P.UNCORE_RAM_BASE[P.PA_BITS-1:0], P.UNCORE_RAM_RANGE[P.PA_BITS-1:0], P.UNCORE_RAM_SUPPORTED, AccessRWXC, Size, SUPPORTED_SIZE, SelRegions[7]);
   adrdec #(P.PA_BITS) clintdec(PhysicalAddress, P.CLINT_BASE[P.PA_BITS-1:0], P.CLINT_RANGE[P.PA_BITS-1:0], P.CLINT_SUPPORTED, AccessRW, Size, SUPPORTED_SIZE, SelRegions[6]);
   adrdec #(P.PA_BITS) gpiodec(PhysicalAddress, P.GPIO_BASE[P.PA_BITS-1:0], P.GPIO_RANGE[P.PA_BITS-1:0], P.GPIO_SUPPORTED, AccessRW, Size, 4'b0100, SelRegions[5]);
   adrdec #(P.PA_BITS) uartdec(PhysicalAddress, P.UART_BASE[P.PA_BITS-1:0], P.UART_RANGE[P.PA_BITS-1:0], P.UART_SUPPORTED, AccessRW, Size, 4'b0001, SelRegions[4]);

--- a/src/mmu/adrdecs.sv
+++ b/src/mmu/adrdecs.sv
@@ -30,17 +30,17 @@
 
 module adrdecs import cvw::*;  #(parameter cvw_t P) (
   input  logic [P.PA_BITS-1:0] PhysicalAddress,
-  input  logic                 AccessRW, AccessRX, AccessRWXZ, AccessRWZ, AccessRXZ,
+  input  logic                 AccessRW, AccessRX, AccessRWXZ, AccessRWC, AccessRXC,
   input  logic [1:0]           Size,
   output logic [11:0]          SelRegions
 );
 
   localparam logic [3:0]       SUPPORTED_SIZE = (P.LLEN == 32 ? 4'b0111 : 4'b1111);
  // Determine which region of physical memory (if any) is being accessed
-  adrdec #(P.PA_BITS) dtimdec(PhysicalAddress, P.DTIM_BASE[P.PA_BITS-1:0], P.DTIM_RANGE[P.PA_BITS-1:0], P.DTIM_SUPPORTED, AccessRWZ, Size, SUPPORTED_SIZE, SelRegions[11]);  
-  adrdec #(P.PA_BITS) iromdec(PhysicalAddress, P.IROM_BASE[P.PA_BITS-1:0], P.IROM_RANGE[P.PA_BITS-1:0], P.IROM_SUPPORTED, AccessRXZ, Size, SUPPORTED_SIZE, SelRegions[10]);  
+  adrdec #(P.PA_BITS) dtimdec(PhysicalAddress, P.DTIM_BASE[P.PA_BITS-1:0], P.DTIM_RANGE[P.PA_BITS-1:0], P.DTIM_SUPPORTED, AccessRWC, Size, SUPPORTED_SIZE, SelRegions[11]);  
+  adrdec #(P.PA_BITS) iromdec(PhysicalAddress, P.IROM_BASE[P.PA_BITS-1:0], P.IROM_RANGE[P.PA_BITS-1:0], P.IROM_SUPPORTED, AccessRXC, Size, SUPPORTED_SIZE, SelRegions[10]);  
   adrdec #(P.PA_BITS) ddr4dec(PhysicalAddress, P.EXT_MEM_BASE[P.PA_BITS-1:0], P.EXT_MEM_RANGE[P.PA_BITS-1:0], P.EXT_MEM_SUPPORTED, AccessRWXZ, Size, SUPPORTED_SIZE, SelRegions[9]);  
-  adrdec #(P.PA_BITS) bootromdec(PhysicalAddress, P.BOOTROM_BASE[P.PA_BITS-1:0], P.BOOTROM_RANGE[P.PA_BITS-1:0], P.BOOTROM_SUPPORTED, AccessRXZ, Size, SUPPORTED_SIZE, SelRegions[8]);
+  adrdec #(P.PA_BITS) bootromdec(PhysicalAddress, P.BOOTROM_BASE[P.PA_BITS-1:0], P.BOOTROM_RANGE[P.PA_BITS-1:0], P.BOOTROM_SUPPORTED, AccessRXC, Size, SUPPORTED_SIZE, SelRegions[8]);
   adrdec #(P.PA_BITS) uncoreramdec(PhysicalAddress, P.UNCORE_RAM_BASE[P.PA_BITS-1:0], P.UNCORE_RAM_RANGE[P.PA_BITS-1:0], P.UNCORE_RAM_SUPPORTED, AccessRWXZ, Size, SUPPORTED_SIZE, SelRegions[7]);
   adrdec #(P.PA_BITS) clintdec(PhysicalAddress, P.CLINT_BASE[P.PA_BITS-1:0], P.CLINT_RANGE[P.PA_BITS-1:0], P.CLINT_SUPPORTED, AccessRW, Size, SUPPORTED_SIZE, SelRegions[6]);
   adrdec #(P.PA_BITS) gpiodec(PhysicalAddress, P.GPIO_BASE[P.PA_BITS-1:0], P.GPIO_RANGE[P.PA_BITS-1:0], P.GPIO_SUPPORTED, AccessRW, Size, 4'b0100, SelRegions[5]);

--- a/src/mmu/mmu.sv
+++ b/src/mmu/mmu.sv
@@ -115,7 +115,7 @@ module mmu import cvw::*;  #(parameter cvw_t P,
   if (P.PMP_ENTRIES > 0) begin : pmp
     pmpchecker #(P) pmpchecker(.PhysicalAddress, .PrivilegeModeW,
       .PMPCFG_ARRAY_REGW, .PMPADDR_ARRAY_REGW,
-      .ExecuteAccessF, .WriteAccessM, .ReadAccessM,
+      .ExecuteAccessF, .WriteAccessM, .ReadAccessM, .CMOp, 
       .PMPInstrAccessFaultF, .PMPLoadAccessFaultM, .PMPStoreAmoAccessFaultM);
   end else begin
     assign PMPInstrAccessFaultF     = 0;

--- a/src/mmu/mmu.sv
+++ b/src/mmu/mmu.sv
@@ -85,7 +85,7 @@ module mmu import cvw::*;  #(parameter cvw_t P,
           .SATP_MODE(SATP_REGW[P.XLEN-1:P.XLEN-P.SVMODE_BITS]),
           .SATP_ASID(SATP_REGW[P.ASID_BASE+P.ASID_BITS-1:P.ASID_BASE]),
           .VAdr(VAdr[P.XLEN-1:0]), .STATUS_MXR, .STATUS_SUM, .STATUS_MPRV, .STATUS_MPP, .ENVCFG_PBMTE, .ENVCFG_HADE,
-          .PrivilegeModeW, .ReadAccess, .WriteAccess,
+          .PrivilegeModeW, .ReadAccess, .WriteAccess, .CMOp,
           .DisableTranslation, .PTE, .PageTypeWriteVal,
           .TLBWrite, .TLBFlush, .TLBPAdr, .TLBMiss, .TLBHit, 
           .Translate, .TLBPageFault, .UpdateDA, .PBMemoryType);

--- a/src/mmu/pmachecker.sv
+++ b/src/mmu/pmachecker.sv
@@ -77,5 +77,5 @@ module pmachecker import cvw::*;  #(parameter cvw_t P) (
   assign PMAAccessFault          = (SelRegions[0]) & AccessRWXZ | AtomicAccessM & ~AtomicAllowed;  
   assign PMAInstrAccessFaultF    = ExecuteAccessF & PMAAccessFault;
   assign PMALoadAccessFaultM     = ReadAccessM    & PMAAccessFault;
-  assign PMAStoreAmoAccessFaultM = WriteAccessM   & PMAAccessFault;
+  assign PMAStoreAmoAccessFaultM = (WriteAccessM | (P.ZICBOM_SUPPORTED & (|CMOp[2:0])) | (P.ZICBOZ_SUPPORTED & CMOp[3]))   & PMAAccessFault;
 endmodule

--- a/src/mmu/pmachecker.sv
+++ b/src/mmu/pmachecker.sv
@@ -51,7 +51,7 @@ module pmachecker import cvw::*;  #(parameter cvw_t P) (
 
   // Determine what type of access is being made
   assign AccessRW  = ReadAccessM | WriteAccessM;
-  assign AccessRWXC = ReadAccessM | WriteAccessM | ExecuteAccessF | (P.ZICBOM_SUPPORTED & (|CMOp[2:0])) | (P.ZICBOZ_SUPPORTED & (CMOp[3]));
+  assign AccessRWXC = ReadAccessM | WriteAccessM | ExecuteAccessF | (|CMOp);
   assign AccessRX  = ReadAccessM | ExecuteAccessF;
 
   // Determine which region of physical memory (if any) is being accessed
@@ -75,5 +75,5 @@ module pmachecker import cvw::*;  #(parameter cvw_t P) (
   assign PMAAccessFault          = (SelRegions[0]) & AccessRWXC | AtomicAccessM & ~AtomicAllowed;  
   assign PMAInstrAccessFaultF    = ExecuteAccessF & PMAAccessFault;
   assign PMALoadAccessFaultM     = ReadAccessM    & PMAAccessFault;
-  assign PMAStoreAmoAccessFaultM = (WriteAccessM | (P.ZICBOM_SUPPORTED & (|CMOp[2:0])) | (P.ZICBOZ_SUPPORTED & CMOp[3]))   & PMAAccessFault;
+  assign PMAStoreAmoAccessFaultM = (WriteAccessM | (|CMOp))   & PMAAccessFault;
 endmodule

--- a/src/mmu/pmachecker.sv
+++ b/src/mmu/pmachecker.sv
@@ -44,20 +44,20 @@ module pmachecker import cvw::*;  #(parameter cvw_t P) (
 );
 
   logic                        PMAAccessFault;
-  logic                        AccessRW, AccessRWXZ, AccessRX, AccessRWZ, AccessRXZ;
+  logic                        AccessRW, AccessRWXZ, AccessRX, AccessRWC, AccessRXC;
   logic [11:0]                 SelRegions;
   logic                        AtomicAllowed;
   logic                        CacheableRegion, IdempotentRegion;
 
   // Determine what type of access is being made
   assign AccessRW  = ReadAccessM | WriteAccessM;
-  assign AccessRWZ  = AccessRW | (P.ZICBOM_SUPPORTED & (|CMOp[2:0]));
+  assign AccessRWC  = AccessRW | (P.ZICBOM_SUPPORTED & (|CMOp[2:0]));
   assign AccessRWXZ = ReadAccessM | WriteAccessM | ExecuteAccessF | (P.ZICBOM_SUPPORTED & (|CMOp[2:0])) | (P.ZICBOZ_SUPPORTED & (CMOp[3]));
   assign AccessRX  = ReadAccessM | ExecuteAccessF;
-  assign AccessRXZ  = AccessRX | (P.ZICBOM_SUPPORTED & (|CMOp[2:0]));
+  assign AccessRXC  = AccessRX | (P.ZICBOM_SUPPORTED & (|CMOp[2:0]));
 
   // Determine which region of physical memory (if any) is being accessed
-  adrdecs #(P) adrdecs(PhysicalAddress, AccessRW, AccessRX, AccessRWXZ, AccessRWZ, AccessRXZ, Size, SelRegions);
+  adrdecs #(P) adrdecs(PhysicalAddress, AccessRW, AccessRX, AccessRWXZ, AccessRWC, AccessRXC, Size, SelRegions);
 
   // Only non-core RAM/ROM memory regions are cacheable. PBMT can override cachable; NC and IO are uncachable
   assign CacheableRegion = SelRegions[9] | SelRegions[8] | SelRegions[7];  // exclusion-tag: unused-cachable

--- a/src/mmu/pmachecker.sv
+++ b/src/mmu/pmachecker.sv
@@ -44,20 +44,18 @@ module pmachecker import cvw::*;  #(parameter cvw_t P) (
 );
 
   logic                        PMAAccessFault;
-  logic                        AccessRW, AccessRWXZ, AccessRX, AccessRWC, AccessRXC;
+  logic                        AccessRW, AccessRWXC, AccessRX;
   logic [11:0]                 SelRegions;
   logic                        AtomicAllowed;
   logic                        CacheableRegion, IdempotentRegion;
 
   // Determine what type of access is being made
   assign AccessRW  = ReadAccessM | WriteAccessM;
-  assign AccessRWC  = AccessRW | (P.ZICBOM_SUPPORTED & (|CMOp[2:0]));
-  assign AccessRWXZ = ReadAccessM | WriteAccessM | ExecuteAccessF | (P.ZICBOM_SUPPORTED & (|CMOp[2:0])) | (P.ZICBOZ_SUPPORTED & (CMOp[3]));
+  assign AccessRWXC = ReadAccessM | WriteAccessM | ExecuteAccessF | (P.ZICBOM_SUPPORTED & (|CMOp[2:0])) | (P.ZICBOZ_SUPPORTED & (CMOp[3]));
   assign AccessRX  = ReadAccessM | ExecuteAccessF;
-  assign AccessRXC  = AccessRX | (P.ZICBOM_SUPPORTED & (|CMOp[2:0]));
 
   // Determine which region of physical memory (if any) is being accessed
-  adrdecs #(P) adrdecs(PhysicalAddress, AccessRW, AccessRX, AccessRWXZ, AccessRWC, AccessRXC, Size, SelRegions);
+  adrdecs #(P) adrdecs(PhysicalAddress, AccessRW, AccessRX, AccessRWXC, Size, SelRegions);
 
   // Only non-core RAM/ROM memory regions are cacheable. PBMT can override cachable; NC and IO are uncachable
   assign CacheableRegion = SelRegions[9] | SelRegions[8] | SelRegions[7];  // exclusion-tag: unused-cachable
@@ -74,7 +72,7 @@ module pmachecker import cvw::*;  #(parameter cvw_t P) (
   assign SelTIM = SelRegions[11] | SelRegions[10]; // exclusion-tag: unused-idempotent
 
   // Detect access faults
-  assign PMAAccessFault          = (SelRegions[0]) & AccessRWXZ | AtomicAccessM & ~AtomicAllowed;  
+  assign PMAAccessFault          = (SelRegions[0]) & AccessRWXC | AtomicAccessM & ~AtomicAllowed;  
   assign PMAInstrAccessFaultF    = ExecuteAccessF & PMAAccessFault;
   assign PMALoadAccessFaultM     = ReadAccessM    & PMAAccessFault;
   assign PMAStoreAmoAccessFaultM = (WriteAccessM | (P.ZICBOM_SUPPORTED & (|CMOp[2:0])) | (P.ZICBOZ_SUPPORTED & CMOp[3]))   & PMAAccessFault;

--- a/src/mmu/tlb/tlb.sv
+++ b/src/mmu/tlb/tlb.sv
@@ -62,6 +62,7 @@ module tlb import cvw::*;  #(parameter cvw_t P,
   input  logic [1:0]               PrivilegeModeW,   // Current privilege level of the processeor
   input  logic                     ReadAccess, 
   input  logic                     WriteAccess,
+  input  logic [3:0]               CMOp,
   input  logic                     DisableTranslation,
   input  logic [P.XLEN-1:0]        VAdr,             // address input before translation (could be physical or virtual)
   input  logic [P.XLEN-1:0]        PTE,              // page table entry to write
@@ -106,7 +107,7 @@ module tlb import cvw::*;  #(parameter cvw_t P,
   assign VPN = VAdr[P.VPN_BITS+11:12];
 
   tlbcontrol #(P, ITLB) tlbcontrol(.SATP_MODE, .VAdr, .STATUS_MXR, .STATUS_SUM, .STATUS_MPRV, .STATUS_MPP, .ENVCFG_PBMTE, .ENVCFG_HADE,
-    .PrivilegeModeW, .ReadAccess, .WriteAccess, .DisableTranslation, .TLBFlush,
+    .PrivilegeModeW, .ReadAccess, .WriteAccess, .CMOp, .DisableTranslation, .TLBFlush,
     .PTEAccessBits, .CAMHit, .Misaligned, 
     .TLBMiss, .TLBHit, .TLBPageFault, 
     .UpdateDA, .SV39Mode, .Translate, .PTE_N, .PBMemoryType);

--- a/src/uncore/uncore.sv
+++ b/src/uncore/uncore.sv
@@ -88,7 +88,7 @@ module uncore import cvw::*;  #(parameter cvw_t P)(
   // Determine which region of physical memory (if any) is being accessed
   // Use a trimmed down portion of the PMA checker - only the address decoders
   // Set access types to all 1 as don't cares because the MMU has already done access checking
-  adrdecs #(P) adrdecs(HADDR, 1'b1, 1'b1, 1'b1, 1'b1, 1'b1, HSIZE[1:0], HSELRegions);
+  adrdecs #(P) adrdecs(HADDR, 1'b1, 1'b1, 1'b1, HSIZE[1:0], HSELRegions);
 
   // unswizzle HSEL signals
   assign {HSELDTIM, HSELIROM, HSELEXT, HSELBootRom, HSELRam, HSELCLINT, HSELGPIO, HSELUART, HSELPLIC, HSELEXTSDC, HSELSPI} = HSELRegions[11:1];


### PR DESCRIPTION
- Fixed subtle bug in the embench makefile if the sim/wkdir directory did not exist.
- Fixed repeatability issues with the branch predictor simulator results generation. I reran using a clean clone of the repo so this should be working now.
- Added files to ignore file.
- Changes to support concurrent simulation of all the branch predictor sweeps.
- Fixed subtle bug in branch prediction post processing script.
- Last little hickups out of the branch predictor results parsing.
- Fixed bug in the wally do script.
- Sutble bug in the cacheway logic for cacheline invalidation.
- Clarified names in cacheway.
- Reduced cache fsm complexity.
- More cache simplifications.
- Modified the pmachecker to correctly check the permissions for cmo instructions. However this isn't fully tested.
- Added correct cbo fault behavior.
- Extended the abhcacheinterface to zero a cacheline's worth of uncached memory on cbo.zero.
- Fixed minor bug in the cbo hazard logic.
- Renamed signal in pmachecker.
- Oups. Introduced undetected bug into the cache's cbo insructions.
