### PR TITLE
more shiftcorrection bug fixes

### DIFF
--- a/config/shared/config-shared.vh
+++ b/config/shared/config-shared.vh
@@ -111,7 +111,7 @@ localparam LLEN = (($unsigned(FLEN)<$unsigned(XLEN)) ? ($unsigned(XLEN)) : ($uns
 localparam LOGCVTLEN = $unsigned($clog2(CVTLEN+1));
 localparam NORMSHIFTSZ = (((CVTLEN+NF+1)>(DIVb + 1 +NF+1) & (CVTLEN+NF+1)>(3*NF+6)) ? (CVTLEN+NF+1) : ((DIVb + 1 +NF+1) > (3*NF+6) ? (DIVb + 1 +NF+1) : (3*NF+6)));
 localparam LOGNORMSHIFTSZ = ($clog2(NORMSHIFTSZ));
-localparam CORRSHIFTSZ = (((DIVMINb+1+NF) > (3*NF+4) ? (DIVMINb+1+NF) : (3*NF+4))); // max(DIVMINb+NF+1, 3*NF+4)
+localparam CORRSHIFTSZ = NORMSHIFTSZ-2;
 
 
 // Disable spurious Verilator warnings

--- a/src/fpu/postproc/shiftcorrection.sv
+++ b/src/fpu/postproc/shiftcorrection.sv
@@ -44,7 +44,7 @@ module shiftcorrection import cvw::*;  #(parameter cvw_t P) (
   output logic [P.NE+1:0]          Ue                      // corrected exponent for divider
 );
 
-  logic [3*P.NF+3:0]               CorrSumShifted;         // the shifted sum after LZA correction
+  logic [P.CORRSHIFTSZ-1:0]        CorrSumShifted;         // the shifted sum after LZA correction
   logic [P.CORRSHIFTSZ-1:0]        CorrQm0, CorrQm1;       // portions of Shifted to select for CorrQmShifted
   logic [P.CORRSHIFTSZ-1:0]        CorrQmShifted;          // the shifted divsqrt result after one bit shift
   logic                            ResSubnorm;             // is the result Subnormal
@@ -68,7 +68,7 @@ module shiftcorrection import cvw::*;  #(parameter cvw_t P) (
   
   // if the result of the divider was calculated to be subnormal, then the result was correctly normalized, so select the top shifted bits
   always_comb
-    if(FmaOp)                       Mf = {CorrSumShifted, {P.CORRSHIFTSZ-(3*P.NF+4){1'b0}}};
+    if(FmaOp)                       Mf = {CorrSumShifted};
     else if (DivOp&~DivResSubnorm)  Mf = CorrQmShifted;
     else                            Mf = Shifted[P.NORMSHIFTSZ-1:P.NORMSHIFTSZ-P.CORRSHIFTSZ];
     


### PR DESCRIPTION
notes:

- hypothesizing that corrshiftsz size is consistently 2 bits smaller than normshiftsz
- suspicious that normshiftsz is dependent on CVTLEN but corrshiftsz isn't (fixed this so that corrshiftsz only relies on normshiftsz)
- corrsumshifted is produced from a mux with a width of normshiftsz-2. changed signal width of corrsumshifted to reflect that instead of statically held at  3 * NF +3 