### PR TITLE
Add linux/buildroot to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ tests/linux-testgen/buildroot-image-output
 tests/linux-testgen/buildroot-config-src/main.config.old
 tests/linux-testgen/buildroot-config-src/linux.config.old
 tests/linux-testgen/buildroot-config-src/busybox.config.old
+linux/buildroot
 linux/testvector-generation/boottrace.S
 linux/testvector-generation/boottrace_disasm.log
 sim/slack-notifier/slack-webhook-url.txt


### PR DESCRIPTION
## Summary of Work

Add linux/buildroot to .gitignore to ignore the intermediate built for RISCV/buildroot