### PR TITLE
On some Ubuntu boxes, the path for Wally interferes with other tools.…

### DIFF
--- a/site-setup.sh
+++ b/site-setup.sh
@@ -21,11 +21,11 @@ export PATH=$QUESTA_HOME/bin:$DC_HOME/bin:$VCS_HOME/bin:$PATH
 
 # GCC
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$RISCV/riscv-gnu-toolchain/lib:$RISCV/riscv-gnu-toolchain/riscv64-unknown-elf/lib
-export PATH=$PATH:$RISCV/riscv-gnu-toolchain/bin:$RISCV/riscv-gnu-toolchain/riscv64-unknown-elf/bin      # GCC tools
+export PATH=$RISCV/riscv-gnu-toolchain/bin:$RISCV/riscv-gnu-toolchain/riscv64-unknown-elf/bin:$PATH      # GCC tools
 
 # Spike
 export LD_LIBRARY_PATH=$RISCV/lib:$LD_LIBRARY_PATH
-export PATH=$PATH:$RISCV/bin
+export PATH=$RISCV/bin:$PATH
 
 # Verilator
 export PATH=/usr/local/bin/verilator:$PATH # Change this for your path to Verilator

--- a/site-setup.sh
+++ b/site-setup.sh
@@ -21,7 +21,6 @@ export PATH=$QUESTA_HOME/bin:$DC_HOME/bin:$VCS_HOME/bin:$PATH
 
 # GCC
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$RISCV/riscv-gnu-toolchain/lib:$RISCV/riscv-gnu-toolchain/riscv64-unknown-elf/lib
-export PATH=$RISCV/riscv-gnu-toolchain/bin:$RISCV/riscv-gnu-toolchain/riscv64-unknown-elf/bin:$PATH      # GCC tools
 
 # Spike
 export LD_LIBRARY_PATH=$RISCV/lib:$LD_LIBRARY_PATH

--- a/site-setup.sh
+++ b/site-setup.sh
@@ -24,7 +24,7 @@ export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$RISCV/riscv-gnu-toolchain/lib:$RISCV/ri
 
 # Spike
 export LD_LIBRARY_PATH=$RISCV/lib:$LD_LIBRARY_PATH
-export PATH=$RISCV/bin:$PATH
+export PATH=$PATH:$RISCV/bin
 
 # Verilator
 export PATH=/usr/local/bin/verilator:$PATH # Change this for your path to Verilator


### PR DESCRIPTION
…  Prepending Wally path to make sure there are no conflicts.   This caused some issues on some fresh Ubuntu boxes.  It allows Wally to get the right path instead of fighting with previous paths and prevents issues with users possibly changing things.