### PR TITLE
add support for internal sd card adapter paths (/dev/mmcblk)

### DIFF
--- a/linux/sdcard/flash-sd.sh
+++ b/linux/sdcard/flash-sd.sh
@@ -110,8 +110,6 @@ KERNEL_SIZE=$(ls -la --block-size=512 $LINUX_KERNEL | cut -d' ' -f 5 )
 
 # Start sectors of OpenSBI and Kernel Partitions
 FW_JUMP_START=$(( 34 + $DST_SIZE ))
-
-
 KERNEL_START=$(( $FW_JUMP_START + $FW_JUMP_SIZE ))
 FS_START=$(( $KERNEL_START + $KERNEL_SIZE ))
 


### PR DESCRIPTION
When writing sd cards from a device with an internal sdcard reader/writer, the device will be listed as something like /dev/mmcblk0 instead of /dev/sd*. The partition numbers for these devices are prefixed with a "p". ex: /dev/mmcblk0p1. This PR adds support for those devices