### PR TITLE
Site setup

### DIFF
--- a/setup.csh
+++ b/setup.csh
@@ -5,48 +5,20 @@
 
 echo "Executing Wally setup.csh"
 
-# Path to Wally repository
-setenv WALLY $PWD
-echo '$WALLY set to ' ${WALLY}
 
 # Extend alias which makes extending PATH much easier.
 alias extend 'if (-d \!:2) if ("$\!:1" \!~ *"\!:2"*) setenv \!:1 ${\!:1}:\!:2;echo Added \!:2 to \!:1'
 alias prepend 'if (-d \!:2) if ("$\!:1" \!~ *"\!:2"*) setenv \!:1 "\!:2":${\!:1};echo Added \!:2 to \!:1'
 
-# License servers and commercial CAD tool paths
-# Must edit these based on your local environment.  Ask your sysadmin.
-setenv MGLS_LICENSE_FILE 27002@zircon.eng.hmc.edu                 # Change this to your Siemens license server
-setenv SNPSLMD_LICENSE_FILE 27020@zircon.eng.hmc.edu              # Change this to your Synopsys license server
-setenv QUESTAPATH /cad/mentor/questa_sim-2022.4_2/questasim/bin   # Change this for your path to Questa
-setenv SNPSPATH /cad/synopsys/SYN/bin                             # Change this for your path to Design Compiler
-
 # Path to RISC-V Tools
 setenv RISCV /opt/riscv   # change this if you installed the tools in a different location
 
-# Tools
-# Questa and Synopsys
-extend PATH $QUESTAPATH
-extend PATH $SNPSPATH 
-# GCC
-prepend LD_LIBRARY_PATH $RISCV/riscv-gnu-toolchain/lib
-prepend LD_LIBRARY_PATH $RISCV/riscv-gnu-toolchain/riscv64-unknown-elf/lib
-extend PATH $RISCV/riscv-gnu-toolchain/bin # GCC tools
-extend PATH $RISCV/riscv-gnu-toolchain/riscv64-unknown-elf/bin # GCC tools
-# Spike
-extend LD_LIBRARY_PATH $RISCV/lib
-extend PATH $RISCV/bin
+# Path to Wally repository
+setenv WALLY $PWD
+echo '$WALLY set to ' ${WALLY}
 # utility functions in Wally repository
 extend PATH $WALLY/bin
-# Verilator
-extend PATH /usr/local/bin/verilator # Change this for your path to Verilator
-# ModelSim/Questa (vsim)
-# Note: 2022.1 complains on cache/sram1p1r1w about StoredData cannot be driven by multiple always_ff blocks.  Ues 2021.2 for now
 
-# Imperas; put this in if you are using it
-#set path = ($RISCV/imperas-riscv-tests/riscv-ovpsim-plus/bin/Linux64 $path)
-#setenv LD_LIBRARY_PATH $RISCV/imperas_riscv_tests/riscv-ovpsim-plus/bin/Linux64:$LD_LIBRARY_PATH # remove if no imperas
-
-# Verilator needs a larger stack to simulate CORE-V Wally
-limit stacksize unlimited
+source $RISCV/site-setup.csh
 
 echo "setup done"

--- a/setup.sh
+++ b/setup.sh
@@ -2,58 +2,31 @@
 
 # setup.sh
 # David_Harris@hmc.edu and kekim@hmc.edu 1 December 2021
-# Set up tools for rvw
+# Set up tools for cvw
+
+# optionally have .bashrc or .bash_profile source this file with
+#if [ -f ~/cvw/setup.sh ]; then
+#	source ~/cvw/setup.sh
+#fi
+
 # SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
 
 echo "Executing Wally setup.sh"
+
+# Path to RISC-V Tools
+export RISCV=/opt/riscv   # change this if you installed the tools in a different location
 
 # Path to Wally repository
 WALLY=$(dirname ${BASH_SOURCE[0]:-$0})
 export WALLY=$(cd "$WALLY" && pwd)
 echo \$WALLY set to ${WALLY}
