### PR TITLE
RISCVDV bringup - Coverage Collection on RISCVISACOV

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,8 @@ imperasdv_cov:
 	echo "0" > ${WALLY}/sim/seed0.txt
 #	/opt/riscv/ImperasDV-OpenHW/scripts/cvw/run-elf-cov.bash --verbose --seed 0 --search ${WALLY}/tests/riscof/work/wally-riscv-arch-test/rv64i_m
 #	/opt/riscv/ImperasDV-OpenHW/scripts/cvw/run-elf-cov.bash --elf ${WALLY}/tests/riscof/work/riscv-arch-test/rv64i_m/I/src/add-01.S/dut/my.elf --seed ${WALLY}/sim/seed0.txt --coverdb ${WALLY}/sim/cov/rv64gc_arch64i.ucdb --verbose
-	/opt/riscv/ImperasDV-OpenHW/scripts/cvw/run-elf-cov.bash --elf ${WALLY}/tests/riscof/work/riscv-arch-test/rv64i_m/I/src/add-01.S/dut/my.elf --seed ${WALLY}/sim/seed0.txt --coverdb riscv.ucdb --verbose
+#	/opt/riscv/ImperasDV-OpenHW/scripts/cvw/run-elf-cov.bash --elf ${WALLY}/tests/riscof/work/riscv-arch-test/rv64i_m/I/src/add-01.S/dut/my.elf --seed ${WALLY}/sim/seed0.txt --coverdb riscv.ucdb --verbose
+	run-elf-cov.bash --elf ${WALLY}/tests/output_folder/asm_test/riscv_arithmetic_basic_test_0.elf --seed ${WALLY}/sim/seed0.txt --coverdb riscv.ucdb --verbose
 	vcover report -details -html sim/riscv.ucdb
 
 funcovreg:
@@ -56,6 +57,58 @@ funcovreg:
 	iter-elf.bash --search ${WALLY}/tests/riscof/work/riscv-arch-test/rv64i_m/I --cover
 	vcover report -details -html sim/riscv.ucdb
 
