### PR TITLE
Fixed missing Zba ISA string from spike_rv64gc_isa.yaml for RISCOF

### DIFF
--- a/tests/riscof/spike/spike_rv64gc_isa.yaml
+++ b/tests/riscof/spike/spike_rv64gc_isa.yaml
@@ -1,8 +1,8 @@
 hart_ids: [0]
 hart0:
-#  ISA: RV64IMAFDCSUZicsr_Zicboz_Zifencei_Zbb_Zbc_Zbs # Zkbs_Zcb
-#  ISA: RV64IMAFDCSUZicsr_Zifencei_Zca_Zcb_Zbb_Zbc_Zbs # Zkbs_Zcb
-  ISA: RV64IMAFDCSUZicsr_Zifencei_Zbb_Zbc_Zbs # Zkbs_Zcb
+#  ISA: RV64IMAFDCSUZicsr_Zicboz_Zifencei_Zba_Zbb_Zbc_Zbs # Zkbs_Zcb
+#  ISA: RV64IMAFDCSUZicsr_Zifencei_Zca_Zcb_Zba_Zbb_Zbc_Zbs # Zkbs_Zcb
+  ISA: RV64IMAFDCSUZicsr_Zifencei_Zba_Zbb_Zbc_Zbs # Zkbs_Zcb
   physical_addr_sz: 56
   User_Spec_Version: '2.3'
   supported_xlen: [64]


### PR DESCRIPTION
Caused slli.uw in riscv64gc_arch64za test to fail.