### PR TITLE
Fixes some but not all of the Issue #405 bugs. Fixes non-cached atomics, zifence when there is no dcache, and more serious bug with compressedF not supressed on the last cycle of a bus fetch.

### DIFF
--- a/src/ebu/ahbinterface.sv
+++ b/src/ebu/ahbinterface.sv
@@ -44,6 +44,7 @@ module ahbinterface #(
   input  logic                          Stall,        // Core pipeline is stalled
   input  logic                          Flush,        // Pipeline stage flush. Prevents bus transaction from starting
   input  logic [1:0]                    BusRW,        // Memory operation read/write control: 10: read, 01: write
+  input  logic                          BusAtomic,    // Uncache atomic memory operation
   input  logic [XLEN/8-1:0]             ByteMask,     // Bytes enables within a word
   input  logic [XLEN-1:0]               WriteData,    // IEU write data for a store
   output logic                          BusStall,     // Bus is busy with an in flight memory operation
@@ -64,7 +65,7 @@ module ahbinterface #(
     assign HWSTRB = '0;
   end    
 
-  busfsm #(~LSU) busfsm(.HCLK, .HRESETn, .Flush, .BusRW,
+  busfsm #(~LSU) busfsm(.HCLK, .HRESETn, .Flush, .BusRW, .BusAtomic,
     .BusCommitted, .Stall, .BusStall, .CaptureEn, .HREADY,
     .HTRANS, .HWRITE);
 

--- a/src/ebu/ahbinterface.sv
+++ b/src/ebu/ahbinterface.sv
@@ -29,7 +29,7 @@
 
 module ahbinterface #(
   parameter XLEN,
