### PR TITLE
Fixed code coverage for regression-wally

### DIFF
--- a/bin/regression-wally
+++ b/bin/regression-wally
@@ -208,7 +208,7 @@ def addTests(tests, sim):
             gs = test[3]
         else:
             gs = "All tests ran without failures"
-        cmdPrefix="wsim --sim " + sim + " " + config
+        cmdPrefix="wsim --sim " + sim + " " + coverStr + " " + config
         for t in suites:
             tc = TestCase(
                     name=t,

--- a/bin/regression-wally
+++ b/bin/regression-wally
@@ -381,7 +381,7 @@ def main():
     #   Presently don't run buildroot because it has a different config and can't be merged with the rv64gc coverage.
     #   Also it is slow to run.   
     #    configs.append(getBuildrootTC(boot=False))
-        os.system('rm -f cov/*.ucdb')
+        os.system('rm -f questa/cov/*.ucdb')
     elif '--nightly' in sys.argv:
         TIMEOUT_DUR = 60*1440 # 1 day
         #configs.append(getBuildrootTC(boot=False))
@@ -407,7 +407,7 @@ def main():
 
     # Coverage report
     if coverage:
-       os.system('make coverage')
+       os.system('make QuestaCoverage')
     # Count the number of failures
     if num_fail:
         print(f"{bcolors.FAIL}Regression failed with %s failed configurations{bcolors.ENDC}" % num_fail)

--- a/sim/Makefile
+++ b/sim/Makefile
@@ -17,28 +17,28 @@ all: riscoftests memfiles coveragetests deriv
 
 wally-riscv-arch-test: wallyriscoftests memfiles
 
-coverage: cov/rv64gc_arch64i.ucdb 
+QuestaCoverage: questa/cov/rv64gc_arch64i.ucdb 
 	#iter-elf.bash --cover --search ../tests/coverage
-	vcover merge -out cov/cov.ucdb cov/rv64gc_arch64i.ucdb cov/rv64gc*.ucdb -logfile cov/log
-#	vcover merge -out cov/cov.ucdb cov/rv64gc_arch64i.ucdb cov/rv64gc*.ucdb cov/buildroot_buildroot.ucdb riscv.ucdb -logfile cov/log
-	vcover report -details cov/cov.ucdb > cov/rv64gc_coverage_details.rpt
-	vcover report cov/cov.ucdb -details -instance=/core/ebu. > cov/rv64gc_coverage_ebu.rpt
-	vcover report cov/cov.ucdb -details -instance=/core/priv. > cov/rv64gc_coverage_priv.rpt
-	vcover report cov/cov.ucdb -details -instance=/core/ifu. > cov/rv64gc_coverage_ifu.rpt
-	vcover report cov/cov.ucdb -details -instance=/core/lsu. > cov/rv64gc_coverage_lsu.rpt
-	vcover report cov/cov.ucdb -details -instance=/core/fpu. > cov/rv64gc_coverage_fpu.rpt
-	vcover report cov/cov.ucdb -details -instance=/core/ieu. > cov/rv64gc_coverage_ieu.rpt
-	vcover report cov/cov.ucdb -below 100 -details -instance=/core/ebu. > cov/rv64gc_uncovered_ebu.rpt
-	vcover report cov/cov.ucdb -below 100 -details -instance=/core/priv. > cov/rv64gc_uncovered_priv.rpt
-	vcover report cov/cov.ucdb -below 100 -details -instance=/core/ifu. > cov/rv64gc_uncovered_ifu.rpt
-	vcover report cov/cov.ucdb -below 100 -details -instance=/core/lsu. > cov/rv64gc_uncovered_lsu.rpt
-	vcover report cov/cov.ucdb -below 100 -details -instance=/core/fpu. > cov/rv64gc_uncovered_fpu.rpt
-	vcover report cov/cov.ucdb -below 100 -details -instance=/core/ieu. > cov/rv64gc_uncovered_ieu.rpt
-	vcover report -hierarchical cov/cov.ucdb > cov/rv64gc_coverage_hierarchical.rpt
-	vcover report -below 100 -hierarchical cov/cov.ucdb > cov/rv64gc_uncovered_hierarchical.rpt
-#	vcover report -below 100 cov/cov.ucdb > cov/rv64gc_coverage.rpt
-#	vcover report -recursive cov/cov.ucdb > cov/rv64gc_recursive.rpt
-	vcover report -details -threshH 100 -html cov/cov.ucdb
+	vcover merge -out questa/cov/cov.ucdb questa/cov/rv64gc_arch64i.ucdb questa/cov/rv64gc*.ucdb -logfile questa/cov/log
+#	vcover merge -out questa/cov/cov.ucdb questa/cov/rv64gc_arch64i.ucdb questa/cov/rv64gc*.ucdb questa/cov/buildroot_buildroot.ucdb riscv.ucdb -logfile questa/cov/log
+	vcover report -details questa/cov/cov.ucdb > questa/cov/rv64gc_coverage_details.rpt
+	vcover report questa/cov/cov.ucdb -details -instance=/core/ebu. > questa/cov/rv64gc_coverage_ebu.rpt
+	vcover report questa/cov/cov.ucdb -details -instance=/core/priv. > questa/cov/rv64gc_coverage_priv.rpt
+	vcover report questa/cov/cov.ucdb -details -instance=/core/ifu. > questa/cov/rv64gc_coverage_ifu.rpt
+	vcover report questa/cov/cov.ucdb -details -instance=/core/lsu. > questa/cov/rv64gc_coverage_lsu.rpt
+	vcover report questa/cov/cov.ucdb -details -instance=/core/fpu. > questa/cov/rv64gc_coverage_fpu.rpt
+	vcover report questa/cov/cov.ucdb -details -instance=/core/ieu. > questa/cov/rv64gc_coverage_ieu.rpt
+	vcover report questa/cov/cov.ucdb -below 100 -details -instance=/core/ebu. > questa/cov/rv64gc_uncovered_ebu.rpt
+	vcover report questa/cov/cov.ucdb -below 100 -details -instance=/core/priv. > questa/cov/rv64gc_uncovered_priv.rpt
+	vcover report questa/cov/cov.ucdb -below 100 -details -instance=/core/ifu. > questa/cov/rv64gc_uncovered_ifu.rpt
+	vcover report questa/cov/cov.ucdb -below 100 -details -instance=/core/lsu. > questa/cov/rv64gc_uncovered_lsu.rpt
+	vcover report questa/cov/cov.ucdb -below 100 -details -instance=/core/fpu. > questa/cov/rv64gc_uncovered_fpu.rpt
+	vcover report questa/cov/cov.ucdb -below 100 -details -instance=/core/ieu. > questa/cov/rv64gc_uncovered_ieu.rpt
+	vcover report -hierarchical questa/cov/cov.ucdb > questa/cov/rv64gc_coverage_hierarchical.rpt
+	vcover report -below 100 -hierarchical questa/cov/cov.ucdb > questa/cov/rv64gc_uncovered_hierarchical.rpt
+#	vcover report -below 100 questa/cov/cov.ucdb > questa/cov/rv64gc_coverage.rpt
+#	vcover report -recursive questa/cov/cov.ucdb > questa/cov/rv64gc_recursive.rpt
+	vcover report -details -threshH 100 -html questa/cov/cov.ucdb
 
 allclean: clean all
 


### PR DESCRIPTION
- Fixed insert_debug_comment.sh to work with the older version of bash.
- Patch makefile in embench to use wsim.
- Fixed regression-wally so it actually produces covereage reports.
- Fixed makefile and regression-wally so that code coverage now works.
