### PR TITLE
added fcvtmod test, cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -221,4 +221,12 @@ sim/questa/riscv.ucdb.log
 sim/questa/riscv.ucdb.summary.log
 sim/questa/riscv.ucdb.testdetails.log
 tests/riscvdv
-
+examples/verilog/fulladder/csrc/
+examples/verilog/fulladder/profileReport.html
+examples/verilog/fulladder/profileReport.json
+examples/verilog/fulladder/profileReport.txt
+examples/verilog/fulladder/profileReport/
+examples/verilog/fulladder/simprofile_dir/
+examples/verilog/fulladder/simv.daidir/
+examples/verilog/fulladder/ucli.key
+examples/verilog/fulladder/verdi_config_file

--- a/Makefile
+++ b/Makefile
@@ -61,9 +61,9 @@ funcovreg:
 
 # test_name=riscv_arithmetic_basic_test
 rvdv: 
-	python3 ${WALLY}/addins/riscv-dv/run.py --test ${test_name} --target rv64gc --output tests/riscvdv  --iterations 1 -si questa --iss spike --verbose --cov --seed 0 --steps gen			>> ${SIM}/questa/regression_logs/${test_name}.log 2>&1
-	python3 ${WALLY}/addins/riscv-dv/run.py --test ${test_name} --target rv64gc --output tests/riscvdv  --iterations 1 -si questa --iss spike --verbose --cov --seed 0 --steps gcc_compile	>> ${SIM}/questa/regression_logs/${test_name}.log 2>&1
-	python3 ${WALLY}/addins/riscv-dv/run.py --test ${test_name} --target rv64gc --output tests/riscvdv  --iterations 1 -si questa --iss spike --verbose --cov --seed 0 --steps iss_sim		>> ${SIM}/questa/regression_logs/${test_name}.log 2>&1
+	python3 ${WALLY}/addins/riscv-dv/run.py --test ${test_name} --target rv64gc --output tests/riscvdv  --iterations 1 -si questa --iss spike --verbose --cov --seed 0 --steps gen,gcc_compile			>> ${SIM}/questa/regression_logs/${test_name}.log 2>&1
+#	python3 ${WALLY}/addins/riscv-dv/run.py --test ${test_name} --target rv64gc --output tests/riscvdv  --iterations 1 -si questa --iss spike --verbose --cov --seed 0 --steps gcc_compile	>> ${SIM}/questa/regression_logs/${test_name}.log 2>&1
+#	python3 ${WALLY}/addins/riscv-dv/run.py --test ${test_name} --target rv64gc --output tests/riscvdv  --iterations 1 -si questa --iss spike --verbose --cov --seed 0 --steps iss_sim		>> ${SIM}/questa/regression_logs/${test_name}.log 2>&1
 #	run-elf.bash --seed ${SIM}/questa/seed0.txt --verbose --elf ${WALLY}/tests/riscvdv/asm_test/${test_name}_0.o													>> ${SIM}/questa/regression_logs/${test_name}.log 2>&1
 	run-elf-cov.bash --seed ${SIM}/questa/seed0.txt --verbose --coverdb ${SIM}/questa/riscv.ucdb --elf ${WALLY}/tests/riscvdv/asm_test/${test_name}_0.o								>> ${SIM}/questa/regression_logs/${test_name}.log 2>&1
 	cp ${SIM}/questa/riscv.ucdb ${SIM}/questa/regression_ucdbs/${test_name}.ucdb

--- a/bin/regression-wally
+++ b/bin/regression-wally
@@ -30,8 +30,8 @@ tests = [
         ["rv32gc", ["arch32f", "arch32d", "arch32f_fma", "arch32d_fma", "arch32f_divsqrt", "arch32d_divsqrt", 
                     "arch32i", "arch32priv", "arch32c",  "arch32m", "arch32a", "arch32zifencei", "arch32zicond", 
                     "arch32zba", "arch32zbb", "arch32zbc", "arch32zbs", "arch32zfh", "arch32zfh_fma", 
-                    "arch32zfh_divsqrt", "arch32zfaf", "wally32a", "wally32priv", "wally32periph", "arch32zcb",
-                    "arch32zbkb", "arch32zbkc", "arch32zbkx", "arch32zknd", "arch32zkne", "arch32zknh"]], #  "arch32zfad"  # fcvtmod.w.d not working because of Sail flag bug. Jordan has PR in to fix Sail
+                    "arch32zfh_divsqrt", "arch32zfaf", "arch32zfad", "wally32a", "wally32priv", "wally32periph", "arch32zcb",
+                    "arch32zbkb", "arch32zbkc", "arch32zbkx", "arch32zknd", "arch32zkne", "arch32zknh"]], 
          ["rv64i", ["arch64i"]]
         ]
 

