### PR TITLE
Merges support for functional coverage into wally.do and testbench.sv

### DIFF
--- a/bin/wsim
+++ b/bin/wsim
@@ -66,8 +66,8 @@ cd = "cd $WALLY/sim/" +args.sim
 if (args.sim == "questa"):
     if (args.lockstep):
         Instret = str(args.locksteplog)
-        CovEnableStr = "1\"" if int(args.covlog) > 0  else "0\"";
-        prefix ="IMPERAS_TOOLS=" + WALLY + "/sim/imperas.ic OTHERFLAGS=\"+IDV_TRACE2LOG=" + Instret + " +IDV_TRACE2COV=" + str(args.covlog) + " +TRACE2COV_ENABLE=" + CovEnableStr;
+        CovEnableStr = "1" if int(args.covlog) > 0  else "0";
+        prefix ="IMPERAS_TOOLS=" + WALLY + "/sim/imperas.ic OTHERFLAGS=\"+IDV_TRACE2LOG=" + Instret + " +IDV_TRACE2COV=" + str(args.covlog) + " +TRACE2COV_ENABLE=" + CovEnableStr + "\"";
         suffix = "--lockstep"
     else:
         prefix = ""

--- a/bin/wsim
+++ b/bin/wsim
@@ -23,6 +23,7 @@ parser.add_argument("--sim", "-s", help="Simulator", choices=["questa", "verilat
 parser.add_argument("--tb", "-t", help="Testbench", choices=["testbench", "testbench_fp"], default="testbench")
 parser.add_argument("--gui", "-g", help="Simulate with GUI", action="store_true")
 parser.add_argument("--coverage", "-c", help="Code & Functional Coverage", action="store_true")
+parser.add_argument("--fcov", "-f", help="Code & Functional Coverage", action="store_true")
 parser.add_argument("--args", "-a", help="Optional arguments passed to simulator via $value$plusargs", default="")
 parser.add_argument("--vcd", "-v", help="Generate testbench.vcd", action="store_true")
 parser.add_argument("--lockstep", "-l", help="Run ImperasDV lock, step, and compare.", action="store_true")
@@ -74,6 +75,8 @@ if (args.sim == "questa"):
     cmd = "do wally.do " + args.config + " " + args.testsuite + " " + args.tb + " " + args.args + " " + ElfFile + " " + suffix
     if (args.coverage):
         cmd += " --coverage"
+    if (args.fcov):
+        cmd += " --fcov"
     if (args.gui):  # launch Questa with GUI; add +acc to keep variables accessible
         if(args.tb == "testbench"): 
             cmd = cd + "; " + prefix + " vsim -do \"" + cmd + " +acc -GDEBUG=1\""

--- a/bin/wsim
+++ b/bin/wsim
@@ -63,18 +63,27 @@ for d in ["logs", "wkdir", "cov"]:
 
 # Launch selected simulator
 cd = "cd $WALLY/sim/" +args.sim
+# ugh.  can't have more than 9 arguments passed to vsim. why? I'll have to remove --lockstep when running
+# functional coverage and imply it.
 if (args.sim == "questa"):
     if (args.lockstep):
-        Instret = str(args.locksteplog)
-        CovEnableStr = "1" if int(args.covlog) > 0  else "0";
-        prefix ="IMPERAS_TOOLS=" + WALLY + "/sim/imperas.ic OTHERFLAGS=\"+IDV_TRACE2LOG=" + Instret + " +IDV_TRACE2COV=" + str(args.covlog) + " +TRACE2COV_ENABLE=" + CovEnableStr + "\"";
-        suffix = "--lockstep"
+        prefix = "IMPERAS_TOOLS=" + WALLY + "/sim/imperas.ic" # OTHERFLAGS=\"+IDV_TRACE2LOG=" + str(args.locksteplog) + " +IDV_TRACE2COV=" + str(args.covlog) + "\"";
+        if(args.fcov):
+            CovEnableStr = "1" if int(args.covlog) > 0  else "0";
+            #ImperasPlusArgs = "+IDV_TRACE2LOG=" + str(args.locksteplog) + " +IDV_TRACE2COV=" + str(args.covlog) + " +TRACE2COV_ENABLE=" + CovEnableStr;
+            ImperasPlusArgs = " +IDV_TRACE2COV=" + str(args.covlog) + " +TRACE2COV_ENABLE=" + CovEnableStr;
+            suffix = ""
+        else:
+            CovEnableStr = ""
+            ImperasPlusArgs = "";
+            suffix = "--lockstep"
     else:
         prefix = ""
+        ImperasPlusArgs = ""
         suffix = ""
     if (args.tb == "testbench_fp"):
-            args.args = " -GTEST=\"" + args.testsuite + "\" " + args.args
-    cmd = "do wally.do " + args.config + " " + args.testsuite + " " + args.tb + " " + args.args + " " + ElfFile + " " + suffix
+        args.args = " -GTEST=\"" + args.testsuite + "\" " + args.args
+    cmd = "do wally.do " + args.config + " " + args.testsuite + " " + args.tb + " " + args.args + " " + ElfFile + " " + suffix + " " + ImperasPlusArgs
     if (args.coverage):
         cmd += " --coverage"
     if (args.fcov):

--- a/bin/wsim
+++ b/bin/wsim
@@ -28,6 +28,7 @@ parser.add_argument("--args", "-a", help="Optional arguments passed to simulator
 parser.add_argument("--vcd", "-v", help="Generate testbench.vcd", action="store_true")
 parser.add_argument("--lockstep", "-l", help="Run ImperasDV lock, step, and compare.", action="store_true")
 parser.add_argument("--locksteplog", "-b", help="Retired instruction number to be begin logging.", default=0)
+parser.add_argument("--covlog", "-d", help="Log coverage after n instructions.", default=0)
 args = parser.parse_args()
 print("Config=" + args.config + " tests=" + args.testsuite + " sim=" + args.sim + " gui=" + str(args.gui) + " args='" + args.args + "'")
 ElfFile=""
@@ -65,7 +66,8 @@ cd = "cd $WALLY/sim/" +args.sim
 if (args.sim == "questa"):
     if (args.lockstep):
         Instret = str(args.locksteplog)
-        prefix ="IMPERAS_TOOLS=" + WALLY + "/sim/imperas.ic OTHERFLAGS=\"+IDV_TRACE2LOG=" + Instret + " +IDV_TRACE2COV=" + Instret + "\" ";
+        CovEnableStr = "1\"" if int(args.covlog) > 0  else "0\"";
+        prefix ="IMPERAS_TOOLS=" + WALLY + "/sim/imperas.ic OTHERFLAGS=\"+IDV_TRACE2LOG=" + Instret + " +IDV_TRACE2COV=" + str(args.covlog) + " +TRACE2COV_ENABLE=" + CovEnableStr;
         suffix = "--lockstep"
     else:
         prefix = ""

--- a/sim/questa/wally-imperas-cov.do
+++ b/sim/questa/wally-imperas-cov.do
@@ -29,6 +29,14 @@ vlog +incdir+$env(WALLY)/config/$1 \
      +incdir+$env(WALLY)/config/shared \
      +define+USE_IMPERAS_DV \
      +define+IDV_INCLUDE_TRACE2COV \
+     +define+INCLUDE_TRACE2COV +define+COVER_BASE_RV64I +define+COVER_LEVEL_DV_PR_EXT \
+       +define+COVER_RV64I \
+       +define+COVER_RV64M \
+       +define+COVER_RV64A \
+       +define+COVER_RV64F \
+       +define+COVER_RV64D \
+       +define+COVER_RV64ZICSR \
+       +define+COVER_RV64C \
      +incdir+$env(IMPERAS_HOME)/ImpPublic/include/host \
      +incdir+$env(IMPERAS_HOME)/ImpProprietary/include/host \
      $env(IMPERAS_HOME)/ImpPublic/source/host/rvvi/rvviApiPkg.sv    \
@@ -39,19 +47,11 @@ vlog +incdir+$env(WALLY)/config/$1 \
      $env(IMPERAS_HOME)/ImpProprietary/source/host/idv/trace2api.sv  \
      $env(IMPERAS_HOME)/ImpProprietary/source/host/idv/trace2log.sv  \
      \
-     +define+INCLUDE_TRACE2COV +define+COVER_BASE_RV64I +define+COVER_LEVEL_DV_PR_EXT \
-       +define+COVER_RV64I \
-       +define+COVER_RV64M \
-       +define+COVER_RV64A \
-       +define+COVER_RV64F \
-       +define+COVER_RV64D \
-       +define+COVER_RV64ZICSR \
-       +define+COVER_RV64C \
      +incdir+$env(IMPERAS_HOME)/ImpProprietary/source/host/riscvISACOV/source \
      $env(IMPERAS_HOME)/ImpProprietary/source/host/idv/trace2cov.sv  \
     \
      $env(WALLY)/src/cvw.sv \
-     $env(WALLY)/testbench/testbench-imperas.sv \
+     $env(WALLY)/testbench/testbench.sv \
      $env(WALLY)/testbench/common/*.sv   \
      $env(WALLY)/src/*/*.sv \
      $env(WALLY)/src/*/*/*.sv \
@@ -61,7 +61,7 @@ vlog +incdir+$env(WALLY)/config/$1 \
 vopt +acc work.testbench -G DEBUG=1 -o workopt 
 eval vsim workopt +nowarn3829  -fatal 7 \
      -sv_lib $env(IMPERAS_HOME)/lib/Linux64/ImperasLib/imperas.com/verification/riscv/1.0/model \
-     +testDir=$env(TESTDIR) $env(OTHERFLAGS) +TRACE2COV_ENABLE=1
+     +ElfFile=$env(TESTDIR)/ref/ref.elf $env(OTHERFLAGS) +TRACE2COV_ENABLE=1
 
 coverage save -onexit $env(WALLY)/sim/questa/riscv.ucdb
 
@@ -76,4 +76,4 @@ run -all
 noview $env(WALLY)/testbench/testbench-imperas.sv
 view wave
 
-quit -f
+#quit -f

--- a/sim/questa/wally.do
+++ b/sim/questa/wally.do
@@ -219,7 +219,7 @@ run -all
 # power off -r /dut/core/*
 
 if {$coverage || $FunctCoverage} {
-    set UCDB cov/${CFG}_${TESTSUITE}.ucdb
+    set UCDB ${WALLY}/sim/questa/cov/${CFG}_${TESTSUITE}.ucdb
     echo "Saving coverage to ${UCDB}"
     do coverage-exclusions-rv64gc.do  # beware: this assumes testing the rv64gc configuration
     coverage save -instance /testbench/dut/core ${UCDB}

--- a/sim/questa/wally.do
+++ b/sim/questa/wally.do
@@ -174,7 +174,7 @@ if {$DEBUG > 0} {
 # "Extra checking for conflicts with always_comb done at vopt time"
 # because vsim will run vopt
 
-vlog -lint -work ${WKDIR}  +incdir+${CONFIG}/${CFG} +incdir+${CONFIG}/deriv/${CFG} ${lockstepvoptstring} ${FCdefineINCLUDE_TRACE2COV} ${FCdefineCOVER_BASE_RV64I} ${FCdefineCOVER_LEVEL_DV_PR_EXT} ${FCdefineCOVER_RV64I} ${FCdefineCOVER_RV64M} ${FCdefineCOVER_RV64A} ${FCdefineCOVER_RV64F} ${FCdefineCOVER_RV64D} ${FCdefineCOVER_RV64ZICSR} ${FCdefineCOVER_RV64C} ${FCdefineIDV_INCLUDE_TRACE2COV}  ${ImperasPubInc} ${ImperasPrivInc}  ${riscvISACOVsrc}   +incdir+${CONFIG}/shared ${rvviFiles} ${idvFiles} ${SRC}/cvw.sv ${TB}/${TESTBENCH}.sv ${TB}/common/*.sv  ${SRC}/*/*.sv ${SRC}/*/*/*.sv -suppress 2583 -suppress 7063,2596,13286
+vlog -lint -work ${WKDIR}  +incdir+${CONFIG}/${CFG} +incdir+${CONFIG}/deriv/${CFG} +incdir+${CONFIG}/shared ${lockstepvoptstring} ${FCdefineIDV_INCLUDE_TRACE2COV} ${ImperasPubInc} ${ImperasPrivInc} ${rvviFiles} ${idvFiles} ${FCdefineINCLUDE_TRACE2COV} ${FCdefineCOVER_BASE_RV64I} ${FCdefineCOVER_LEVEL_DV_PR_EXT} ${FCdefineCOVER_RV64I} ${FCdefineCOVER_RV64M} ${FCdefineCOVER_RV64A} ${FCdefineCOVER_RV64F} ${FCdefineCOVER_RV64D} ${FCdefineCOVER_RV64ZICSR} ${FCdefineCOVER_RV64C}  ${riscvISACOVsrc} ${SRC}/cvw.sv ${TB}/${TESTBENCH}.sv ${TB}/common/*.sv  ${SRC}/*/*.sv ${SRC}/*/*/*.sv -suppress 2583 -suppress 7063,2596,13286
 
 # start and run simulation
 # remove +acc flag for faster sim during regressions if there is no need to access internal signals

--- a/sim/questa/wally.do
+++ b/sim/questa/wally.do
@@ -197,7 +197,7 @@ if { ${GUI} } {
 run -all
 # power off -r /dut/core/*
 
-if {$coverage} {
+if {$coverage || $FunctCoverage} {
     set UCDB cov/${CFG}_${TESTSUITE}.ucdb
     echo "Saving coverage to ${UCDB}"
     do coverage-exclusions-rv64gc.do  # beware: this assumes testing the rv64gc configuration

--- a/sim/questa/wally.do
+++ b/sim/questa/wally.do
@@ -174,7 +174,7 @@ if {$DEBUG > 0} {
 # "Extra checking for conflicts with always_comb done at vopt time"
 # because vsim will run vopt
 
-vlog -lint -work ${WKDIR}  +incdir+${CONFIG}/${CFG} +incdir+${CONFIG}/deriv/${CFG} ${lockstepvoptstring} ${ImperasPubInc} ${ImperasPrivInc} ${riscvISACOVsrc} ${FCdefineINCLUDE_TRACE2COV} ${FCdefineCOVER_BASE_RV64I} ${FCdefineCOVER_LEVEL_DV_PR_EXT} ${FCdefineCOVER_RV64I} ${FCdefineCOVER_RV64M} ${FCdefineCOVER_RV64A} ${FCdefineCOVER_RV64F} ${FCdefineCOVER_RV64D} ${FCdefineCOVER_RV64ZICSR} ${FCdefineCOVER_RV64C} ${FCdefineIDV_INCLUDE_TRACE2COV} +incdir+${CONFIG}/shared ${rvviFiles} ${idvFiles} ${SRC}/cvw.sv ${TB}/${TESTBENCH}.sv ${TB}/common/*.sv  ${SRC}/*/*.sv ${SRC}/*/*/*.sv -suppress 2583 -suppress 7063,2596,13286
+vlog -lint -work ${WKDIR}  +incdir+${CONFIG}/${CFG} +incdir+${CONFIG}/deriv/${CFG} ${lockstepvoptstring} ${FCdefineINCLUDE_TRACE2COV} ${FCdefineCOVER_BASE_RV64I} ${FCdefineCOVER_LEVEL_DV_PR_EXT} ${FCdefineCOVER_RV64I} ${FCdefineCOVER_RV64M} ${FCdefineCOVER_RV64A} ${FCdefineCOVER_RV64F} ${FCdefineCOVER_RV64D} ${FCdefineCOVER_RV64ZICSR} ${FCdefineCOVER_RV64C} ${FCdefineIDV_INCLUDE_TRACE2COV}  ${ImperasPubInc} ${ImperasPrivInc}  ${riscvISACOVsrc}   +incdir+${CONFIG}/shared ${rvviFiles} ${idvFiles} ${SRC}/cvw.sv ${TB}/${TESTBENCH}.sv ${TB}/common/*.sv  ${SRC}/*/*.sv ${SRC}/*/*/*.sv -suppress 2583 -suppress 7063,2596,13286
 
 # start and run simulation
 # remove +acc flag for faster sim during regressions if there is no need to access internal signals

--- a/sim/questa/wally.do
+++ b/sim/questa/wally.do
@@ -174,7 +174,7 @@ if {$DEBUG > 0} {
 # "Extra checking for conflicts with always_comb done at vopt time"
 # because vsim will run vopt
 
-vlog -lint -work ${WKDIR}  +incdir+${CONFIG}/${CFG} +incdir+${CONFIG}/deriv/${CFG} +incdir+${CONFIG}/shared ${lockstepvoptstring} ${FCdefineIDV_INCLUDE_TRACE2COV} ${ImperasPubInc} ${ImperasPrivInc} ${rvviFiles} ${idvFiles} ${FCdefineINCLUDE_TRACE2COV} ${FCdefineCOVER_BASE_RV64I} ${FCdefineCOVER_LEVEL_DV_PR_EXT} ${FCdefineCOVER_RV64I} ${FCdefineCOVER_RV64M} ${FCdefineCOVER_RV64A} ${FCdefineCOVER_RV64F} ${FCdefineCOVER_RV64D} ${FCdefineCOVER_RV64ZICSR} ${FCdefineCOVER_RV64C}  ${riscvISACOVsrc} ${SRC}/cvw.sv ${TB}/${TESTBENCH}.sv ${TB}/common/*.sv  ${SRC}/*/*.sv ${SRC}/*/*/*.sv -suppress 2583 -suppress 7063,2596,13286
+vlog -lint -work ${WKDIR}  +incdir+${CONFIG}/${CFG} +incdir+${CONFIG}/deriv/${CFG} +incdir+${CONFIG}/shared ${lockstepvoptstring} ${FCdefineIDV_INCLUDE_TRACE2COV} ${FCdefineINCLUDE_TRACE2COV} ${ImperasPubInc} ${ImperasPrivInc} ${rvviFiles} ${idvFiles}  ${FCdefineCOVER_BASE_RV64I} ${FCdefineCOVER_LEVEL_DV_PR_EXT} ${FCdefineCOVER_RV64I} ${FCdefineCOVER_RV64M} ${FCdefineCOVER_RV64A} ${FCdefineCOVER_RV64F} ${FCdefineCOVER_RV64D} ${FCdefineCOVER_RV64ZICSR} ${FCdefineCOVER_RV64C}  ${riscvISACOVsrc} ${SRC}/cvw.sv ${TB}/${TESTBENCH}.sv ${TB}/common/*.sv  ${SRC}/*/*.sv ${SRC}/*/*/*.sv -suppress 2583 -suppress 7063,2596,13286
 
 # start and run simulation
 # remove +acc flag for faster sim during regressions if there is no need to access internal signals

--- a/sim/questa/wally.do
+++ b/sim/questa/wally.do
@@ -44,6 +44,20 @@ set coverage 0
 set CoverageVoptArg ""
 set CoverageVsimArg ""
 
+set FunctCoverage 0
+set riscvISACOVsrc ""
+set FCdefineINCLUDE_TRACE2COV ""
+set FCdefineCOVER_BASE_RV64I ""
+set FCdefineCOVER_LEVEL_DV_PR_EXT  ""
+set FCdefineCOVER_RV64I ""
+set FCdefineCOVER_RV64M ""
+set FCdefineCOVER_RV64A ""
+set FCdefineCOVER_RV64F ""
+set FCdefineCOVER_RV64D ""
+set FCdefineCOVER_RV64ZICSR ""
+set FCdefineCOVER_RV64C ""
+set FCdefineIDV_INCLUDE_TRACE2COV ""
+
 set lockstep 0
 # ok this is annoying. vlog, vopt, and vsim are very picky about how arguments are passed.
 # unforunately it won't allow these to be grouped as one argument per command so they are broken
@@ -98,6 +112,27 @@ if {$CoverageIndex >= 0} {
     set lst [lreplace $lst $CoverageIndex $CoverageIndex]
 }
 
+# if +coverage found set flag and remove from list
+set FunctCoverageIndex [lsearch -exact $lst "--fcov"]
+if {$FunctCoverageIndex >= 0} {
+    set FunctCoverage 1
+    set riscvISACOVsrc +incdir+$env(IMPERAS_HOME)/ImpProprietary/source/host/riscvISACOV/source
+
+    set FCdefineINCLUDE_TRACE2COV "+define+INCLUDE_TRACE2COV"
+    set FCdefineCOVER_BASE_RV64I "+define+COVER_BASE_RV64I"
+    set FCdefineCOVER_LEVEL_DV_PR_EXT  "+define+COVER_LEVEL_DV_PR_EXT"
+    set FCdefineCOVER_RV64I "+define+COVER_RV64I"
+    set FCdefineCOVER_RV64M "+define+COVER_RV64M"
+    set FCdefineCOVER_RV64A "+define+COVER_RV64A"
+    set FCdefineCOVER_RV64F "+define+COVER_RV64F"
+    set FCdefineCOVER_RV64D "+define+COVER_RV64D"
+    set FCdefineCOVER_RV64ZICSR "+define+COVER_RV64ZICSR"
+    set FCdefineCOVER_RV64C "+define+COVER_RV64C"
+    set FCdefineIDV_INCLUDE_TRACE2COV "+define+IDV_INCLUDE_TRACE2COV"
+
+    set lst [lreplace $lst $FunctCoverageIndex $FunctCoverageIndex]
+}
+
 set LockStepIndex [lsearch -exact $lst "--lockstep"]
 if {$LockStepIndex >= 0} {
     set lockstep 1
@@ -139,7 +174,7 @@ if {$DEBUG > 0} {
 # "Extra checking for conflicts with always_comb done at vopt time"
 # because vsim will run vopt
 
-vlog -lint -work ${WKDIR}  +incdir+${CONFIG}/${CFG} +incdir+${CONFIG}/deriv/${CFG} ${lockstepvoptstring} ${ImperasPubInc} ${ImperasPrivInc} +incdir+${CONFIG}/shared ${rvviFiles} ${idvFiles} ${SRC}/cvw.sv ${TB}/${TESTBENCH}.sv ${TB}/common/*.sv  ${SRC}/*/*.sv ${SRC}/*/*/*.sv -suppress 2583 -suppress 7063,2596,13286
+vlog -lint -work ${WKDIR}  +incdir+${CONFIG}/${CFG} +incdir+${CONFIG}/deriv/${CFG} ${lockstepvoptstring} ${ImperasPubInc} ${ImperasPrivInc} ${riscvISACOVsrc} ${FCdefineINCLUDE_TRACE2COV} ${FCdefineCOVER_BASE_RV64I} ${FCdefineCOVER_LEVEL_DV_PR_EXT} ${FCdefineCOVER_RV64I} ${FCdefineCOVER_RV64M} ${FCdefineCOVER_RV64A} ${FCdefineCOVER_RV64F} ${FCdefineCOVER_RV64D} ${FCdefineCOVER_RV64ZICSR} ${FCdefineCOVER_RV64C} ${FCdefineIDV_INCLUDE_TRACE2COV} +incdir+${CONFIG}/shared ${rvviFiles} ${idvFiles} ${SRC}/cvw.sv ${TB}/${TESTBENCH}.sv ${TB}/common/*.sv  ${SRC}/*/*.sv ${SRC}/*/*/*.sv -suppress 2583 -suppress 7063,2596,13286
 
 # start and run simulation
 # remove +acc flag for faster sim during regressions if there is no need to access internal signals

--- a/testbench/testbench-imperas.sv
+++ b/testbench/testbench-imperas.sv
@@ -149,10 +149,11 @@ module testbench;
         $display($sformatf("%m @ t=%0t: Expecting RVVI API version %0d.", $time, RVVI_API_VERSION));
         $fatal;
       end
+      
       void'(rvviRefConfigSetString(IDV_CONFIG_MODEL_VENDOR,            "riscv.ovpworld.org"));
       void'(rvviRefConfigSetString(IDV_CONFIG_MODEL_NAME,              "riscv"));
       void'(rvviRefConfigSetString(IDV_CONFIG_MODEL_VARIANT,           "RV64GC"));
-      void'(rvviRefConfigSetInt(IDV_CONFIG_MODEL_ADDRESS_BUS_WIDTH,     39));
+      void'(rvviRefConfigSetInt(IDV_CONFIG_MODEL_ADDRESS_BUS_WIDTH,     56));
       void'(rvviRefConfigSetInt(IDV_CONFIG_MAX_NET_LATENCY_RETIREMENTS, 6));
 
       if (!rvviRefInit(elffilename)) begin
@@ -189,7 +190,7 @@ module testbench;
       end
       if (P.SDC_SUPPORTED) begin
           void'(rvviRefMemorySetVolatile(P.SDC_BASE, (P.SDC_BASE + P.SDC_RANGE)));
-      end      
+      end
       if (P.SPI_SUPPORTED) begin
           void'(rvviRefMemorySetVolatile(P.SPI_BASE, (P.SPI_BASE + P.SPI_RANGE)));
       end

--- a/testbench/testbench.sv
+++ b/testbench/testbench.sv
@@ -681,7 +681,7 @@ end
   wallyTracer #(P) wallyTracer(rvvi);
 
   trace2log idv_trace2log(rvvi);
-  //      trace2cov idv_trace2cov(rvvi);
+  trace2cov idv_trace2cov(rvvi);
 
   // enabling of comparison types
   trace2api #(.CMP_PC      (1),


### PR DESCRIPTION
This is bit hacky and will need to be cleaned up with future commits.  However, I have the base features finally working.  ImperasDV and riscvISACOV both work with wally.do, wsim, and testbench.sv and don't require any outside scripts.

To run functional coverage add the flag --fcov to wsim and run with a single elf file.

I've confirmed coverage is generated in the GUI.