### PR TITLE
Fix issue with running all and then going from one operand width to a…

### DIFF
--- a/testbench/testbench-fp.sv
+++ b/testbench/testbench-fp.sv
@@ -88,7 +88,6 @@ module testbenchfp;
    logic 			OldFDivBusyE;
    logic                        reset = 1'b0;
    logic [$clog2(P.NF+2)-1:0] 	XZeroCnt, YZeroCnt;
-   logic [P.DURLEN-1:0] 	Dur;
 
    // in-between FMA signals
    logic                        Mult;
@@ -779,19 +778,19 @@ module testbenchfp;
       end
       else if (UnitVal === `CVTFPUNIT) begin
 	 case (OpCtrlVal[1:0])
-           4'b11: begin // quad             
+           2'b11: begin // quad             
               AnsNaN = &Ans[P.Q_LEN-2:P.NF]&(|Ans[P.Q_NF-1:0]);
               ResNaN = &Res[P.Q_LEN-2:P.NF]&(|Res[P.Q_NF-1:0]);
            end
-           4'b01: begin // double                 
+           2'b01: begin // double                 
               AnsNaN = &Ans[P.D_LEN-2:P.D_NF]&(|Ans[P.D_NF-1:0]);
               ResNaN = &Res[P.D_LEN-2:P.D_NF]&(|Res[P.D_NF-1:0]);
            end
-           4'b00: begin // single
+           2'b00: begin // single
               AnsNaN = &Ans[P.S_LEN-2:P.S_NF]&(|Ans[P.S_NF-1:0]);
               ResNaN = &Res[P.S_LEN-2:P.S_NF]&(|Res[P.S_NF-1:0]);
            end
-           4'b10: begin // half
+           2'b10: begin // half
               AnsNaN = &Ans[P.H_LEN-2:P.H_NF]&(|Ans[P.H_NF-1:0]);
               ResNaN = &Res[P.H_LEN-2:P.H_NF]&(|Res[P.H_NF-1:0]);
            end
@@ -799,19 +798,19 @@ module testbenchfp;
       end
       else begin
 	 case (FmtVal)
-           4'b11: begin // quad             
+           2'b11: begin // quad             
               AnsNaN = &Ans[P.Q_LEN-2:P.Q_NF]&(|Ans[P.Q_NF-1:0]);
               ResNaN = &Res[P.Q_LEN-2:P.Q_NF]&(|Res[P.Q_NF-1:0]);
            end
-           4'b01: begin // double                 
+           2'b01: begin // double                 
               AnsNaN = &Ans[P.D_LEN-2:P.D_NF]&(|Ans[P.D_NF-1:0]);
               ResNaN = &Res[P.D_LEN-2:P.D_NF]&(|Res[P.D_NF-1:0]);
            end
-           4'b00: begin // single
+           2'b00: begin // single
               AnsNaN = &Ans[P.S_LEN-2:P.S_NF]&(|Ans[P.S_NF-1:0]);
               ResNaN = &Res[P.S_LEN-2:P.S_NF]&(|Res[P.S_NF-1:0]);
            end
-           4'b10: begin // half
+           2'b10: begin // half
               AnsNaN = &Ans[P.H_LEN-2:P.H_NF]&(|Ans[P.H_NF-1:0]);
               ResNaN = &Res[P.H_LEN-2:P.H_NF]&(|Res[P.H_NF-1:0]);
            end
@@ -852,22 +851,22 @@ module testbenchfp;
 	 // arbitrary value and can be changed, if needed.
 	 case (FmtVal)
 	   // QP
-	   4'b11: begin
+	   2'b11: begin
 	      repeat (20)
 		@(posedge clk);
 	   end
 	   // HP
-	   4'b10: begin
+	   2'b10: begin
 	      repeat (14)
 		@(posedge clk);
 	   end
 	   // DP
-	   4'b01: begin
+	   2'b01: begin
 	      repeat (18)
 		@(posedge clk);
 	   end
 	   // SP
-	   4'b00: begin
+	   2'b00: begin
 	      repeat (16)
 		@(posedge clk);
 	   end
@@ -884,22 +883,22 @@ module testbenchfp;
       //    - when 2 or more NaNs are inputed the NaN that is propigated doesn't matter
       if (UnitVal !== `CVTFPUNIT & UnitVal !== `CVTINTUNIT)
 	case (FmtVal)
-          4'b11: NaNGood =  (((P.IEEE754==0)&AnsNaN&(Res === {1'b0, {P.Q_NE+1{1'b1}}, {P.Q_NF-1{1'b0}}})) |
+          2'b11: NaNGood =  (((P.IEEE754==0)&AnsNaN&(Res === {1'b0, {P.Q_NE+1{1'b1}}, {P.Q_NF-1{1'b0}}})) |
                              (AnsFlg[4]&(Res[P.Q_LEN-2:0] === {{P.Q_NE+1{1'b1}}, {P.Q_NF-1{1'b0}}})) |
                              (XNaN&(Res[P.Q_LEN-2:0] === {X[P.Q_LEN-2:P.Q_NF],1'b1,X[P.Q_NF-2:0]})) | 
                              (YNaN&(Res[P.Q_LEN-2:0] === {Y[P.Q_LEN-2:P.Q_NF],1'b1,Y[P.Q_NF-2:0]})) |
                              (ZNaN&(Res[P.Q_LEN-2:0] === {Z[P.Q_LEN-2:P.Q_NF],1'b1,Z[P.Q_NF-2:0]})));
-          4'b01: NaNGood =  (((P.IEEE754==0)&AnsNaN&(Res[P.D_LEN-1:0] === {1'b0, {P.D_NE+1{1'b1}}, {P.D_NF-1{1'b0}}})) |
+          2'b01: NaNGood =  (((P.IEEE754==0)&AnsNaN&(Res[P.D_LEN-1:0] === {1'b0, {P.D_NE+1{1'b1}}, {P.D_NF-1{1'b0}}})) |
                              (AnsFlg[4]&(Res[P.D_LEN-2:0] === {{P.D_NE+1{1'b1}}, {P.D_NF-1{1'b0}}})) |
                              (XNaN&(Res[P.D_LEN-2:0] === {X[P.D_LEN-2:P.D_NF],1'b1,X[P.D_NF-2:0]})) | 
                              (YNaN&(Res[P.D_LEN-2:0] === {Y[P.D_LEN-2:P.D_NF],1'b1,Y[P.D_NF-2:0]})) |
                              (ZNaN&(Res[P.D_LEN-2:0] === {Z[P.D_LEN-2:P.D_NF],1'b1,Z[P.D_NF-2:0]})));
-          4'b00: NaNGood =  (((P.IEEE754==0)&AnsNaN&(Res[P.S_LEN-1:0] === {1'b0, {P.S_NE+1{1'b1}}, {P.S_NF-1{1'b0}}})) |
+          2'b00: NaNGood =  (((P.IEEE754==0)&AnsNaN&(Res[P.S_LEN-1:0] === {1'b0, {P.S_NE+1{1'b1}}, {P.S_NF-1{1'b0}}})) |
                              (AnsFlg[4]&(Res[P.S_LEN-2:0] === {{P.S_NE+1{1'b1}}, {P.S_NF-1{1'b0}}})) |
                              (XNaN&(Res[P.S_LEN-2:0] === {X[P.S_LEN-2:P.S_NF],1'b1,X[P.S_NF-2:0]})) | 
                              (YNaN&(Res[P.S_LEN-2:0] === {Y[P.S_LEN-2:P.S_NF],1'b1,Y[P.S_NF-2:0]})) |
                              (ZNaN&(Res[P.S_LEN-2:0] === {Z[P.S_LEN-2:P.S_NF],1'b1,Z[P.S_NF-2:0]})));
-          4'b10: NaNGood =  (((P.IEEE754==0)&AnsNaN&(Res[P.H_LEN-1:0] === {1'b0, {P.H_NE+1{1'b1}}, {P.H_NF-1{1'b0}}})) |
+          2'b10: NaNGood =  (((P.IEEE754==0)&AnsNaN&(Res[P.H_LEN-1:0] === {1'b0, {P.H_NE+1{1'b1}}, {P.H_NF-1{1'b0}}})) |
                              (AnsFlg[4]&(Res[P.H_LEN-2:0] === {{P.H_NE+1{1'b1}}, {P.H_NF-1{1'b0}}})) |
                              (XNaN&(Res[P.H_LEN-2:0] === {X[P.H_LEN-2:P.H_NF],1'b1,X[P.H_NF-2:0]})) | 
                              (YNaN&(Res[P.H_LEN-2:0] === {Y[P.H_LEN-2:P.H_NF],1'b1,Y[P.H_NF-2:0]})) |
@@ -985,8 +984,14 @@ module testbenchfp;
 	 // incemet the operation if all the rounding modes have been tested
 	 if (FrmNum === 4) OpCtrlNum += 1;
 	 // increment the rounding mode or loop back to rne 
-	 if (FrmNum < 4) FrmNum += 1;
-	 else FrmNum = 0; 
+	 if (FrmNum < 4) 
+	   FrmNum += 1;
+	 else begin
+	   FrmNum = 0;
+	    // Add some time as a buffer between tests at the end of each test
+	    repeat (10)
+	      @(posedge clk);
+	 end	 
 	 // if no more Tests - finish
 	 if (Tests[TestNum] === "") begin
             $display("\nAll Tests completed with %d errors\n", errors);


### PR DESCRIPTION
…nother.  Issue is due to signals resolving between sizes.  I did not catch it before because I did not run through the complete exhaustive tests.  This time, went through all tests and tested all the data sizes.