### PR TITLE
fixed bug in intdivrem test vector extraction

### DIFF
--- a/config/derivlist.txt
+++ b/config/derivlist.txt
@@ -1078,4 +1078,213 @@ IEEE754         1
 deriv fdqh_ieee_div_4_4_rv64gc    fdqh_div_4_4_rv64gc    
 IEEE754         1
 
+#### DIVIDER VARIANTS WITH IDIV ON FPU
+
+deriv f_ieee_div_2_1i_rv32gc f_ieee_div_2_1_rv32gc        
+IDIV_ON_FPU     1
+
+deriv f_ieee_div_2_2i_rv32gc f_ieee_div_2_2_rv32gc        
+IDIV_ON_FPU     1
+
+deriv f_ieee_div_2_4i_rv32gc f_ieee_div_2_4_rv32gc        
+IDIV_ON_FPU     1
+
+deriv f_ieee_div_4_1i_rv32gc f_ieee_div_4_1_rv32gc        
+IDIV_ON_FPU     1
+
+deriv f_ieee_div_4_2i_rv32gc f_ieee_div_4_2_rv32gc        
+IDIV_ON_FPU     1
+
+deriv f_ieee_div_2_1i_rv64gc f_ieee_div_2_1_rv64gc        
+IDIV_ON_FPU     1
+
+deriv f_ieee_div_2_2i_rv64gc f_ieee_div_2_2_rv64gc        
+IDIV_ON_FPU     1
+
+deriv f_ieee_div_2_4i_rv64gc f_ieee_div_2_4_rv64gc        
+IDIV_ON_FPU     1
+
+deriv f_ieee_div_4_1i_rv64gc f_ieee_div_4_1_rv64gc        
+IDIV_ON_FPU     1
+
+deriv f_ieee_div_4_2i_rv64gc f_ieee_div_4_2_rv64gc        
+IDIV_ON_FPU     1
+
+deriv f_ieee_div_4_4i_rv64gc f_ieee_div_4_4_rv64gc        
+IDIV_ON_FPU     1
+
+#### FH_only, RK variable
+deriv fh_ieee_div_2_1i_rv32gc fh_ieee_div_2_1_rv32gc        
+IDIV_ON_FPU     1
+
+deriv fh_ieee_div_2_2i_rv32gc fh_ieee_div_2_2_rv32gc        
+IDIV_ON_FPU     1
+
+deriv fh_ieee_div_2_4i_rv32gc fh_ieee_div_2_4_rv32gc        
+IDIV_ON_FPU     1
+
+deriv fh_ieee_div_4_1i_rv32gc fh_ieee_div_4_1_rv32gc        
+IDIV_ON_FPU     1
+
+deriv fh_ieee_div_4_2i_rv32gc fh_ieee_div_4_2_rv32gc        
+IDIV_ON_FPU     1
+
+deriv fh_ieee_div_2_1i_rv64gc fh_ieee_div_2_1_rv64gc        
+IDIV_ON_FPU     1
+
+deriv fh_ieee_div_2_2i_rv64gc fh_ieee_div_2_2_rv64gc        
+IDIV_ON_FPU     1
+
+deriv fh_ieee_div_2_4i_rv64gc fh_ieee_div_2_4_rv64gc        
+IDIV_ON_FPU     1
+
+deriv fh_ieee_div_4_1i_rv64gc fh_ieee_div_4_1_rv64gc        
+IDIV_ON_FPU     1
+
+deriv fh_ieee_div_4_2i_rv64gc fh_ieee_div_4_2_rv64gc        
+IDIV_ON_FPU     1
+
+deriv fh_ieee_div_4_4i_rv64gc fh_ieee_div_4_4_rv64gc        
+IDIV_ON_FPU     1
+
+# FD only , rk variable
+
+deriv fd_ieee_div_2_1i_rv32gc fd_ieee_div_2_1_rv32gc        
+IDIV_ON_FPU     1
+
+deriv fd_ieee_div_2_2i_rv32gc fd_ieee_div_2_2_rv32gc        
+IDIV_ON_FPU     1
+
+deriv fd_ieee_div_2_4i_rv32gc fd_ieee_div_2_4_rv32gc        
+IDIV_ON_FPU     1
+
+deriv fd_ieee_div_4_1i_rv32gc fd_ieee_div_4_1_rv32gc        
+IDIV_ON_FPU     1
+
+deriv fd_ieee_div_4_2i_rv32gc fd_ieee_div_4_2_rv32gc        
+IDIV_ON_FPU     1
+
+deriv fd_ieee_div_2_1i_rv64gc fd_ieee_div_2_1_rv64gc        
+IDIV_ON_FPU     1
+
+deriv fd_ieee_div_2_2i_rv64gc fd_ieee_div_2_2_rv64gc        
+IDIV_ON_FPU     1
+
+deriv fd_ieee_div_2_4i_rv64gc fd_ieee_div_2_4_rv64gc        
+IDIV_ON_FPU     1
+
+deriv fd_ieee_div_4_1i_rv64gc fd_ieee_div_4_1_rv64gc        
+IDIV_ON_FPU     1
+
+deriv fd_ieee_div_4_2i_rv64gc fd_ieee_div_4_2_rv64gc        
+IDIV_ON_FPU     1
+
+deriv fd_ieee_div_4_4i_rv64gc fd_ieee_div_4_4_rv64gc        
+IDIV_ON_FPU     1
+
+# FDH only , rk variable
+
+deriv fdh_ieee_div_2_1i_rv32gc fdh_ieee_div_2_1_rv32gc        
+IDIV_ON_FPU     1
+
+deriv fdh_ieee_div_2_2i_rv32gc fdh_ieee_div_2_2_rv32gc        
+IDIV_ON_FPU     1
+
+deriv fdh_ieee_div_2_4i_rv32gc fdh_ieee_div_2_4_rv32gc        
+IDIV_ON_FPU     1
+
+deriv fdh_ieee_div_4_1i_rv32gc fdh_ieee_div_4_1_rv32gc        
+IDIV_ON_FPU     1
+
+deriv fdh_ieee_div_4_2i_rv32gc fdh_ieee_div_4_2_rv32gc        
+IDIV_ON_FPU     1
+
+deriv fdh_ieee_div_2_1i_rv64gc fdh_ieee_div_2_1_rv64gc        
+IDIV_ON_FPU     1
+
+deriv fdh_ieee_div_2_2i_rv64gc fdh_ieee_div_2_2_rv64gc        
+IDIV_ON_FPU     1
+
+deriv fdh_ieee_div_2_4i_rv64gc fdh_ieee_div_2_4_rv64gc        
+IDIV_ON_FPU     1
+
+deriv fdh_ieee_div_4_1i_rv64gc fdh_ieee_div_4_1_rv64gc        
+IDIV_ON_FPU     1
+
+deriv fdh_ieee_div_4_2i_rv64gc fdh_ieee_div_4_2_rv64gc        
+IDIV_ON_FPU     1
+
+deriv fdh_ieee_div_4_4i_rv64gc fdh_ieee_div_4_4_rv64gc        
+IDIV_ON_FPU     1
+
+# FDQ only , rk variable
+
+deriv fdq_ieee_div_2_1i_rv32gc fdq_ieee_div_2_1_rv32gc        
+IDIV_ON_FPU     1
+
+deriv fdq_ieee_div_2_2i_rv32gc fdq_ieee_div_2_2_rv32gc        
+IDIV_ON_FPU     1
+
+deriv fdq_ieee_div_2_4i_rv32gc fdq_ieee_div_2_4_rv32gc        
+IDIV_ON_FPU     1
+
+deriv fdq_ieee_div_4_1i_rv32gc fdq_ieee_div_4_1_rv32gc        
+IDIV_ON_FPU     1
+
+deriv fdq_ieee_div_4_2i_rv32gc fdq_ieee_div_4_2_rv32gc        
+IDIV_ON_FPU     1
+
+deriv fdq_ieee_div_2_1i_rv64gc fdq_ieee_div_2_1_rv64gc        
+IDIV_ON_FPU     1
+
+deriv fdq_ieee_div_2_2i_rv64gc fdq_ieee_div_2_2_rv64gc        
+IDIV_ON_FPU     1
+
+deriv fdq_ieee_div_2_4i_rv64gc fdq_ieee_div_2_4_rv64gc        
+IDIV_ON_FPU     1
+
+deriv fdq_ieee_div_4_1i_rv64gc fdq_ieee_div_4_1_rv64gc        
+IDIV_ON_FPU     1
+
+deriv fdq_ieee_div_4_2i_rv64gc fdq_ieee_div_4_2_rv64gc        
+IDIV_ON_FPU     1
+
+deriv fdq_ieee_div_4_4i_rv64gc fdq_ieee_div_4_4_rv64gc        
+IDIV_ON_FPU     1
+
+# FDQH only , rk variable
+
+deriv fdqh_ieee_div_2_1i_rv32gc fdqh_ieee_div_2_1_rv32gc        
+IDIV_ON_FPU     1
+
+deriv fdqh_ieee_div_2_2i_rv32gc fdqh_ieee_div_2_2_rv32gc        
+IDIV_ON_FPU     1
+
+deriv fdqh_ieee_div_2_4i_rv32gc fdqh_ieee_div_2_4_rv32gc        
+IDIV_ON_FPU     1
+
+deriv fdqh_ieee_div_4_1i_rv32gc fdqh_ieee_div_4_1_rv32gc        
+IDIV_ON_FPU     1
+
+deriv fdqh_ieee_div_4_2i_rv32gc fdqh_ieee_div_4_2_rv32gc        
+IDIV_ON_FPU     1
+
+deriv fdqh_ieee_div_2_1i_rv64gc fdqh_ieee_div_2_1_rv64gc        
+IDIV_ON_FPU     1
+
+deriv fdqh_ieee_div_2_2i_rv64gc fdqh_ieee_div_2_2_rv64gc        
+IDIV_ON_FPU     1
+
+deriv fdqh_ieee_div_2_4i_rv64gc fdqh_ieee_div_2_4_rv64gc        
+IDIV_ON_FPU     1
+
+deriv fdqh_ieee_div_4_1i_rv64gc fdqh_ieee_div_4_1_rv64gc        
+IDIV_ON_FPU     1
+
+deriv fdqh_ieee_div_4_2i_rv64gc fdqh_ieee_div_4_2_rv64gc        
+IDIV_ON_FPU     1
+
+deriv fdqh_ieee_div_4_4i_rv64gc fdqh_ieee_div_4_4_rv64gc        
+IDIV_ON_FPU     1
+
 

