### PR TITLE
Merged all regression tests except imperas linux boot into testbench.sv.

### DIFF
--- a/config/rv32gc/config.vh
+++ b/config/rv32gc/config.vh
@@ -154,22 +154,11 @@ localparam PLIC_SPI_ID = 32'd6;
 localparam PLIC_SDC_ID = 32'd9;
 
 localparam BPRED_SUPPORTED = 1;
-// this is an annoying hack for the branch predictor parameterization override.
-`ifdef BPRED_OVERRIDE
-localparam BPRED_TYPE = `BPRED_TYPE;
-localparam BPRED_SIZE = `BPRED_SIZE;
-`else
 localparam BPRED_TYPE = `BP_GSHARE; // BP_GSHARE_BASIC, BP_GLOBAL, BP_GLOBAL_BASIC, BP_TWOBIT
 localparam BPRED_SIZE = 32'd10;
-`endif
 localparam BPRED_NUM_LHR = 32'd6;
-`ifdef BTB_OVERRIDE
-localparam BTB_SIZE = `BTB_SIZE;
-localparam RAS_SIZE = `RAS_SIZE;
-`else
 localparam BTB_SIZE = 32'd10;
 localparam RAS_SIZE = 32'd16;
-`endif
 localparam INSTR_CLASS_PRED = 1;
 
 localparam SVADU_SUPPORTED = 1;

--- a/sim/regression-wally
+++ b/sim/regression-wally
@@ -72,7 +72,7 @@ def getBuildrootTC(boot):
             BRcmd="vsim > {} -c <<!\ndo wally-batch.do buildroot buildroot $RISCV "+str(INSTR_LIMIT)+" 1 0 -coverage\n!"
         else:
             print( "buildroot no coverage")
-            BRcmd="vsim > {} -c <<!\ndo wally-batch.do buildroot buildroot -GINSTR_LIMIT=" +str(INSTR_LIMIT) + " \n!"
+            BRcmd="vsim > {} -c <<!\ndo wally-batch.do buildroot configOptions buildroot -GINSTR_LIMIT=" +str(INSTR_LIMIT) + " \n!"
         BRgrepstr=str(INSTR_LIMIT)+" instructions"
     return  TestCase(name,variant="rv64gc",cmd=BRcmd,grepstr=BRgrepstr)
 

--- a/sim/regression-wally
+++ b/sim/regression-wally
@@ -72,7 +72,7 @@ def getBuildrootTC(boot):
             BRcmd="vsim > {} -c <<!\ndo wally-batch.do buildroot buildroot $RISCV "+str(INSTR_LIMIT)+" 1 0 -coverage\n!"
         else:
             print( "buildroot no coverage")
-            BRcmd="vsim > {} -c <<!\ndo wally-batch.do buildroot buildroot $RISCV "+str(INSTR_LIMIT)+" 1 0\n!"
+            BRcmd="vsim > {} -c <<!\ndo wally-batch.do buildroot buildroot -GINSTR_LIMIT=" +str(INSTR_LIMIT) + " \n!"
         BRgrepstr=str(INSTR_LIMIT)+" instructions"
     return  TestCase(name,variant="rv64gc",cmd=BRcmd,grepstr=BRgrepstr)
 

--- a/sim/wally-batch.do
+++ b/sim/wally-batch.do
@@ -51,35 +51,7 @@ if {$argc >= 3} {
 
 # default to config/rv64ic, but allow this to be overridden at the command line.  For example:
 # do wally-pipelined-batch.do ../config/rv32imc rv32imc
-if {$2 eq "buildroot"} {
-    vlog -lint -work wkdir/work_${1}_${2} +incdir+../config/$1 +incdir+../config/deriv/$1 +incdir+../config/shared ../src/cvw.sv ../testbench/testbench-linux.sv ../testbench/common/*.sv ../src/*/*.sv ../src/*/*/*.sv -suppress 2583
-    # start and run simulation
-    if { $coverage } {
-        echo "wally-batch buildroot coverage"
-        vopt wkdir/work_${1}_${2}.testbench -work wkdir/work_${1}_${2} -G RISCV_DIR=$3 -G INSTR_LIMIT=$4 -G INSTR_WAVEON=$5 -o testbenchopt +cover=sbecf
-        vsim -lib wkdir/work_${1}_${2} testbenchopt -suppress 8852,12070,3084,3691,13286  -fatal 7 -cover
-     } else {
-        vopt wkdir/work_${1}_${2}.testbench -work wkdir/work_${1}_${2} -G RISCV_DIR=$3 -G INSTR_LIMIT=$4 -G INSTR_WAVEON=$5 -o testbenchopt 
-        vsim -lib wkdir/work_${1}_${2} testbenchopt -suppress 8852,12070,3084,3691,13286  -fatal 7
-    }
-
-    run -all
-    run -all
-    exec ./slack-notifier/slack-notifier.py
-} elseif {$2 eq "buildroot-no-trace"} {
-    vlog -lint -work work_${1}_${2} +incdir+../config/$1 +incdir+../config/deriv/$1 +incdir+../config/shared ../testbench/testbench-linux.sv ../testbench/common/*.sv ../src/*/*.sv ../src/*/*/*.sv -suppress 2583
-    # start and run simulation
-    vopt +acc work_${1}_${2}.testbench -work work_${1}_${2} -G RISCV_DIR=$3 -G INSTR_LIMIT=$4 -G INSTR_WAVEON=$5 -G NO_SPOOFING=1 -o testbenchopt 
-    vsim -lib work_${1}_${2} testbenchopt -suppress 8852,12070,3084,3829,13286  -fatal 7
-
-    #-- Run the Simulation
-    echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
-    echo "Don't forget to change DEBUG_LEVEL = 0."
-    echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
-    run -all
-    run -all
-    exec ./slack-notifier/slack-notifier.py
-} elseif {$2 eq "configOptions"} {
+if {$2 eq "configOptions"} {
     # set arguments " "
     # for {set i 5} {$i <= $argc} {incr i} {
     # 	append arguments "\$$i "
@@ -111,12 +83,13 @@ if {$2 eq "buildroot"} {
         vopt wkdir/work_${1}_${2}.testbench -work wkdir/work_${1}_${2} -G TEST=$2 -o testbenchopt +cover=sbecf
         vsim -lib wkdir/work_${1}_${2} testbenchopt  -fatal 7 -suppress 3829 -coverage
     } else {
-        vopt wkdir/work_${1}_${2}.testbench -work wkdir/work_${1}_${2} -G TEST=$2 -o testbenchopt
+        vopt +acc wkdir/work_${1}_${2}.testbench -work wkdir/work_${1}_${2} -G TEST=$2 -o testbenchopt
         vsim -lib wkdir/work_${1}_${2} testbenchopt  -fatal 7 -suppress 3829
     }
 #    vsim -lib wkdir/work_${1}_${2} testbenchopt  -fatal 7 -suppress 3829
     # power add generates the logging necessary for said generation.
     # power add -r /dut/core/*
+    do wave.do
     run -all
     # power off -r /dut/core/*
 } 

--- a/sim/wally-batch.do
+++ b/sim/wally-batch.do
@@ -58,8 +58,8 @@ if {$2 eq "configOptions"} {
     # }
     # puts $arguments
     # set options eval $arguments
-    # **** fix this so we can pass any number of +defines.
-    # only allows 3 right now
+    # **** fix this so we can pass any number of +defines or top level params.
+    # only allows 1 right now
 
     vlog -lint -work wkdir/work_${1}_${3}_${4} +incdir+../config/$1 +incdir+../config/deriv/$1 +incdir+../config/shared ../src/cvw.sv ../testbench/testbench.sv ../testbench/common/*.sv   ../src/*/*.sv ../src/*/*/*.sv -suppress 2583 -suppress 7063,2596,13286 
     # start and run simulation

--- a/sim/wally-batch.do
+++ b/sim/wally-batch.do
@@ -83,13 +83,12 @@ if {$2 eq "configOptions"} {
         vopt wkdir/work_${1}_${2}.testbench -work wkdir/work_${1}_${2} -G TEST=$2 -o testbenchopt +cover=sbecf
         vsim -lib wkdir/work_${1}_${2} testbenchopt  -fatal 7 -suppress 3829 -coverage
     } else {
-        vopt +acc wkdir/work_${1}_${2}.testbench -work wkdir/work_${1}_${2} -G TEST=$2 -o testbenchopt
+        vopt wkdir/work_${1}_${2}.testbench -work wkdir/work_${1}_${2} -G TEST=$2 -o testbenchopt
         vsim -lib wkdir/work_${1}_${2} testbenchopt  -fatal 7 -suppress 3829
     }
 #    vsim -lib wkdir/work_${1}_${2} testbenchopt  -fatal 7 -suppress 3829
     # power add generates the logging necessary for said generation.
     # power add -r /dut/core/*
-    do wave.do
     run -all
     # power off -r /dut/core/*
 } 

--- a/testbench/testbench.sv
+++ b/testbench/testbench.sv
@@ -539,10 +539,12 @@ module testbench;
   
   DCacheFlushFSM #(P) DCacheFlushFSM(.clk(clk), .reset(reset), .start(DCacheFlushStart), .done(DCacheFlushDone));
 
-  logic [P.XLEN-1:0] Minstret;
-  assign Minstret = testbench.dut.core.priv.priv.csr.counters.counters.HPMCOUNTER_REGW[2];  
-  always @(negedge clk) begin
-    if((Minstret != 0) && (Minstret % 'd100000 == 0)) $display("Reached %d instructions", Minstret);
+  if(P.ZICSR_SUPPORTED) begin
+    logic [P.XLEN-1:0] Minstret;
+    assign Minstret = testbench.dut.core.priv.priv.csr.counters.counters.HPMCOUNTER_REGW[2];  
+    always @(negedge clk) begin
+      if((Minstret != 0) && (Minstret % 'd100000 == 0)) $display("Reached %d instructions", Minstret);
+    end
   end
 
   task automatic CheckSignature;

--- a/testbench/testbench.sv
+++ b/testbench/testbench.sv
@@ -384,10 +384,10 @@ module testbench;
       if (LoadMem) begin
         if (TEST == "buildroot") begin
           memFile = $fopen(bootmemfilename, "rb");
-          readResult = $fread(dut.uncore.uncore.ram.ram.memory.RAM, memFile);
+          readResult = $fread(dut.uncore.uncore.bootrom.bootrom.memory.ROM, memFile);
           $fclose(memFile);
           memFile = $fopen(memfilename, "rb");
-          readResult = $fread(dut.uncore.uncore.bootrom.bootrom.memory.ROM, memFile);
+          readResult = $fread(dut.uncore.uncore.ram.ram.memory.RAM, memFile);
           $fclose(memFile);
         end else 
           $readmemh(memfilename, dut.uncore.uncore.ram.ram.memory.RAM);

--- a/testbench/testbench.sv
+++ b/testbench/testbench.sv
@@ -41,7 +41,8 @@ module testbench;
   parameter I_CACHE_ADDR_LOGGER=0;
   parameter D_CACHE_ADDR_LOGGER=0;
   parameter RISCV_DIR = "/opt/riscv";
- 
+  parameter INSTR_LIMIT = 0;
+  
 `include "parameter-defs.vh"
 
   logic        clk;
