### PR TITLE
Use correct version of riscv-gnu-toolchain and Fix Typo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ imperasdv:
 	iter-elf.bash --search ${WALLY}/tests/riscof/work/riscv-arch-test/rv64i_m
 
 coverage:
-	cd ${WALLY}/sim; ./regresssion-wally -coverage -fp
+	cd ${WALLY}/sim; ./regression-wally -coverage -fp
 
 benchmarks:
 	make coremark

--- a/bin/wally-tool-chain-install.sh
+++ b/bin/wally-tool-chain-install.sh
@@ -181,8 +181,10 @@ git clone https://github.com/riscv/sail-riscv.git
 cd sail-riscv
 # For now, use checkout that is stable for Wally
 #git checkout 72b2516d10d472ac77482fd959a9401ce3487f60  # not new enough for Zicboz?
-make -j ${NUM_THREADS}
-ARCH=RV32 make -j ${NUM_THREADS}
+# make -j ${NUM_THREADS}
+git checkout 9602e3a525af1404fe51676214b457bd1a0b70d0
+ARCH=64 make -j ${NUM_THREADS} c_emulator/riscv_sim_RV64
+ARCH=32 make -j ${NUM_THREADS} c_emulator/riscv_sim_RV32
 sudo ln -sf $RISCV/sail-riscv/c_emulator/riscv_sim_RV64 /usr/bin/riscv_sim_RV64
 sudo ln -sf $RISCV/sail-riscv/c_emulator/riscv_sim_RV32 /usr/bin/riscv_sim_RV32
 


### PR DESCRIPTION
## Summary of Work

- As mentioned in #296, the master branch version is causing the problem of illegal operation as the change of binutils's version. I make modifications to change the `bin/wally-tool-chain-install.sh`.
- Found one typo in `Makefile`