### PR TITLE
Updating ease of usage of nightly_build.py

### DIFF
--- a/bin/nightly_build.py
+++ b/bin/nightly_build.py
@@ -351,7 +351,7 @@ class TestRunner:
 
         if test_exctention:
             command = [test_type, test_name, test_exctention]
-            logger.info(f"Command used to run tests: {test_type} {test_name} -{test_exctention}")
+            logger.info(f"Command used to run tests: {test_type} {test_name} {test_exctention}")
         else:
             command = [test_type, test_name]
             logger.info(f"Command used to run tests: {test_type} {test_name}")

--- a/bin/nightly_build.py
+++ b/bin/nightly_build.py
@@ -302,7 +302,7 @@ class TestRunner:
         # Prepare the command to execute the Makefile
         make_file_path = os.path.join(self.base_dir, "sim")
         os.chdir(make_file_path)
-
+        
         output_file = os.path.join(self.base_dir, "tmp", "make_output.log")
 
         command = ["make"]
@@ -662,10 +662,10 @@ def main():
 
     parser = argparse.ArgumentParser(description='Nightly Verification Testing for WALLY.')
 
-    parser.add_argument('--path', help='specify the path for where the nightly repositories will be cloned ex: "nightly-runs')
-    parser.add_argument('--repository', help='specify which github repository you want to clone')
-    parser.add_argument('--target', help='types of tests you can make are: all, wally-riscv-arch-test')
-    parser.add_argument('--send_email', help='do you want to send emails: "yes" or "y"')
+    parser.add_argument('--path',default = "nightly", help='specify the path for where the nightly repositories will be cloned ex: "nightly-runs')
+    parser.add_argument('--repository',default = "https://github.com/openhwgroup/cvw", help='specify which github repository you want to clone')
+    parser.add_argument('--target', default = "all", help='types of tests you can make are: all, wally-riscv-arch-test')
+    parser.add_argument('--send_email',default = "yes", help='do you want to send emails: "yes" or "y"')
     
     args = parser.parse_args()
 
@@ -673,6 +673,8 @@ def main():
     logger.info(f"repository: {args.repository}")
     logger.info(f"target: {args.target}")
     logger.info(f"send_email: {args.send_email}")
+    
+    
 
     # file paths for where the results and repos will be saved: repos and results can be changed to whatever
     repos_path = f"{args.path}/repos/"

--- a/bin/wrapper_nightly_runs.sh
+++ b/bin/wrapper_nightly_runs.sh
@@ -24,5 +24,5 @@ source ./setup_host.sh >> $LOG 2>&1
 cd $PYTHON_SCRIPT
 pwd
 echo "Running python file"
-python nightly_build.py --path "nightly-runs" --repository "https://github.com/openhwgroup/cvw" --target "all" --send_email "yes" >> $LOG 2>&1
+python nightly_build.py  >> $LOG 2>&1
 echo "Finished"

--- a/bin/wrapper_nightly_runs.sh
+++ b/bin/wrapper_nightly_runs.sh
@@ -1,15 +1,8 @@
 #!/bin/bash
-date
-
 
 # Variables
-LOG=$HOME/nightly-runs/logs/from_wrapper.log    # you can store your log file where you would like
 PYTHON_SCRIPT=$HOME/nightly-runs/cvw/bin/       # cvw can be anywhere you would like it. Make sure to point your variable there
 SETUP_SCRIPT=$HOME/nightly-runs/cvw/            # cvw can be anywhere you would like it. Make sure to point your variable there
-
-
-
-date > $LOG 2>&1
 
 echo "Current directory"
 pwd
@@ -19,10 +12,10 @@ echo "Current directory"
 pwd
 
 echo "Sourcing setup_host"
-source ./setup.sh >> $LOG 2>&1
+source ./setup.sh 
 
 cd $PYTHON_SCRIPT
 pwd
 echo "Running python file"
-python nightly_build.py >> $LOG 2>&1
+python nightly_build.py 
 echo "Finished"

--- a/bin/wrapper_nightly_runs.sh
+++ b/bin/wrapper_nightly_runs.sh
@@ -19,10 +19,10 @@ echo "Current directory"
 pwd
 
 echo "Sourcing setup_host"
-source ./setup_host.sh >> $LOG 2>&1
+source ./setup.sh >> $LOG 2>&1
 
 cd $PYTHON_SCRIPT
 pwd
 echo "Running python file"
-python nightly_build.py  >> $LOG 2>&1
+python nightly_build.py >> $LOG 2>&1
 echo "Finished"


### PR DESCRIPTION
# Two main changes:

**Change 1**
nightly_build.py has a new directory structure and default arguments for running the script. 

The arguments are:

```
'--path',default = "nightly"
'--repository',default = "https://github.com/openhwgroup/cvw"
'--target', default = "all"
'--send_email',default = "yes"
```

The new directory structure is that by default the new repositories and results will be in the following:
`~/nightly/<date>/cvw`
`~/nightly/<date>/results`
`~/nightly/<date>/logs`

The logger class creates a really readable log file in `~/nightly/<date>/logs` called nightly_build.log. Other log files in there are from making and running the tests. 

**Change 2**
The wrapper_nightly_build.sh is modified to source a setup.sh script and get rid of the log directories since that causes issues with running the tests. Getting rid of the logs for running the commands is okay, in my opinion, because of the logger class that documents the issues caught in the program. This logging still needs to improve with added try and except statements but its a move in the right direction for readability and accessibility of the log file. Also now there is a log folder specifically for each day instead of just one. 

