### PR TITLE
Update RISCOF ISA config MISA values to be consistent

### DIFF
--- a/tests/riscof/spike/spike_rv64gc_isa.yaml
+++ b/tests/riscof/spike/spike_rv64gc_isa.yaml
@@ -27,7 +27,7 @@ hart0:
            warl:
               dependency_fields: []
               legal:
-                - extensions[25:0] bitmask [0x014112D, 0x0000000]
+                - extensions[25:0] bitmask [0x015112D, 0x0000000]
               wr_illegal:
                 - Unchanged
  


### PR DESCRIPTION
The reset value and the value defined under extensions were inconsistent with each other. One had Q enabled and the other did not. This enables it in both places.