@@ -543,7 +544,8 @@ module testbench;
     logic [P.XLEN-1:0] Minstret;
     assign Minstret = testbench.dut.core.priv.priv.csr.counters.counters.HPMCOUNTER_REGW[2];  
     always @(negedge clk) begin
-      if((Minstret != 0) && (Minstret % 'd100000 == 0)) $display("Reached %d instructions", Minstret);
+      if((Minstret != 0) && (Minstret % 'd100000 == 0)) $display("Reached %d instructions, %d", Minstret, INSTR_LIMIT);
+      if((Minstret == INSTR_LIMIT) & (INSTR_LIMIT!=0)) begin $stop; $stop; end
     end
   end
 

--- a/testbench/testbench.sv
+++ b/testbench/testbench.sv
@@ -290,6 +290,9 @@ module testbench;
       if (riscofTest) begin
         ProgramAddrMapFile = {pathname, tests[test], "/ref/ref.elf.objdump.addr"};
         ProgramLabelMapFile = {pathname, tests[test], "/ref/ref.elf.objdump.lab"};
+      end else if (TEST == "buildroot") begin
+        ProgramAddrMapFile = {RISCV_DIR, "/buildroot/output/images/disassembly/vmlinux.objdump.addr"};
+        ProgramLabelMapFile = {RISCV_DIR, "/buildroot/output/images/disassembly/vmlinux.objdump.lab"};
       end else begin
         ProgramAddrMapFile = {pathname, tests[test], ".elf.objdump.addr"};
         ProgramLabelMapFile = {pathname, tests[test], ".elf.objdump.lab"};

--- a/testbench/testbench.sv
+++ b/testbench/testbench.sv
@@ -40,6 +40,7 @@ module testbench;
   parameter BPRED_LOGGER=0;
   parameter I_CACHE_ADDR_LOGGER=0;
   parameter D_CACHE_ADDR_LOGGER=0;
+  parameter RISCV_DIR = "/opt/riscv";
  
 `include "parameter-defs.vh"
 
@@ -134,6 +135,7 @@ module testbench;
         "arch64zfh_divsqrt":     if (P.ZFH_SUPPORTED)     tests = arch64zfh_divsqrt;
         "arch64zfaf":    if (P.ZFA_SUPPORTED)     tests = arch64zfaf;
         "arch64zfad":    if (P.ZFA_SUPPORTED & P.D_SUPPORTED)  tests = arch64zfad;
+        "buildroot":                              tests = buildroot;
       endcase 
     end else begin // RV32
       case (TEST)
@@ -210,7 +212,7 @@ module testbench;
   logic        ResetCntRst;
   logic        CopyRAM;
 
-  string  signame, memfilename, pathname;
+  string  signame, memfilename, bootmemfilename, pathname;
   integer begin_signature_addr, end_signature_addr, signature_size;
 
   assign ResetThreshold = 3'd5;
@@ -279,7 +281,12 @@ module testbench;
   always @(posedge clk) begin
     if(SelectTest) begin
       if (riscofTest) memfilename = {pathname, tests[test], "/ref/ref.elf.memfile"};
+      else if(TEST == "buildroot") begin 
+        memfilename = {RISCV_DIR, "/linux-testvectors/ram.bin"};
+        bootmemfilename = {RISCV_DIR, "/linux-testvectors/bootmem.bin"};
+      end
       else            memfilename = {pathname, tests[test], ".elf.memfile"};
+      $display("!!!!!!!!!!!!!!!!!!!!!memfilename is %s \n", memfilename);
       if (riscofTest) begin
         ProgramAddrMapFile = {pathname, tests[test], "/ref/ref.elf.objdump.addr"};
         ProgramLabelMapFile = {pathname, tests[test], "/ref/ref.elf.objdump.lab"};
@@ -352,6 +359,8 @@ module testbench;
   integer StartIndex;
   integer EndIndex;
   integer BaseIndex;
+  integer memFile;
+  integer readResult;
   if (P.SDC_SUPPORTED) begin
     always @(posedge clk) begin
       if (LoadMem) begin
@@ -373,7 +382,16 @@ module testbench;
   end else if (P.BUS_SUPPORTED) begin : bus_supported
     always @(posedge clk) begin
       if (LoadMem) begin
-        $readmemh(memfilename, dut.uncore.uncore.ram.ram.memory.RAM);
+        if (TEST == "buildroot") begin
+          memFile = $fopen(bootmemfilename, "rb");
+          readResult = $fread(dut.uncore.uncore.ram.ram.memory.RAM, memFile);
+          $fclose(memFile);
+          memFile = $fopen(memfilename, "rb");
+          readResult = $fread(dut.uncore.uncore.bootrom.bootrom.memory.ROM, memFile);
+          $fclose(memFile);
+        end else 
+          $readmemh(memfilename, dut.uncore.uncore.ram.ram.memory.RAM);
+        if (TEST == "embench") $display("Read memfile %s", memfilename);
       end
       if (CopyRAM) begin
         LogXLEN = (1 + P.XLEN/32); // 2 for rv32 and 3 for rv64

--- a/testbench/testbench.sv
+++ b/testbench/testbench.sv
@@ -286,7 +286,6 @@ module testbench;
         bootmemfilename = {RISCV_DIR, "/linux-testvectors/bootmem.bin"};
       end
       else            memfilename = {pathname, tests[test], ".elf.memfile"};
-      $display("!!!!!!!!!!!!!!!!!!!!!memfilename is %s \n", memfilename);
       if (riscofTest) begin
         ProgramAddrMapFile = {pathname, tests[test], "/ref/ref.elf.objdump.addr"};
         ProgramLabelMapFile = {pathname, tests[test], "/ref/ref.elf.objdump.lab"};
@@ -539,6 +538,12 @@ module testbench;
   //assign DCacheFlushStart =  TestComplete;
   
   DCacheFlushFSM #(P) DCacheFlushFSM(.clk(clk), .reset(reset), .start(DCacheFlushStart), .done(DCacheFlushDone));
+
+  logic [P.XLEN-1:0] Minstret;
+  assign Minstret = testbench.dut.core.priv.priv.csr.counters.counters.HPMCOUNTER_REGW[2];  
+  always @(negedge clk) begin
+    if((Minstret != 0) && (Minstret % 'd100000 == 0)) $display("Reached %d instructions", Minstret);
+  end
 
   task automatic CheckSignature;
     // This task must be declared inside this module as it needs access to parameter P.  There is

--- a/testbench/tests.vh
+++ b/testbench/tests.vh
@@ -31,6 +31,7 @@
 `define EMBENCH "4"
 `define CUSTOM "5"
 `define COVERAGE "6"
+`define BUILDROOT "7"
 
 string tvpaths[] = '{
     "$RISCV/imperas-riscv-tests/work/",
@@ -69,6 +70,11 @@ string tvpaths[] = '{
     "pmppriority",
     "pmpcbo",
     "pmpadrdecs"
+  };
+
+  string buildroot[] = '{
+    `BUILDROOT,
+    "buildroot"
   };
 
   string coremark[] = '{


### PR DESCRIPTION
- added branch predictor configs with embench to nightly.
- Increased timeout for nighly regressions.
- Rough draft removal of duplicate BPBTAWrongE logic.
- Fixed bugs in the regression-wally script required for branch predictor sweeps.
- Ugh. This is getting frustrating. Can't seem to get embench to run correctly in new script.
- Ugh. I can't seem to get questa to set the top level parameters anymore.
- Finally have regression-wally -nightly producing branch predictor results.
- Updated branch predictor derivative configs.
- Added makefile rule to build the embench benchmarks.
- Added coremark to benchmarks.
- First cut at removing the linux testbench and merging build root into the main testbench.
- Moved buildroot testbench to the main testbench. However I don't have a positive control or negative indicator to say when the test completes or passes.
- Updated comments in do file.
- Fixed paths to buildroot objdump label and addr files.
- Buildroot now reports every 100K instructions as before.
- Only output instruction count when the csrs are implemented.
- Fixed issue with branch deriv configs.
- All regression tests run using the main testbench.sv script now. Still need to remove configOptions.