--- a/tests/fp/combined_IF_vectors/extract_arch_vectors.py
+++ b/tests/fp/combined_IF_vectors/extract_arch_vectors.py
@@ -116,6 +116,11 @@ def create_vectors(my_config):
                         if "op1val" in line:
                             # print("det2")
                             # parse line
+
+                            # handle special case where destination register is hardwired to zero
+                            if "dest:x0" in line:
+                              answer = "x" * len(answer)
+
                             op1val = line.split("op1val")[1].split("x")[1].split(";")[0]
                             if my_config.op != "fsqrt": # sqrt doesn't have two input vals
                                 op2val = line.split("op2val")[1].split("x")[1].strip()
@@ -158,6 +163,9 @@ def create_vectors(my_config):
                         if "op1val" in line:
                             # print("det2")
                             # parse line
+                            # handle special case where destination register is hardwired to zero
+                            if "dest:x0" in line:
+                              answer = "x" * len(answer)
                             op1val = line.split("op1val")[1].split("x")[1].split(";")[0]
                             if "-" in line.split("op1val")[1].split("x")[0]: # neg sign handling
                                 op1val = twos_comp(my_config.bits, op1val)
@@ -201,7 +209,12 @@ def create_vectors(my_config):
                         if "op1val" in line:
                             # print("det2")
                             # parse line