--- a/testbench/common/wallyTracer.sv
+++ b/testbench/common/wallyTracer.sv
@@ -46,7 +46,6 @@ module wallyTracer import cvw::*; #(parameter cvw_t P) (rvviTrace rvvi);
   logic 						 StallE, StallM, StallW;
   logic 						 FlushD, FlushE, FlushM, FlushW;
   logic 						 TrapM, TrapW;
-  logic 						 IntrF, IntrD, IntrE, IntrM, IntrW;
   logic 						 HaltM, HaltW;
   logic [1:0] 					 PrivilegeModeW;
   logic [P.XLEN-1:0] 			 rf[NUMREGS];
@@ -268,13 +267,6 @@ module wallyTracer import cvw::*; #(parameter cvw_t P) (rvviTrace rvvi);
   flopenrc #(1)     TrapWReg (clk, reset, 1'b0, ~StallW, TrapM, TrapW);
   flopenrc #(1)     InterruptWReg (clk, reset, 1'b0, ~StallW, InterruptM, InterruptW);
   flopenrc #(1)     HaltWReg (clk, reset, 1'b0, ~StallW, HaltM, HaltW);
-
-  // **** remove?  are these used?
-  flopenrc #(1)     IntrFReg (clk, reset, 1'b0, ~StallF, TrapM, IntrF);
-  flopenrc #(1)     IntrDReg (clk, reset, FlushD, ~StallD, IntrF, IntrD);
-  flopenrc #(1)     IntrEReg (clk, reset, FlushE, ~StallE, IntrD, IntrE);
-  flopenrc #(1)     IntrMReg (clk, reset, FlushM, ~StallM, IntrE, IntrM);
-  flopenrc #(1)     IntrWReg (clk, reset, FlushW, ~StallW, IntrM, IntrW);
 
   flopenrc #(12)    CSRAdrWReg (clk, reset, FlushW, ~StallW, CSRAdrM, CSRAdrW);
   flopenrc #(1)     CSRWriteWReg (clk, reset, FlushW, ~StallW, CSRWriteM, CSRWriteW);

--- a/testbench/tests.vh
+++ b/testbench/tests.vh
@@ -1929,6 +1929,7 @@ string arch64zknh[] = '{
 
   string arch32f[] = '{
     `RISCVARCHTEST,
+    "rv32i_m/F/src/fadd_b11-01.S",
     "rv32i_m/F/src/fadd_b10-01.S",
     "rv32i_m/F/src/fadd_b1-01.S",
     "rv32i_m/F/src/fadd_b11-01.S",
@@ -2276,7 +2277,7 @@ string arch64zknh[] = '{
     //`RISCVARCHTEST,
     `WALLYTEST,
     "rv64i_m/D_Zfa/src/fcvtmod.w.d_b1-01.S",
-//    "rv64i_m/D_Zfa/src/fcvtmod.w.d_b22-01.S", // temporarily excluded because Sail produces wrong signature  https://github.com/riscv/sail-riscv/issues/388
+    "rv64i_m/D_Zfa/src/fcvtmod.w.d_b22-01.S", 
     "rv64i_m/D_Zfa/src/fcvtmod.w.d_b23-01.S",
     "rv64i_m/D_Zfa/src/fcvtmod.w.d_b24-01.S",
     "rv64i_m/D_Zfa/src/fcvtmod.w.d_b27-01.S",


### PR DESCRIPTION
Now that fcvtmod.w.d is running on Sail, this PR adds it to the tests.
It will require rebuilding the latest Sail on systems.

Also removed Spike simulation from riscv-dv that might be generating infinite log files.