### PR TITLE
TLB fixes; Resolves Issue #547

### DIFF
--- a/benchmarks/coremark/riscv64-baremetal/core_portme.h
+++ b/benchmarks/coremark/riscv64-baremetal/core_portme.h
@@ -109,7 +109,8 @@ typedef unsigned short ee_u16;
 typedef signed int ee_s32;
 typedef double ee_f32;
 typedef unsigned char ee_u8;
-typedef unsigned int ee_u32;
+//typedef unsigned int ee_u32;
+typedef signed int ee_u32; // replaced with signed to improve performance per https://github.com/sifive/benchmark-coremark/blob/master/linux64/core_portme.h#L102
 #if (XLEN==64) 
 	typedef unsigned long long ee_ptr_int;
 #else

--- a/bin/wally-tool-chain-install.sh
+++ b/bin/wally-tool-chain-install.sh
@@ -113,7 +113,7 @@ cd ../arch_test_target/spike/device
 sed -i 's/--isa=rv32ic/--isa=rv32iac/' rv32i_m/privilege/Makefile.include
 sed -i 's/--isa=rv64ic/--isa=rv64iac/' rv64i_m/privilege/Makefile.include
 
-# Wally needs Verilator 5.0 or later.
+# Wally needs Verilator 5.021 or later.
 # Verilator needs to be built from scratch to get the latest version
 # apt-get install verilator installs version 4.028 as of 6/8/23
 sudo apt-get install -y perl g++ ccache help2man libgoogle-perftools-dev numactl perl-doc zlib1g 

--- a/setup.sh
+++ b/setup.sh
@@ -54,5 +54,7 @@ if [ -e "$IDV" ]; then
     export PATH=$IDV/scripts/cvw:$PATH
 fi
 
+# Verilator needs a larger stack to simulate CORE-V Wally
+ulimit -s 100000
 
 echo "setup done"

--- a/sim/coverage-exclusions-rv64gc.do
+++ b/sim/coverage-exclusions-rv64gc.do
@@ -198,17 +198,17 @@ set line [GetLineNum ../src/mmu/mmu.sv "TLBPageFault & ExecuteAccessF"]
 coverage exclude -scope /dut/core/ifu/immu/immu -linerange $line-$line -item e 1 -fecexprrow 3
 set line [GetLineNum ../src/mmu/mmu.sv "TLBPageFault & ReadNoAmoAccessM"] 
 coverage exclude -scope /dut/core/ifu/immu/immu -linerange $line-$line -item e 1 -fecexprrow 1,2,4
-#set line [GetLineNum ../src/mmu/mmu.sv "TLBPageFault & WriteAccessM"] 
-#coverage exclude -scope /dut/core/ifu/immu/immu -linerange $line-$line -item e 1 -fecexprrow 1,2,4
+set line [GetLineNum ../src/mmu/mmu.sv "StoreAmoPageFaultM \="] 
+coverage exclude -scope /dut/core/ifu/immu/immu -linerange $line-$line -item e 1 -fecexprrow 1,2,4
 set line [GetLineNum ../src/mmu/mmu.sv "DataMisalignedM & ReadNoAmoAccessM"] 
 coverage exclude -scope /dut/core/ifu/immu/immu -linerange $line-$line -item e 1 -fecexprrow 1,2,4
 set line [GetLineNum ../src/mmu/pmpchecker.sv "EnforcePMP & WriteAccessM"] 
 coverage exclude -scope /dut/core/ifu/immu/immu/pmp/pmpchecker -linerange $line-$line -item e 1 -fecexprrow 1,2,4,5,6
 set line [GetLineNum ../src/mmu/pmpchecker.sv "EnforcePMP & ReadAccessM"] 
 coverage exclude -scope /dut/core/ifu/immu/immu/pmp/pmpchecker -linerange $line-$line -item e 1 -fecexprrow 1,2,4,5,6
