### PR TITLE
Revert "Remove existing derived configs before creating new ones" and remove in derivgen.pl instead

### DIFF
--- a/bin/derivgen.pl
+++ b/bin/derivgen.pl
@@ -70,10 +70,10 @@ foreach my $line (<$fh>) {
 }
 &terminateDeriv();
 close($fh);
+system("rm -rf $ENV{WALLY}/config/deriv");
 #foreach my $key (keys %derivs) {
 foreach my $key (@derivnames) {
     my $dir = "$ENV{WALLY}/config/deriv/$key";
-    system("rm -rf $dir");
     system("mkdir -p $dir");
     my $configunmod = "$dir/config_unmod.vh";
     my $config = "$dir/config.vh";

--- a/sim/Makefile
+++ b/sim/Makefile
@@ -62,7 +62,6 @@ coveragetests:
 	make -C ../tests/coverage/ --jobs
 
 deriv:
-	rm -rf ../config/deriv
 	derivgen.pl
 
 benchmarks:


### PR DESCRIPTION
- Reverts openhwgroup/cvw#811 which removed deriv directory in makefile
- Remove in derivgen.pl instead