-  parameter LSU = 0                                   // 1: LSU bus width is `XLEN, 0: IFU bus width is 32 bits
+  parameter logic LSU = 1'b0                                   // 1: LSU bus width is `XLEN, 0: IFU bus width is 32 bits
 )( 
   input  logic                          HCLK, HRESETn,
   // bus interface

--- a/src/ebu/ahbinterface.sv
+++ b/src/ebu/ahbinterface.sv
@@ -64,7 +64,7 @@ module ahbinterface #(
     assign HWSTRB = '0;
   end    
 
-  busfsm busfsm(.HCLK, .HRESETn, .Flush, .BusRW,
+  busfsm #(~LSU) busfsm(.HCLK, .HRESETn, .Flush, .BusRW,
     .BusCommitted, .Stall, .BusStall, .CaptureEn, .HREADY,
     .HTRANS, .HWRITE);
 

--- a/src/ebu/busfsm.sv
+++ b/src/ebu/busfsm.sv
@@ -28,7 +28,9 @@
 ////////////////////////////////////////////////////////////////////////////////////////////////
 
 // HCLK and clk must be the same clock!
-module busfsm (
+module busfsm #(
+  parameter READ_ONLY
+)(
   input  logic       HCLK,
   input  logic       HRESETn,
 
@@ -70,7 +72,7 @@ module busfsm (
 //                  (CurrState == DATA_PHASE & ~BusRW[0]); // possible optimization here.  fails uart test, but i'm not sure the failure is valid.
                     (CurrState == DATA_PHASE); 
   
-  assign BusCommitted = CurrState != ADR_PHASE;
+  assign BusCommitted = CurrState != ADR_PHASE & ~(READ_ONLY & CurrState == MEM3);
 
   assign HTRANS = (CurrState == ADR_PHASE & HREADY & |BusRW & ~Flush) ? AHB_NONSEQ : AHB_IDLE;
   assign HWRITE = BusRW[0];

--- a/src/ebu/busfsm.sv
+++ b/src/ebu/busfsm.sv
@@ -29,7 +29,7 @@
 
 // HCLK and clk must be the same clock!
 module busfsm #(
-  parameter READ_ONLY
+  parameter logic READ_ONLY
 )(
   input  logic       HCLK,
   input  logic       HRESETn,
@@ -72,7 +72,7 @@ module busfsm #(
 //                  (CurrState == DATA_PHASE & ~BusRW[0]); // possible optimization here.  fails uart test, but i'm not sure the failure is valid.
                     (CurrState == DATA_PHASE); 
   
-  assign BusCommitted = CurrState != ADR_PHASE & ~(READ_ONLY & CurrState == MEM3);
+  assign BusCommitted = (CurrState != ADR_PHASE) & ~(READ_ONLY & CurrState == MEM3);
 
   assign HTRANS = (CurrState == ADR_PHASE & HREADY & |BusRW & ~Flush) ? AHB_NONSEQ : AHB_IDLE;
   assign HWRITE = BusRW[0];

--- a/src/ieu/controller.sv
+++ b/src/ieu/controller.sv
@@ -370,7 +370,7 @@ module controller import cvw::*;  #(parameter cvw_t P) (
   // Fences
   // Ordinary fence is presently a nop
   // fence.i flushes the D$ and invalidates the I$ if Zifencei is supported and I$ is implemented
-  if (P.ZIFENCEI_SUPPORTED & P.ICACHE_SUPPORTED) begin:fencei
+  if (P.ZIFENCEI_SUPPORTED & (P.ICACHE_SUPPORTED | P.DCACHE_SUPPORTED)) begin:fencei
     logic FenceID;
     assign FenceID = FenceXD & (Funct3D == 3'b001); // is it a FENCE.I instruction?
     assign InvalidateICacheD = FenceID;

--- a/src/ifu/ifu.sv
+++ b/src/ifu/ifu.sv
@@ -275,7 +275,7 @@ module ifu import cvw::*;  #(parameter cvw_t P) (
 
       ahbinterface #(P.XLEN, 1'b0) ahbinterface(.HCLK(clk), .Flush(FlushD), .HRESETn(~reset), .HREADY(IFUHREADY), 
         .HRDATA(HRDATA), .HTRANS(IFUHTRANS), .HWRITE(IFUHWRITE), .HWDATA(),
-        .HWSTRB(), .BusRW, .ByteMask(), .WriteData('0),
+        .HWSTRB(), .BusRW, .BusAtomic('0), .ByteMask(), .WriteData('0),
         .Stall(GatedStallD), .BusStall, .BusCommitted(BusCommittedF), .FetchBuffer(FetchBuffer));
 
       assign CacheCommittedF = '0;

--- a/src/ifu/ifu.sv
+++ b/src/ifu/ifu.sv
@@ -273,7 +273,7 @@ module ifu import cvw::*;  #(parameter cvw_t P) (
       assign BusRW = ~ITLBMissF & ~SelIROM ? IFURWF : '0;
       assign IFUHSIZE = 3'b010;
 
-      ahbinterface #(P.XLEN, 0) ahbinterface(.HCLK(clk), .Flush(FlushD), .HRESETn(~reset), .HREADY(IFUHREADY), 
+      ahbinterface #(P.XLEN, 1'b0) ahbinterface(.HCLK(clk), .Flush(FlushD), .HRESETn(~reset), .HREADY(IFUHREADY), 
         .HRDATA(HRDATA), .HTRANS(IFUHTRANS), .HWRITE(IFUHWRITE), .HWDATA(),
         .HWSTRB(), .BusRW, .ByteMask(), .WriteData('0),
         .Stall(GatedStallD), .BusStall, .BusCommitted(BusCommittedF), .FetchBuffer(FetchBuffer));

--- a/src/lsu/lsu.sv
+++ b/src/lsu/lsu.sv
@@ -342,7 +342,6 @@ module lsu import cvw::*;  #(parameter cvw_t P) (
       assign DCacheStallM = CacheStall & ~IgnoreRequestTLB;
       assign CacheBusRW = CacheBusRWTemp;
 
-      // *** add support for cboz
       ahbcacheinterface #(.AHBW(P.AHBW), .LLEN(P.LLEN), .PA_BITS(P.PA_BITS), .BEATSPERLINE(BEATSPERLINE), .AHBWLOGBWPL(AHBWLOGBWPL), .LINELEN(LINELEN),  .LLENPOVERAHBW(LLENPOVERAHBW), .READ_ONLY_CACHE(0)) ahbcacheinterface(
         .HCLK(clk), .HRESETn(~reset), .Flush(FlushW | IgnoreRequestTLB),
         .HRDATA, .HWDATA(LSUHWDATA), .HWSTRB(LSUHWSTRB),

--- a/src/lsu/lsu.sv
+++ b/src/lsu/lsu.sv
@@ -367,7 +367,7 @@ module lsu import cvw::*;  #(parameter cvw_t P) (
       assign LSUHADDR = PAdrM;
       assign LSUHSIZE = LSUFunct3M;
 
-      ahbinterface #(P.XLEN, 1) ahbinterface(.HCLK(clk), .HRESETn(~reset), .Flush(FlushW), .HREADY(LSUHREADY), 
+      ahbinterface #(P.XLEN, 1'b1) ahbinterface(.HCLK(clk), .HRESETn(~reset), .Flush(FlushW), .HREADY(LSUHREADY), 
         .HRDATA(HRDATA), .HTRANS(LSUHTRANS), .HWRITE(LSUHWRITE), .HWDATA(LSUHWDATA),
         .HWSTRB(LSUHWSTRB), .BusRW, .ByteMask(ByteMaskM), .WriteData(LSUWriteDataM[P.XLEN-1:0]),
         .Stall(GatedStallW), .BusStall, .BusCommitted(BusCommittedM), .FetchBuffer(FetchBuffer));

--- a/src/lsu/lsu.sv
+++ b/src/lsu/lsu.sv
@@ -369,7 +369,7 @@ module lsu import cvw::*;  #(parameter cvw_t P) (
 
       ahbinterface #(P.XLEN, 1'b1) ahbinterface(.HCLK(clk), .HRESETn(~reset), .Flush(FlushW), .HREADY(LSUHREADY), 
         .HRDATA(HRDATA), .HTRANS(LSUHTRANS), .HWRITE(LSUHWRITE), .HWDATA(LSUHWDATA),
-        .HWSTRB(LSUHWSTRB), .BusRW, .ByteMask(ByteMaskM), .WriteData(LSUWriteDataM[P.XLEN-1:0]),
+        .HWSTRB(LSUHWSTRB), .BusRW, .BusAtomic(AtomicM[1]), .ByteMask(ByteMaskM), .WriteData(LSUWriteDataM[P.XLEN-1:0]),
         .Stall(GatedStallW), .BusStall, .BusCommitted(BusCommittedM), .FetchBuffer(FetchBuffer));
 
     // Mux between the 2 sources of read data, 0: Bus, 1: DTIM


### PR DESCRIPTION
- Fixed the zifencei bug (part of issue 405).
- Fixed part of issue #405. The non-cache version of the bus controller did not have the correct supression of BusCommitted for a read only controller.
- Hmm. Verilator is complaining about the parameter width.  I'm not sure why so I changed to 1 bit.
- Added logic for the non-cache atomics.
- Atomics work correctly without a d cache.