-set line [GetLineNum ../src/mmu/mmu.sv "PMALoadAccessFaultM     \\| PMPLoadAccessFaultM"] 
+set line [GetLineNum ../src/mmu/mmu.sv "LoadAccessFaultM     \="] 
 coverage exclude -scope /dut/core/ifu/immu/immu -linerange $line-$line -item e 1 -fecexprrow 2,4,5,6
-set line [GetLineNum ../src/mmu/mmu.sv "PMAStoreAmoAccessFaultM \\| PMPStoreAmoAccessFaultM"] 
+set line [GetLineNum ../src/mmu/mmu.sv "StoreAmoAccessFaultM \="] 
 coverage exclude -scope /dut/core/ifu/immu/immu -linerange $line-$line -item e 1 -fecexprrow 2,4,5,6
 set line [GetLineNum ../src/mmu/tlb/tlbcontrol.sv "ReadAccess \\| WriteAccess"] 
 coverage exclude -scope /dut/core/ifu/immu/immu/tlb/tlb/tlbcontrol -linerange $line-$line -item e 1 -fecexprrow 1,3,4

--- a/sim/coverage-exclusions-rv64gc.do
+++ b/sim/coverage-exclusions-rv64gc.do
@@ -198,8 +198,8 @@ set line [GetLineNum ../src/mmu/mmu.sv "TLBPageFault & ExecuteAccessF"]
 coverage exclude -scope /dut/core/ifu/immu/immu -linerange $line-$line -item e 1 -fecexprrow 3
 set line [GetLineNum ../src/mmu/mmu.sv "TLBPageFault & ReadNoAmoAccessM"] 
 coverage exclude -scope /dut/core/ifu/immu/immu -linerange $line-$line -item e 1 -fecexprrow 1,2,4
-set line [GetLineNum ../src/mmu/mmu.sv "TLBPageFault & WriteAccessM"] 
-coverage exclude -scope /dut/core/ifu/immu/immu -linerange $line-$line -item e 1 -fecexprrow 1,2,4
+#set line [GetLineNum ../src/mmu/mmu.sv "TLBPageFault & WriteAccessM"] 
+#coverage exclude -scope /dut/core/ifu/immu/immu -linerange $line-$line -item e 1 -fecexprrow 1,2,4
 set line [GetLineNum ../src/mmu/mmu.sv "DataMisalignedM & ReadNoAmoAccessM"] 
 coverage exclude -scope /dut/core/ifu/immu/immu -linerange $line-$line -item e 1 -fecexprrow 1,2,4
 set line [GetLineNum ../src/mmu/pmpchecker.sv "EnforcePMP & WriteAccessM"] 
@@ -229,6 +229,12 @@ set line [GetLineNum ../src/ifu/ifu.sv "~ITLBMissF & ~CacheableF & ~SelIROM"]
 coverage exclude -scope /dut/core/ifu -linerange $line-$line -item c 1 -feccondrow 6
 set line [GetLineNum ../src/ifu/ifu.sv "~ITLBMissF & CacheableF & ~SelIROM"] 
 coverage exclude -scope /dut/core/ifu -linerange $line-$line -item c 1 -feccondrow 4
+
+# no DTIM 
+set line [GetLineNum ../src/lsu/lsu.sv "assign BusRW"] 
+coverage exclude -scope /dut/core/lsu -linerange $line-$line -item c 1 -feccondrow 4
+set line [GetLineNum ../src/lsu/lsu.sv "assign CacheRWM"] 
+coverage exclude -scope /dut/core/lsu -linerange $line-$line -item c 1 -feccondrow 4
 
 # Excluding reset and clear for impossible case in the wficountreg in privdec
 set line [GetLineNum ../src/generic/flop/floprc.sv "reset \\| clear"]

