### PR TITLE
Add support for getenvval as wrapper for Verilator's getenv

### DIFF
--- a/sim/verilator/Makefile
+++ b/sim/verilator/Makefile
@@ -1,0 +1,55 @@
+.PHONY: profile run questa clean
+
+OPT=
+PARAMS?=-DVERILATOR=1 --no-trace-top
+NONPROF?=--stats
+WORKING_DIR=${WALLY}/sim/verilator
+TARGET=$(WORKING_DIR)/target
+SOURCE=${WALLY}/config/shared/*.vh ${WALLY}/config/${WALLYCONF} ${WALLY}/src/cvw.sv ${WALLY}/testbench/testbench.sv ${WALLY}/testbench/common/*.sv ${WALLY}/src/*/*.sv ${WALLY}/src/*/*/*.sv
+
+WALLYCONF?=rv64gc
+TEST?=arch64i
+
+default: run
+
+profile: obj_dir_profiling/Vtestbench_$(WALLYCONF)
+	$(WORKING_DIR)/obj_dir_profiling/Vtestbench_$(WALLYCONF) +TEST=$(TEST) 
+	mv gmon.out gmon_$(WALLYCONF).out
+	gprof $(WORKING_DIR)/obj_dir_profiling/Vtestbench_$(WALLYCONF) gmon_$(WALLYCONF).out > gmon_$(WALLYCONF).log
+	verilator_profcfunc gmon_$(WALLYCONF).log > gmon_$(WALLYCONF).log2
+	mkdir -p $(WORKING_DIR)/logs_profiling
+	mv gmon_$(WALLYCONF)* $(WORKING_DIR)/logs_profiling
+	echo "Please check $(WORKING_DIR)/logs_profiling/gmon_$(WALLYCONF)* for logs and output files."
+
+run: obj_dir_non_profiling/Vtestbench_$(WALLYCONF)
+	mkdir -p $(WORKING_DIR)/logs
+	time $(WORKING_DIR)/obj_dir_non_profiling/Vtestbench_$(WALLYCONF) +TEST=$(TEST) 2>&1 > $(WORKING_DIR)/logs/$(WALLYCONF)_$(TEST).log
+	echo "Please check $(WORKING_DIR)/logs/$(WALLYCONF)_$(TEST).log for logs and output files."
+	
+obj_dir_non_profiling/Vtestbench_$(WALLYCONF): $(SOURCE)
+	mkdir -p obj_dir_non_profiling
+	time verilator \
+	--Mdir obj_dir_non_profiling -o Vtestbench_$(WALLYCONF) \
+	-cc --binary \
+	$(OPT) $(PARAMS) $(NONPROF) \
+	--timescale "1ns/1ns" --timing --top-module testbench  --relative-includes \
+	"-I${WALLY}/config/shared" "-I${WALLY}/config/$(WALLYCONF)" \
+	wrapper.c \
+	${WALLY}/src/cvw.sv ${WALLY}/testbench/testbench.sv ${WALLY}/testbench/common/*.sv ${WALLY}/src/*/*.sv ${WALLY}/src/*/*/*.sv
+
+	
+obj_dir_profiling/Vtestbench_$(WALLYCONF): $(SOURCE)
+	mkdir -p obj_dir_profiling
+	time verilator \
+	--Mdir obj_dir_profiling -o Vtestbench_$(WALLYCONF) \
+	-cc --binary \
+	--prof-cfuncs $(OPT) $(PARAMS) \
+	--timescale "1ns/1ns" --timing --top-module testbench  --relative-includes \
+	wrapper.c \
+	"-I${WALLY}/config/shared" "-I${WALLY}/config/$(WALLYCONF)" ${WALLY}/src/cvw.sv ${WALLY}/testbench/testbench.sv ${WALLY}/testbench/common/*.sv ${WALLY}/src/*/*.sv ${WALLY}/src/*/*/*.sv
+
+questa:
+	time vsim -c -do "do ${WALLY}/sim/wally-batch.do $(WALLYCONF) $(TEST)"
+
+clean:
+	rm -rf $(WORKING_DIR)/obj_dir_non_profiling $(WORKING_DIR)/obj_dir_profiling $(WORKING_DIR)/logs $(WORKING_DIR)/logs_profiling

--- a/sim/verilator/wrapper.c
+++ b/sim/verilator/wrapper.c
@@ -1,0 +1,7 @@
+#include <stdlib.h>
+
+#include "Vtestbench__Dpi.h"
+
+const char *getenvval(const char *pszName) {
+    return ((const char *) getenv(pszName));
+}

--- a/testbench/testbench.sv
+++ b/testbench/testbench.sv
@@ -34,7 +34,11 @@
 `endif
 
 import cvw::*;
+`ifdef VERILATOR
+import "DPI-C" function string getenvval(input string env_name);
+`else
 import "DPI-C" function string getenv(input string env_name);
+`endif
 
 module testbench;
   /* verilator lint_off WIDTHTRUNC */
@@ -60,7 +64,12 @@ module testbench;
   // Variables that can be overwritten with $value$plusargs at start of simulation
   string       TEST;
   integer      INSTR_LIMIT;
+`ifdef VERILATOR
+  string       RISCV_DIR = getenvval("RISCV"); // "/opt/riscv";
+`else
   string       RISCV_DIR = getenv("RISCV"); // "/opt/riscv";
+`endif
+  // string       RISCV_DIR = "/opt/riscv";
 
   // DUT signals
   logic [P.AHBW-1:0]    HRDATAEXT;


### PR DESCRIPTION
As suggested in #723 by europe2024 and demand for support of `getenv` in Verilator, this commit adds support for `getenv` through DPI.

The reason why it is not using `getenv` directly is that there are some problems with the function signature in C and C++. So it is necessary to add wrapper around `getenv` to explicitly specify it is using C++ version `getenv`.