### PR TITLE
Update recent Issue 541 due to differences in RISC-V vs. IEEE 754 for fp -> integer/long conversion

### DIFF
--- a/examples/fp/softfloat_demo/Makefile
+++ b/examples/fp/softfloat_demo/Makefile
@@ -6,7 +6,7 @@ LFLAGS = -L.
 # Link against the riscv-isa-sim version of SoftFloat rather than 
 # the regular version to get RISC-V NaN behavior
 #IFLAGS   = -I$(RISCV)/riscv-isa-sim/softfloat
-#LIBS   = $(RISCV)/riscv-isa-sim/build/libsoftfloat.a
+#LIBS   = $(RISCV)/riscv-isa-sim/build/libsoftfloat.a -lm -lquadmath
 IFLAGS = -I../../../addins/SoftFloat-3e/source/include/
 LIBS   = ../../../addins/SoftFloat-3e/build/Linux-x86_64-GCC/softfloat.a -lm -lquadmath
 SRCS   = $(wildcard *.c)

--- a/examples/fp/softfloat_demo/softfloat_demoDP.c
+++ b/examples/fp/softfloat_demo/softfloat_demoDP.c
@@ -38,16 +38,19 @@ void printF64 (char *msg, float64_t d) {
   int i, j;
   conv.v = d.v; // use union to convert between hexadecimal and floating-point views
   printf("%s: ", msg);  // print out nicely
-  printf("0x%08x_%08x = %g\n", (conv.v >> 32),(conv.v & 0xFFFFFFFF), conv.d);
+  printf("0x%08lx_%08lx = %g\n", (conv.v >> 32),(conv.v & 0xFFFFFFFF), conv.d);
 }
 
 void printF128 (char *msg, float128_t q) {
   qp conv;
   int i, j;
+  char buf[64];
   conv.v[0] = q.v[0]; // use union to convert between hexadecimal and floating-point views
   conv.v[1] = q.v[1]; // use union to convert between hexadecimal and floating-point views  
   printf("%s: ", msg);  // print out nicely
-  printf("0x%016" PRIx64 "_%016" PRIx64 " = %1.15Qe\n", q.v[1], q.v[0], conv.q);
+  //printf("0x%016" PRIx64 "_%016" PRIx64 " = %1.15Qe\n", q.v[1], q.v[0], conv.q);
+  quadmath_snprintf (buf, sizeof buf, "%1.15Qe", conv.q);
+  printf("0x%016" PRIx64 "_%016" PRIx64 " = %s\n", q.v[1], q.v[0], buf);    
 }
 
 void printFlags(void) {

--- a/examples/fp/softfloat_demo/softfloat_demoQP.c
+++ b/examples/fp/softfloat_demo/softfloat_demoQP.c
@@ -38,16 +38,23 @@ void printF64 (char *msg, float64_t d) {
   int i, j;
   conv.v = d.v; // use union to convert between hexadecimal and floating-point views
   printf("%s: ", msg);  // print out nicely
-  printf("0x%08x_%08x = %g\n", (conv.v >> 32),(conv.v & 0xFFFFFFFF), conv.d);
+  printf("0x%08lx_%08lx = %g\n", (conv.v >> 32),(conv.v & 0xFFFFFFFF), conv.d);
 }
 
 void printF128 (char *msg, float128_t q) {
   qp conv;
   int i, j;
+  char buf[64];
   conv.v[0] = q.v[0]; // use union to convert between hexadecimal and floating-point views
   conv.v[1] = q.v[1]; // use union to convert between hexadecimal and floating-point views  
   printf("%s: ", msg);  // print out nicely
-  printf("0x%016" PRIx64 "_%016" PRIx64 " = %1.15Qe\n", q.v[1], q.v[0], conv.q);
+
+  // Some compilers can understand %Q for printf on quad precision instead of the
+  // API call of quadmath_snprintf
+  // printf("0x%016" PRIx64 "_%016" PRIx64 " = %1.15Qe\n", q.v[1], q.v[0], conv.q);
+  quadmath_snprintf (buf, sizeof buf, "%1.15Qe", conv.q);
+  printf("0x%016" PRIx64 "_%016" PRIx64 " = %s\n", q.v[1], q.v[0], buf);  
+
 }
 
 void printFlags(void) {
@@ -74,6 +81,8 @@ int main() {
   
   float128_t x, y, z;
   float128_t r;
+  uint32_t u, v, w;
+  int32_t a, b, c;
 
   x.v[1] = 0xBFFF988ECE97DFEB;
   x.v[0] = 0xC3BBA082445B4836;

--- a/examples/fp/softfloat_demo/softfloat_demoSP.c
+++ b/examples/fp/softfloat_demo/softfloat_demoSP.c
@@ -38,16 +38,19 @@ void printF64 (char *msg, float64_t d) {
   int i, j;
   conv.v = d.v; // use union to convert between hexadecimal and floating-point views
   printf("%s: ", msg);  // print out nicely
-  printf("0x%08x_%08x = %g\n", (conv.v >> 32),(conv.v & 0xFFFFFFFF), conv.d);
+  printf("0x%08lx_%08lx = %g\n", (conv.v >> 32),(conv.v & 0xFFFFFFFF), conv.d);
 }
 
 void printF128 (char *msg, float128_t q) {
   qp conv;
   int i, j;
+  char buf[64];
   conv.v[0] = q.v[0]; // use union to convert between hexadecimal and floating-point views
   conv.v[1] = q.v[1]; // use union to convert between hexadecimal and floating-point views  
   printf("%s: ", msg);  // print out nicely
-  printf("0x%016" PRIx64 "_%016" PRIx64 " = %1.15Qe\n", q.v[1], q.v[0], conv.q);
+  //printf("0x%016" PRIx64 "_%016" PRIx64 " = %1.15Qe\n", q.v[1], q.v[0], conv.q);
+  quadmath_snprintf (buf, sizeof buf, "%1.15Qe", conv.q);
+  printf("0x%016" PRIx64 "_%016" PRIx64 " = %s\n", q.v[1], q.v[0], buf);    
 }
 
 void printFlags(void) {

--- a/src/fpu/postproc/specialcase.sv
+++ b/src/fpu/postproc/specialcase.sv
@@ -273,27 +273,7 @@ module specialcase import cvw::*;  #(parameter cvw_t P) (
   //           overflows to the maximum value 
   // signed: if invalid, result should overflow to maximum negative value 
   //         but is undefined and used for information only
-  // The IEEE 754 result comes from values in TestFloat for x86_64
-   
-  // Nothing from the C standard will justify the choices made by one ISA or 
-  // another regarding the behavior for out-of-range values of the floating-point-to-integer
-  // conversion, because the C standard leaves what happens then “Undefined Behavior” 
-  // (with the caveat that it's only UB if the result is out of range, 
-  // so converting -0.9999f to an unsigned integer must produce 0u).
-
-  // “Undefined Behavior” means that the execution can continue with an 
-  // arbitrary value when this kind of conversion happens, or the program may crash, 
-  // or any other thing. The phrase “nasal demons” has been used for decades to 
-  // emphasize that the C standard does not place any requirement on what happens 
-  // when a C program runs into UB.
-
-  // Other programming languages are less flippant in their use of Undefined Behavior, 
-  // for instance Java. Since the goal of the people defining a new ISA is to make all 
-  // programs as fast as possible regardless of the programming language they are developed in, 
-  // the people designing RISC-V may have made the choices they made in order to ensure that the 
-  // conversion from floating-point to integer in Java, or a selection of other popular 
-  // programming languages, could be translated to the shortest, fastest possible sequence of 
-  // instructions in RISC-V.
+  // Note: The IEEE 754 result comes from values in TestFloat for x86_64
    
   // IEEE 754
   // select the overflow integer res


### PR DESCRIPTION
Make changes to interpret config.vh for fp -> int (e.g., f128_to_ui32 and f128_to_i32) for IEEE 754 vs. RISC-V (i.e., Table 11.4: Domains of float-to-integer conversions and behavior for invalid inputs. in RISC-V Unprivileged ISA manual).