--- a/sim/regression-wally
+++ b/sim/regression-wally
@@ -133,7 +133,7 @@ tests64gc = ["arch64f", "arch64d", "arch64f_fma", "arch64d_fma", "arch64i", "arc
 if (coverage):  # delete all but 64gc tests when running coverage
     configs = []
     tests64gc = ["coverage64gc", "arch64i", "arch64priv", "arch64c",  "arch64m", 
-                 "arch64zifencei", "wally64a", "wally64periph", "wally64priv", 
+                 "arch64zifencei", "arch64a", "wally64a", "wally64periph", "wally64priv", 
                  "arch64zba",  "arch64zbb",  "arch64zbc",  "arch64zbs"] # add when working: "arch64zicboz", "arch64zcb", 
     if (fp):
        tests64gc.append("arch64f")

--- a/sim/verilate
+++ b/sim/verilate
@@ -1,7 +1,8 @@
 #!/bin/bash
 # simulate with Verilator
 
-# verilator --timescale "1ns/1ns" --timing --binary -GTEST="arch64i" --top-module testbench "-I../config/shared" "-I../config/rv64gc" ../src/cvw.sv ../testbench/testbench.sv ../testbench/common/*.sv ../src/*/*.sv ../src/*/*/*.sv --relative-includes
+# verilator -CFLAGS -DVL_DEBUG -CFLAGS -D_GLIBCXX_DEBUG -CFLAGS -ggdb -LDFLAGS -ggdb -CFLAGS -fsanitize=address,undefined -LDFLAGS -fsanitize=address,undefined --timescale "1ns/1ns" --timing --binary --top-module testbench "-I../config/shared" "-I../config/rv64gc" ../src/cvw.sv ../testbench/testbench.sv ../testbench/common/*.sv ../src/*/*.sv ../src/*/*/*.sv --relative-includes
+# verilator -GTEST="arch64i" --timescale "1ns/1ns" --timing --binary --top-module testbench "-I../config/shared" "-I../config/rv64gc" ../src/cvw.sv ../testbench/testbench.sv ../testbench/common/*.sv ../src/*/*.sv ../src/*/*/*.sv --relative-includes
 
 export PATH=$PATH:/usr/local/bin/
 verilator=`which verilator`

--- a/sim/verilate
+++ b/sim/verilate
@@ -2,7 +2,7 @@
 # simulate with Verilator
 
 # verilator -CFLAGS -DVL_DEBUG -CFLAGS -D_GLIBCXX_DEBUG -CFLAGS -ggdb -LDFLAGS -ggdb -CFLAGS -fsanitize=address,undefined -LDFLAGS -fsanitize=address,undefined --timescale "1ns/1ns" --timing --binary --top-module testbench "-I../config/shared" "-I../config/rv64gc" ../src/cvw.sv ../testbench/testbench.sv ../testbench/common/*.sv ../src/*/*.sv ../src/*/*/*.sv --relative-includes
-# verilator -GTEST="arch64i" --timescale "1ns/1ns" --timing --binary --top-module testbench "-I../config/shared" "-I../config/rv64gc" ../src/cvw.sv ../testbench/testbench.sv ../testbench/common/*.sv ../src/*/*.sv ../src/*/*/*.sv --relative-includes
+# verilator -GTEST="\"arch64i\"" --timescale "1ns/1ns" --timing --binary --top-module testbench "-I../config/shared" "-I../config/rv64gc" ../src/cvw.sv ../testbench/testbench.sv ../testbench/common/*.sv ../src/*/*.sv ../src/*/*/*.sv --relative-includes
 
 export PATH=$PATH:/usr/local/bin/
 verilator=`which verilator`
@@ -12,7 +12,7 @@ basepath=$(dirname $0)/..
 for config in  rv64gc; do
     echo "$config simulating..."
     # not working: -GTEST="arch64i"
-    if !($verilator --timescale "1ns/1ns" --timing --binary "$@" -GTEST="arch64i" --top-module testbench "-I$basepath/config/shared" "-I$basepath/config/$config" $basepath/src/cvw.sv $basepath/testbench/testbench.sv $basepath/testbench/common/*.sv   $basepath/src/*/*.sv $basepath/src/*/*/*.sv --relative-includes ); then
+    if !($verilator --timescale "1ns/1ns" --timing --binary "$@" -GTEST="\"arch64i\"" --top-module testbench "-I$basepath/config/shared" "-I$basepath/config/$config" $basepath/src/cvw.sv $basepath/testbench/testbench.sv $basepath/testbench/common/*.sv   $basepath/src/*/*.sv $basepath/src/*/*/*.sv --relative-includes ); then
         echo "Exiting after $config lint due to errors or warnings"
         exit 1
     fi

--- a/src/mmu/tlb/tlbcontrol.sv
+++ b/src/mmu/tlb/tlbcontrol.sv
@@ -97,7 +97,7 @@ module tlbcontrol import cvw::*;  #(parameter cvw_t P, ITLB = 0) (
     assign PreUpdateDA = ~PTE_A;
     assign InvalidAccess = ~PTE_X;
  end else begin:dtlb // Data TLB fault checking
-    logic InvalidRead, InvalidWrite, ReservtedEncoding;
+    logic InvalidRead, InvalidWrite, ReservedEncoding;
     logic InvalidCBOM, InvalidCBOZ;
 
     // User mode may only load/store from user mode pages, and supervisor mode

--- a/tests/coverage/tlbmisc.S
+++ b/tests/coverage/tlbmisc.S
@@ -59,7 +59,7 @@ main:
     li t0, 0x80200000
     jalr ra, t0 # jump to misaligned megapage
 
-    # exercise ebufsmarb
+    # exercise ebufsmarb (not yet providing coverage 1/1/24 DH & RT)
     li t0, 0x80000000
     lw t1, 0(t0)        # fetch from an address to warm up tlb entries
     li t0, 0x80A00000
@@ -80,6 +80,20 @@ main:
     sw t1, 0(t0)    # write to page
     jalr ra, t0     # jump to page
 
+    # jump to address for TLB miss to trigger HPTW to make access with DisableTranslation = 1, Translate = 0
+    li t0, 0x80805000
+    jalr ra, t0         
+
+    # Good PBMT with menvcfg.PBMTE = 0
+    li t0, 3
+    ecall   # switch to machine mode
+    li t5, 0x1
+    slli t5, t5, 62
+    csrc menvcfg, t5  # menvcfg.PBMTE = 0
+    li t0, 1
+    ecall   # switch back to supervisor mode
+    li t0, 0x80806000
+    jalr ra, t0      # jump to page to exercise ITLB with PBMT !=0 when ENVCFG_BPMTE=0
 
     # change back to default trap handler after checking everything that might cause an instruction page fault
     jal changetodefaulthandler
@@ -135,7 +149,6 @@ main:
     csrc mstatus, t0 # mstatus.mxr = 1
     li a0, 1
     ecall
-
 
     # wrap up
     li a0, 3 # switch back to machine mode because code at 0x80000000 may not have clean page table entry
@@ -327,7 +340,8 @@ pagetable:
     .8byte 0x00000000200000CF   # valid rwx for VA 80800000
     .8byte 0x00000000200000CB   # valid r x for VA 80801000
     .8byte 0x00000000200000C3   # valid r   for VA 80802000
-    .8byte 0x00000000200000C5   # valid   x for VA 80803000
+    .8byte 0x00000000200000C9   # valid   x for VA 80803000
     .8byte 0x00000000200000CD   # valid  wx for VA 80804000 (illegal combination, but used to test tlbcontrol)
-
+    .8byte 0x000000002000000F   # valid rwx for VA 80805000  for covering ITLB translate and UpdateDA
+    .8byte 0x20000000200000CF   # PBMT=1    for VA 80806000  for covering ITLB BadPBMT
 


### PR DESCRIPTION
Improved tlbcontrol to fault on R=0,W=1
fixed more coverage tests in tlbmisc.S
changed integer type to try to speed up CoreMark
comments in Verilate

In conjunction with PR553 resolves issue #547