### PR TITLE
fix typo in flash-sd.sh

### DIFF
--- a/linux/sdcard/flash-sd.sh
+++ b/linux/sdcard/flash-sd.sh
@@ -74,9 +74,9 @@ fi
 
 # Prefix partition with "p" for non-SCSI disks (mmcblk, nvme)
 if [[ $SDCARD == "/dev/sd"* ]]; then
-    $PART_PREFIX=""
+    PART_PREFIX=""
 else
-    $PART_PREFIX="p"
+    PART_PREFIX="p"
 fi
 
 # If no images directory, images have not been built


### PR DESCRIPTION
The current version doesn't use the correct syntax to assign a value to $PART_PREFIX. I'm not sure how I didn't notice it in my testing before.