### PR TITLE
Fixed testbench for coremark. Possibly broke verilator.

### DIFF
--- a/benchmarks/coremark/riscv64-baremetal/crt.S
+++ b/benchmarks/coremark/riscv64-baremetal/crt.S
@@ -134,6 +134,8 @@ _start:
   add sp, sp, tp
 
   j _init
+sig_end_canary:       
+  nop
 
   .align 2
 trap_entry:

--- a/testbench/testbench.sv
+++ b/testbench/testbench.sv
@@ -387,7 +387,15 @@ module testbench;
       end
     end
   end
- 
+
+  // *** 06 January 2024 RT: may have to uncomment this block for vcs/verilator
+  integer adrindex;
+  if (P.UNCORE_RAM_SUPPORTED)
+    always @(posedge clk) 
+      if (ResetMem)  // program memory is sometimes reset
+        for (adrindex=0; adrindex<(P.UNCORE_RAM_RANGE>>1+(P.XLEN/32)); adrindex = adrindex+1) 
+          dut.uncore.uncore.ram.ram.memory.RAM[adrindex] = '0;
+
   ////////////////////////////////////////////////////////////////////////////////
   // Actual hardware
   ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
- Fixed bug # 547, but there are other bugs which follow.
- added sig_end_canary to coremark.
- Fixes coremark. Maybe works with verilator.
