### PR TITLE
Added build for coremark and embench to main makefile.

### DIFF
--- a/sim/Makefile
+++ b/sim/Makefile
@@ -1,5 +1,5 @@
 
-all: riscoftests memfiles coveragetests deriv
+all: riscoftests memfiles coveragetests deriv benchmarks
 	# *** Build old tests/imperas-riscv-tests for now;
 	# Delete this part when the privileged tests transition over to tests/wally-riscv-arch-test
 	# DH: 2/27/22 temporarily commented out imperas-riscv-tests because license expired
@@ -54,7 +54,7 @@ riscoftests:
 wallyriscoftests: 
 # 	Builds riscv-arch-test 64 and 32-bit versions and builds wally-riscv-arch-test 64 and 32-bit versions
 	make -C ../tests/riscof/ wally-riscv-arch-test
-	
+
 memfiles:
 	make -f makefile-memfile wally-sim-files --jobs
 
@@ -63,4 +63,9 @@ coveragetests:
 
 deriv:
 	derivgen.pl
-	
+
+benchmarks:
+	$(MAKE) -C ../benchmarks/embench build
+	$(MAKE) -C ../benchmarks/embench size
+	$(MAKE) -C ../benchmarks/embench modelsim_build_memfile
+

--- a/sim/Makefile
+++ b/sim/Makefile
@@ -68,4 +68,5 @@ benchmarks:
 	$(MAKE) -C ../benchmarks/embench build
 	$(MAKE) -C ../benchmarks/embench size
 	$(MAKE) -C ../benchmarks/embench modelsim_build_memfile
+	$(MAKE) -C ../benchmarks/coremark 
 


### PR DESCRIPTION
- added branch predictor configs with embench to nightly.
- Increased timeout for nighly regressions.
- Rough draft removal of duplicate BPBTAWrongE logic.
- Fixed bugs in the regression-wally script required for branch predictor sweeps.
- Ugh. This is getting frustrating. Can't seem to get embench to run correctly in new script.
- Ugh. I can't seem to get questa to set the top level parameters anymore.
- Finally have regression-wally -nightly producing branch predictor results.
- Updated branch predictor derivative configs.
- Added makefile rule to build the embench benchmarks.
- Added coremark to benchmarks.