-
-# License servers and commercial CAD tool paths
-# Must edit these based on your local environment.  Ask your sysadmin.
-export MGLS_LICENSE_FILE=27002@zircon.eng.hmc.edu                   # Change this to your Siemens license server
-export SNPSLMD_LICENSE_FILE=27020@zircon.eng.hmc.edu                # Change this to your Synopsys license server
-export QUESTA_HOME=/cad/mentor/questa_sim-2023.4/questasim        # Change this for your path to Questa, excluding bin
-export SNPS_HOME=/cad/synopsys/SYN                                  # Change this for your path to Design Compiler, excluding bin
-
-# Path to RISC-V Tools
-export RISCV=/opt/riscv   # change this if you installed the tools in a different location
-
-# Tools
-# Questa and Synopsys
-export PATH=$QUESTA_HOME/bin:$SNPS_HOME/bin:$PATH
-# GCC
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$RISCV/riscv-gnu-toolchain/lib:$RISCV/riscv-gnu-toolchain/riscv64-unknown-elf/lib
-export PATH=$PATH:$RISCV/riscv-gnu-toolchain/bin:$RISCV/riscv-gnu-toolchain/riscv64-unknown-elf/bin      # GCC tools
-# Spike
-export LD_LIBRARY_PATH=$RISCV/lib:$LD_LIBRARY_PATH
-export PATH=$PATH:$RISCV/bin
 # utility functions in Wally repository
 export PATH=$WALLY/bin:$PATH    
-# Verilator
-export PATH=/usr/local/bin/verilator:$PATH # Change this for your path to Verilator
-# ModelSim/Questa (vsim)
-# Note: 2022.1 complains on cache/sram1p1r1w about StoredData cannot be driven by multiple always_ff blocks.  Ues 2021.2 for now
-
-# Imperas; put this in if you are using it
-#export PATH=$RISCV/imperas-riscv-tests/riscv-ovpsim-plus/bin/Linux64:$PATH  
-#export LD_LIBRARY_PATH=$RISCV/imperas_riscv_tests/riscv-ovpsim-plus/bin/Linux64:$LD_LIBRARY_PATH # remove if no imperas
-
-export IDV=$RISCV/ImperasDV-OpenHW
-if [ -e "$IDV" ]; then
-#    echo "Imperas exists"
-    export IMPERAS_HOME=$IDV/Imperas
-    export IMPERAS_PERSONALITY=CPUMAN_DV_ASYNC
-    export ROOTDIR=~/
-    source ${IMPERAS_HOME}/bin/setup.sh
-    setupImperas ${IMPERAS_HOME}
-    export PATH=$IDV/scripts/cvw:$PATH
-fi
 
 # Verilator needs a larger stack to simulate CORE-V Wally
 ulimit -s 100000
+
+# load site licenses and tool locations
+source $RISCV/site-setup.sh
 
 echo "setup done"

--- a/site-setup.csh
+++ b/site-setup.csh
@@ -38,8 +38,8 @@ if ($?IDV) then
 #    echo "Imperas exists"
     setenv IMPERAS_HOME $IDV/Imperas
     setenv IMPERAS_PERSONALITY CPUMAN_DV_ASYNC
-    setenv ROOTDIR=~/
-    setenv ${IMPERAS_HOME}/bin/setup.sh
+    setenv ROOTDIR ~/
+    source ${IMPERAS_HOME}/bin/setup.sh
     setupImperas ${IMPERAS_HOME}
     extend PATH $IDV/scripts/cvw
 endfi

--- a/site-setup.csh
+++ b/site-setup.csh
@@ -1,0 +1,46 @@
+#!/bin/csh
+
+# site-setup.csh
+
+# License servers and commercial CAD tool paths
+# Must edit these based on your local environment.  Ask your sysadmin.
+setenv MGLS_LICENSE_FILE 27002@zircon.eng.hmc.edu                 # Change this to your Siemens license server
+setenv SNPSLMD_LICENSE_FILE 27020@zircon.eng.hmc.edu              # Change this to your Synopsys license server
+setenv QUESTAPATH /cad/mentor/questa_sim-2022.4_2/questasim/bin   # Change this for your path to Questa
+setenv SNPSPATH /cad/synopsys/SYN/bin                             # Change this for your path to Design Compiler
+
+# Tools
+# Questa and Synopsys
+extend PATH $QUESTAPATH
+extend PATH $SNPSPATH 
+
+# GCC
+prepend LD_LIBRARY_PATH $RISCV/riscv-gnu-toolchain/lib
+prepend LD_LIBRARY_PATH $RISCV/riscv-gnu-toolchain/riscv64-unknown-elf/lib
+extend PATH $RISCV/riscv-gnu-toolchain/bin # GCC tools
+extend PATH $RISCV/riscv-gnu-toolchain/riscv64-unknown-elf/bin # GCC tools
+
+# Spike
+extend LD_LIBRARY_PATH $RISCV/lib
+extend PATH $RISCV/bin
+
+# Verilator
+extend PATH /usr/local/bin/verilator # Change this for your path to Verilator
+# Verilator needs a larger stack to simulate CORE-V Wally
+limit stacksize unlimited
+
+# Imperas; put this in if you are using it
+#set path = ($RISCV/imperas-riscv-tests/riscv-ovpsim-plus/bin/Linux64 $path)
+#setenv LD_LIBRARY_PATH $RISCV/imperas_riscv_tests/riscv-ovpsim-plus/bin/Linux64:$LD_LIBRARY_PATH # remove if no imperas
+
+setenv IDV $RISCV/ImperasDV-OpenHW
+if ($?IDV) then
+#    echo "Imperas exists"
+    setenv IMPERAS_HOME $IDV/Imperas
+    setenv IMPERAS_PERSONALITY CPUMAN_DV_ASYNC
+    setenv ROOTDIR=~/
+    setenv ${IMPERAS_HOME}/bin/setup.sh
+    setupImperas ${IMPERAS_HOME}
+    extend PATH $IDV/scripts/cvw
+endfi
+

