### PR TITLE
FIXED: Regression flow based on tests generated by RISCV-DV and coverage captured by RISCVISACOV is fixed

### DIFF
--- a/sim/questa/wally-imperas-cov.do
+++ b/sim/questa/wally-imperas-cov.do
@@ -24,8 +24,8 @@ vlib work
 # start and run simulation
 # remove +acc flag for faster sim during regressions if there is no need to access internal signals
         # *** modelsim won't take `PA_BITS, but will take other defines for the lengths of DTIM_RANGE and IROM_LEN.  For now just live with the warnings.
-vlog +incdir+../config/$1 \
-     +incdir+../config/shared \
+vlog +incdir+$env(WALLY)/config/$1 \
+     +incdir+$env(WALLY)/config/shared \
      +define+USE_IMPERAS_DV \
      +define+IDV_INCLUDE_TRACE2COV \
      +incdir+$env(IMPERAS_HOME)/ImpPublic/include/host \
@@ -49,11 +49,11 @@ vlog +incdir+../config/$1 \
      +incdir+$env(IMPERAS_HOME)/ImpProprietary/source/host/riscvISACOV/source \
      $env(IMPERAS_HOME)/ImpProprietary/source/host/idv/trace2cov.sv  \
     \
-    ../src/cvw.sv \
-     ../testbench/testbench-imperas.sv \
-     ../testbench/common/*.sv   \
-     ../src/*/*.sv \
-     ../src/*/*/*.sv \
+     $env(WALLY)/src/cvw.sv \
+     $env(WALLY)/testbench/testbench-imperas.sv \
+     $env(WALLY)/testbench/common/*.sv   \
+     $env(WALLY)/src/*/*.sv \
+     $env(WALLY)/src/*/*/*.sv \
      -suppress 2583 \
      -suppress 7063  \
      +acc
@@ -72,7 +72,7 @@ view wave
 
 run -all
 
-noview ../testbench/testbench-imperas.sv
-view wave
+# noview ../testbench/testbench-imperas.sv
+# view wave
 
 quit -f

--- a/site-setup.sh
+++ b/site-setup.sh
@@ -11,7 +11,7 @@
 # Must edit these based on your local environment.
 export MGLS_LICENSE_FILE=27002@zircon.eng.hmc.edu                   # Change this to your Siemens license server for Questa
 export SNPSLMD_LICENSE_FILE=27020@zircon.eng.hmc.edu                # Change this to your Synopsys license server for Design Compiler
-export QUESTA_HOME=/cad/mentor/questa_sim-2023.4                    # Change this for your path to Questa, excluding bin
+export QUESTA_HOME=/cad/mentor/questa_sim-2023.4/questasim          # Change this for your path to Questa, excluding bin
 export DC_HOME=/cad/synopsys/SYN                                    # Change this for your path to Synopsys Design Compiler, excluding bin
 export VCS_HOME=/cad/synopsys/vcs/U-2023.03-SP2-4                   # Change this for your path to Synopsys VCS, exccluding bin
 


### PR DESCRIPTION
1. The $QUESTA_HOME environmental variable is fixed
2. The relative paths to design and testbench files are fixed in the cvw/sim/questa/wally-imperas-cov.do tcl file
3. The RISCV-DV submodule is updated back to the latest commit on master branch