+                            # handle special case where destination register is hardwired to zero
+                            if "dest:x0" in line: 
+                              answer = "x" * len(answer)
                             op1val = line.split("op1val")[1].split("x")[1].split(";")[0]
+                            if "-" in line.split("op1val")[1].split("x")[0]: # neg sign handling
+                              op1val = line.split("op1val")[1].split("x")[1].split(";")[0]
                             if "-" in line.split("op1val")[1].split("x")[0]: # neg sign handling
                                 op1val = twos_comp(my_config.bits, op1val)
                             if my_config.op != "fsqrt": # sqrt doesn't have two input vals, unnec here but keeping for later
@@ -243,6 +256,11 @@ def create_vectors(my_config):
                         if "op1val" in line:
                             # print("det2")
                             # parse line
+
+                            # handle special case where destination register is hardwired to zero
+                            if "dest:x0" in line: 
+                              answer = "x" * len(answer)
+
                             op1val = line.split("op1val")[1].split("x")[1].split(";")[0]
                             if "-" in line.split("op1val")[1].split("x")[0]: # neg sign handling
                                 op1val = twos_comp(my_config.bits, op1val)


### PR DESCRIPTION
for integer division/sqrt test vector extraction, we now handle the edge case where rd is hardwired to zero.
This fixes a bug where the testbench would check against a division/remainder operation that gives a correct nonzero result, but because the assembly sets rd=zero, the testbench raises an error because the expected result is zero.

the fix is to set the testvector's answer field to Xs when encountering this edge case, in which the testbench can skip over this testvector.