--- a/site-setup.sh
+++ b/site-setup.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# site-setup.sh
+# David_Harris@hmc.edu and kekim@hmc.edu 1 December 2021
+# System Admin should install this into $RISCV/site-setup.sh
+# $RISCV is typically /opt/riscv
+# System Admin must update the licenses and paths for localization.
+# SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+
+# license servers and commercial CAD tool paths
+# Must edit these based on your local environment.
+export MGLS_LICENSE_FILE=27002@zircon.eng.hmc.edu                   # Change this to your Siemens license server for Questa
+export SNPSLMD_LICENSE_FILE=27020@zircon.eng.hmc.edu                # Change this to your Synopsys license server for Design Compiler
+export QUESTA_HOME=/cad/mentor/questa_sim-2023.4/questasim          # Change this for your path to Questa, excluding bin
+export SNPS_HOME=/cad/synopsys/SYN                                  # Change this for your path to Design Compiler, excluding bin
+
+# Tools
+# Questa and Synopsys
+export PATH=$QUESTA_HOME/bin:$SNPS_HOME/bin:$PATH
+
+# GCC
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$RISCV/riscv-gnu-toolchain/lib:$RISCV/riscv-gnu-toolchain/riscv64-unknown-elf/lib
+export PATH=$PATH:$RISCV/riscv-gnu-toolchain/bin:$RISCV/riscv-gnu-toolchain/riscv64-unknown-elf/bin      # GCC tools
+
+# Spike
+export LD_LIBRARY_PATH=$RISCV/lib:$LD_LIBRARY_PATH
+export PATH=$PATH:$RISCV/bin
+
+# Verilator
+export PATH=/usr/local/bin/verilator:$PATH # Change this for your path to Verilator
+
+# Imperas OVPsim; put this in if you are using it
+#export PATH=$RISCV/imperas-riscv-tests/riscv-ovpsim-plus/bin/Linux64:$PATH  
+#export LD_LIBRARY_PATH=$RISCV/imperas_riscv_tests/riscv-ovpsim-plus/bin/Linux64:$LD_LIBRARY_PATH
+
+export IDV=$RISCV/ImperasDV-OpenHW
+if [ -e "$IDV" ]; then
+#    echo "Imperas exists"
+    export IMPERAS_HOME=$IDV/Imperas
+    export IMPERAS_PERSONALITY=CPUMAN_DV_ASYNC
+    export ROOTDIR=~/
+    source ${IMPERAS_HOME}/bin/setup.sh
+    setupImperas ${IMPERAS_HOME}
+    export PATH=$IDV/scripts/cvw:$PATH
+fi
+


### PR DESCRIPTION
Modified the setup files to be system-independent.  Admins need to do some work to ensure the repo still runs correctly after merging this pull request.

Splits setup.sh into two parts, setup.sh and site-setup.sh.  site-setup.sh should be copied to $RISCV/site-setup.sh and modified as needed by the particular system.  This is done once by the admin installing the tools.  setup.sh then is independent of the particulars for commercial tool install locations and licenses.

I've modified setup.csh to support the same system independence.

site-setup.sh and site-setup.csh are reference examples.  HMC computers should be able to just copy to $RISCV.  OSU admins will know how to edit accordingly.