### PR TITLE
Remove existing derived configs before creating new ones

### DIFF
--- a/sim/Makefile
+++ b/sim/Makefile
@@ -62,6 +62,7 @@ coveragetests:
 	make -C ../tests/coverage/ --jobs
 
 deriv:
+	rm -rf ../config/deriv
 	derivgen.pl
 
 benchmarks:


### PR DESCRIPTION
There have been several instances where derived configs were improperly regenerated when running make. This removes the derived configs before recreating them to avoid this.