+# test_name=riscv_arithmetic_basic_test
+rvdv: sim/regression_logs sim/regression_ucdbs
+	python3 ${WALLY}/addins/riscv-dv/run.py --test ${test_name} --target rv64gc --output tests/output_folder  --iterations 1 -si questa --iss spike --verbose --cov --seed 0 --steps gen			>> sim/regression_logs/${test_name}.log 2>&1
+	python3 ${WALLY}/addins/riscv-dv/run.py --test ${test_name} --target rv64gc --output tests/output_folder  --iterations 1 -si questa --iss spike --verbose --cov --seed 0 --steps gcc_compile	>> sim/regression_logs/${test_name}.log 2>&1
+	python3 ${WALLY}/addins/riscv-dv/run.py --test ${test_name} --target rv64gc --output tests/output_folder  --iterations 1 -si questa --iss spike --verbose --cov --seed 0 --steps iss_sim		>> sim/regression_logs/${test_name}.log 2>&1
+#	run-elf.bash --seed ${WALLY}/sim/seed0.txt --verbose --elf ${WALLY}/tests/output_folder/asm_test/${test_name}_0.o													>> sim/regression_logs/${test_name}.log 2>&1
+	/home/qabid/scripts/run-elf-cov.bash --seed ${WALLY}/sim/seed0.txt --verbose --coverdb sim/riscv.ucdb --elf ${WALLY}/tests/output_folder/asm_test/${test_name}_0.o								>> sim/regression_logs/${test_name}.log 2>&1
+	cp sim/riscv.ucdb sim/regression_ucdbs/${test_name}.ucdb
+
+rvdv_regression:
+	mkdir -p sim/regression_logs
+	mkdir -p sim/regression_ucdbs
+	cd sim/regression_logs && rm -rf *
+	cd sim/regression_ucdbs && rm -rf *
+	make rvdv test_name=riscv_arithmetic_basic_test				>> sim/regression.log 2>&1
+	make rvdv test_name=riscv_amo_test							>> sim/regression.log 2>&1
+	make rvdv test_name=riscv_ebreak_debug_mode_test			>> sim/regression.log 2>&1
+	make rvdv test_name=riscv_ebreak_test						>> sim/regression.log 2>&1
+	make rvdv test_name=riscv_floating_point_arithmetic_test	>> sim/regression.log 2>&1
+	make rvdv test_name=riscv_floating_point_mmu_stress_test	>> sim/regression.log 2>&1
+	make rvdv test_name=riscv_floating_point_rand_test			>> sim/regression.log 2>&1
+	make rvdv test_name=riscv_full_interrupt_test				>> sim/regression.log 2>&1
+	make rvdv test_name=riscv_hint_instr_test					>> sim/regression.log 2>&1
+	make rvdv test_name=riscv_illegal_instr_test				>> sim/regression.log 2>&1
+	make rvdv test_name=riscv_invalid_csr_test					>> sim/regression.log 2>&1
+	make rvdv test_name=riscv_jump_stress_test					>> sim/regression.log 2>&1
+	make rvdv test_name=riscv_loop_test							>> sim/regression.log 2>&1
+	make rvdv test_name=riscv_machine_mode_rand_test			>> sim/regression.log 2>&1
+	make rvdv test_name=riscv_mmu_stress_test					>> sim/regression.log 2>&1
+	make rvdv test_name=riscv_no_fence_test						>> sim/regression.log 2>&1
+	make rvdv test_name=riscv_non_compressed_instr_test			>> sim/regression.log 2>&1
+	make rvdv test_name=riscv_pmp_test							>> sim/regression.log 2>&1
+	make rvdv test_name=riscv_privileged_mode_rand_test			>> sim/regression.log 2>&1
+	make rvdv test_name=riscv_rand_instr_test					>> sim/regression.log 2>&1
+	make rvdv test_name=riscv_rand_jump_test					>> sim/regression.log 2>&1
+	make rvdv test_name=riscv_sfence_exception_test				>> sim/regression.log 2>&1
+	make rvdv test_name=riscv_unaligned_load_store_test			>> sim/regression.log 2>&1
+
+rvdv_combine_coverage:
+	mkdir -p sim/regcov
+	cd sim/regcov && rm -rf *
+	vcover merge sim/regcov/regcov.ucdb  sim/regression_ucdbs/* -suppress 6854 -64
+	vcover report -details -html sim/regcov/regcov.ucdb
+	vcover report sim/regcov/regcov.ucdb -details -cvg > sim/regcov/regcov.ucdb.log
+	vcover report sim/regcov/regcov.ucdb -testdetails -cvg > sim/regcov/regcov.ucdb.testdetails.log
+	vcover report sim/regcov/regcov.ucdb -details -cvg -below 100 | egrep "Coverpoint|Covergroup|Cross" | grep -v Metric > sim/regcov/regcov.ucdb.summary.log
+	grep "Total Coverage By Instance" sim/regcov/regcov.ucdb.log
+
+remove_rvdv_artifacts:
+	rm sim/riscv.ucdb sim/regression.log covhtmlreport/ sim/regression_logs/ sim/regression_ucdbs/ sim/regcov/ -rf
+
+collect_riscvdv_regression_coverage: remove_rvdv_artifacts rvdv_regression rvdv_combine_coverage
 coverage:
 	regression-wally -coverage -fp
 

--- a/README.md
+++ b/README.md
@@ -49,10 +49,14 @@ Add the following lines to your .bashrc or .bash_profile to run the setup script
 
 Edit setup.sh and change the following lines to point to the path and license server for your Siemens Questa and Synopsys Design Compiler installation and license server.  If you only have Questa, you can still simulate but cannot run logic synthesis.
 
-	export MGLS_LICENSE_FILE=1717@solidworks.eng.hmc.edu                # Change this to your Siemens license server
-	export SNPSLMD_LICENSE_FILE=27020@zircon.eng.hmc.edu                # Change this to your Synopsys license server
-	export QUESTAPATH=/cad/mentor/questa_sim-2021.2_1/questasim/bin     # Change this for your path to Questa
-	export SNPSPATH=/cad/synopsys/SYN/bin                               # Change this for your path to Design Compiler
+	export MGLS_LICENSE_FILE=1717@solidworks.eng.hmc.edu                	# Change this to your Siemens license server
+	export SNPSLMD_LICENSE_FILE=27020@zircon.eng.hmc.edu                	# Change this to your Synopsys license server
+	export QUESTAPATH=/cad/mentor/questa_sim-2021.2_1/questasim/bin     	# Change this for your path to Questa
+	export SNPSPATH=/cad/synopsys/SYN/bin                               	# Change this for your path to Design Compiler
+	export RISCV_TOOLCHAIN=/opt/riscv										# Change this for your path to RISCV GNU toolchain
+	export RISCV_GCC="$RISCV_TOOLCHAIN/bin/riscv64-unknown-elf-gcc"			# Copy this as it is
+	export RISCV_OBJCOPY="$RISCV_TOOLCHAIN/bin/riscv64-unknown-elf-objcopy"	# Copy this as it is
+	export SPIKE_PATH=/usr/bin												# Change this for your path to riscv-isa-sim (spike)
 
 If the tools are not yet installed on your server, follow the Toolchain Installation instructions in the section below.
 

--- a/sim/questa/wally-imperas-cov.do
+++ b/sim/questa/wally-imperas-cov.do
@@ -40,8 +40,12 @@ vlog +incdir+../config/$1 \
      \
      +define+INCLUDE_TRACE2COV +define+COVER_BASE_RV64I +define+COVER_LEVEL_DV_PR_EXT \
        +define+COVER_RV64I \
-       +define+COVER_RV64C \
        +define+COVER_RV64M \
+       +define+COVER_RV64A \
+       +define+COVER_RV64F \
+       +define+COVER_RV64D \
+       +define+COVER_RV64ZICSR \
+       +define+COVER_RV64C \
      +incdir+$env(IMPERAS_HOME)/ImpProprietary/source/host/riscvISACOV/source \
      $env(IMPERAS_HOME)/ImpProprietary/source/host/idv/trace2cov.sv  \
     \


### PR DESCRIPTION
The purpose of this PR is to collect and merge coverage on a test regression (tests generated from RISCVDV while coverpoints from RISCVISACOV)

After updating your local .bashrc file*, and updating to this branch. Run $time** make collect_riscvdv_regression_coverage and expect output similar to below:

*See README.md
**optional: `time`

```
$ time make collect_riscvdv_regression_coverage
rm sim/riscv.ucdb regression.log covhtmlreport/ regression_logs/ regression_ucdbs/ -rf
mkdir -p regression_logs
mkdir -p regression_ucdbs
cd regression_logs && rm -rf *
cd regression_ucdbs && rm -rf *
make rvdv test_name=riscv_arithmetic_basic_test                         >> regression.log 2>&1
make rvdv test_name=riscv_amo_test                                                      >> regression.log 2>&1
make rvdv test_name=riscv_ebreak_debug_mode_test                        >> regression.log 2>&1
make rvdv test_name=riscv_ebreak_test                                           >> regression.log 2>&1
make rvdv test_name=riscv_floating_point_arithmetic_test        >> regression.log 2>&1
make rvdv test_name=riscv_floating_point_mmu_stress_test        >> regression.log 2>&1
make rvdv test_name=riscv_floating_point_rand_test                      >> regression.log 2>&1
make rvdv test_name=riscv_full_interrupt_test                           >> regression.log 2>&1
make rvdv test_name=riscv_hint_instr_test                                       >> regression.log 2>&1
make rvdv test_name=riscv_illegal_instr_test                            >> regression.log 2>&1
make rvdv test_name=riscv_invalid_csr_test                                      >> regression.log 2>&1
make rvdv test_name=riscv_jump_stress_test                                      >> regression.log 2>&1
make rvdv test_name=riscv_loop_test                                                     >> regression.log 2>&1
make rvdv test_name=riscv_machine_mode_rand_test                        >> regression.log 2>&1
make rvdv test_name=riscv_mmu_stress_test                                       >> regression.log 2>&1
make rvdv test_name=riscv_no_fence_test                                         >> regression.log 2>&1
make rvdv test_name=riscv_non_compressed_instr_test                     >> regression.log 2>&1
make rvdv test_name=riscv_pmp_test                                                      >> regression.log 2>&1
make rvdv test_name=riscv_privileged_mode_rand_test                     >> regression.log 2>&1
make rvdv test_name=riscv_rand_instr_test                                       >> regression.log 2>&1
make rvdv test_name=riscv_rand_jump_test                                        >> regression.log 2>&1
make rvdv test_name=riscv_sfence_exception_test                         >> regression.log 2>&1
make rvdv test_name=riscv_unaligned_load_store_test                     >> regression.log 2>&1
mkdir -p regcov
cd regcov && rm -rf *
vcover merge regcov/regcov.ucdb  regression_ucdbs/* -suppress 6854 -64
QuestaSim-64 vcover 2023.4 Coverage Utility 2023.10 Oct  9 2023
Start time: 16:50:01 on Apr 23,2024
vcover merge regcov/regcov.ucdb regression_ucdbs/riscv_amo_test.ucdb regression_ucdbs/riscv_arithmetic_basic_test.ucdb regression_ucdbs/riscv_ebreak_debug_mode_test.ucdb regression_ucdbs/riscv_ebreak_test.ucdb regression_ucdbs/riscv_floating_point_arithmetic_test.ucdb regression_ucdbs/riscv_floating_point_mmu_stress_test.ucdb regression_ucdbs/riscv_floating_point_rand_test.ucdb regression_ucdbs/riscv_full_interrupt_test.ucdb regression_ucdbs/riscv_hint_instr_test.ucdb regression_ucdbs/riscv_illegal_instr_test.ucdb regression_ucdbs/riscv_invalid_csr_test.ucdb regression_ucdbs/riscv_jump_stress_test.ucdb regression_ucdbs/riscv_loop_test.ucdb regression_ucdbs/riscv_machine_mode_rand_test.ucdb regression_ucdbs/riscv_mmu_stress_test.ucdb regression_ucdbs/riscv_no_fence_test.ucdb regression_ucdbs/riscv_non_compressed_instr_test.ucdb regression_ucdbs/riscv_pmp_test.ucdb regression_ucdbs/riscv_privileged_mode_rand_test.ucdb regression_ucdbs/riscv_rand_instr_test.ucdb regression_ucdbs/riscv_rand_jump_test.ucdb regression_ucdbs/riscv_sfence_exception_test.ucdb regression_ucdbs/riscv_unaligned_load_store_test.ucdb -suppress 6854 -64 
QuestaSim-64 vcover 2023.4 Coverage Utility 2023.10 Oct  9 2023
Merging file regression_ucdbs/riscv_amo_test.ucdb
Merging file regression_ucdbs/riscv_arithmetic_basic_test.ucdb
Merging file regression_ucdbs/riscv_ebreak_debug_mode_test.ucdb
Merging file regression_ucdbs/riscv_ebreak_test.ucdb
Merging file regression_ucdbs/riscv_floating_point_arithmetic_test.ucdb
Merging file regression_ucdbs/riscv_floating_point_mmu_stress_test.ucdb
Merging file regression_ucdbs/riscv_floating_point_rand_test.ucdb
Merging file regression_ucdbs/riscv_full_interrupt_test.ucdb
Merging file regression_ucdbs/riscv_hint_instr_test.ucdb
Merging file regression_ucdbs/riscv_illegal_instr_test.ucdb
Merging file regression_ucdbs/riscv_invalid_csr_test.ucdb
Merging file regression_ucdbs/riscv_jump_stress_test.ucdb
Merging file regression_ucdbs/riscv_loop_test.ucdb
Merging file regression_ucdbs/riscv_machine_mode_rand_test.ucdb
Merging file regression_ucdbs/riscv_mmu_stress_test.ucdb
Merging file regression_ucdbs/riscv_no_fence_test.ucdb
Merging file regression_ucdbs/riscv_non_compressed_instr_test.ucdb
Merging file regression_ucdbs/riscv_pmp_test.ucdb
Merging file regression_ucdbs/riscv_privileged_mode_rand_test.ucdb
Merging file regression_ucdbs/riscv_rand_instr_test.ucdb
Merging file regression_ucdbs/riscv_rand_jump_test.ucdb
Merging file regression_ucdbs/riscv_sfence_exception_test.ucdb
Merging file regression_ucdbs/riscv_unaligned_load_store_test.ucdb
Writing merged result to regcov/regcov.ucdb

End time: 16:50:01 on Apr 23,2024, Elapsed time: 0:00:00
Errors: 0, Warnings: 0
vcover report -details -html regcov/regcov.ucdb
QuestaSim-64 vcover 2023.4 Coverage Utility 2023.10 Oct  9 2023
Start time: 16:50:01 on Apr 23,2024
vcover report -details -html regcov/regcov.ucdb 

End time: 16:50:01 on Apr 23,2024, Elapsed time: 0:00:00
Errors: 0, Warnings: 0
vcover report regcov/regcov.ucdb -details -cvg > regcov/regcov.ucdb.log
vcover report regcov/regcov.ucdb -testdetails -cvg > regcov/regcov.ucdb.testdetails.log
vcover report regcov/regcov.ucdb -details -cvg -below 100 | egrep "Coverpoint|Covergroup|Cross" | grep -v Metric > regcov/regcov.ucdb.summary.log
grep "Total Coverage By Instance" regcov/regcov.ucdb.log
Total Coverage By Instance (filtered view): 46.78%

real    5m37.079s
user    5m12.155s
sys     1m14.281s
```

The PR is a little too crude for what it achieves. Subsequent updates will be contributed in new PRs.