### PR TITLE
Updated spill logic to match textbook.

### DIFF
--- a/src/cache/cache.sv
+++ b/src/cache/cache.sv
@@ -127,7 +127,7 @@ module cache import cvw::*; #(parameter cvw_t P,
   // Select victim way for associative caches
   if(NUMWAYS > 1) begin:vict
     cacheLRU #(NUMWAYS, SETLEN, OFFSETLEN, NUMSETS) cacheLRU(
-      .clk, .reset, .FlushStage, .CacheEn, .HitWay, .ValidWay, .VictimWay, .CacheSetData, .CacheSetTag, .LRUWriteEn,
+      .clk, .reset, .FlushStage, .CacheEn, .HitWay, .ValidWay, .VictimWay, .CacheSetTag, .LRUWriteEn,
       .SetValid, .ClearValid, .PAdr(PAdr[SETTOP-1:OFFSETLEN]), .InvalidateCache);
   end else 
     assign VictimWay = 1'b1; // one hot.

--- a/src/cache/cacheLRU.sv
+++ b/src/cache/cacheLRU.sv
@@ -36,7 +36,6 @@ module cacheLRU
   input  logic                CacheEn,         // Enable the cache memory arrays.  Disable hold read data constant
   input  logic [NUMWAYS-1:0]  HitWay,          // Which way is valid and matches PAdr's tag
   input  logic [NUMWAYS-1:0]  ValidWay,        // Which ways for a particular set are valid, ignores tag
-  input  logic [SETLEN-1:0]   CacheSetData,    // Cache address, the output of the address select mux, NextAdr, PAdr, or FlushAdr
   input  logic [SETLEN-1:0]   CacheSetTag,     // Cache address, the output of the address select mux, NextAdr, PAdr, or FlushAdr
   input  logic [SETLEN-1:0]   PAdr,            // Physical address 
   input  logic                LRUWriteEn,      // Update the LRU state
@@ -140,7 +139,7 @@ module cacheLRU
 
   // LRU storage must be reset for modelsim to run. However the reset value does not actually matter in practice.
   // This is a two port memory.
-  // Every cycle must read from CacheSetData and each load/store must write the new LRU.
+  // Every cycle must read from CacheSetTag and each load/store must write the new LRU.
 
   // note: Verilator lint doesn't like <= for array initialization (https://verilator.org/warn/BLKLOOPINIT?v=5.021)
   // Move to = to keep Verilator happy and simulator running fast

--- a/src/ifu/bpred/bpred.sv
+++ b/src/ifu/bpred/bpred.sv
@@ -59,7 +59,7 @@ module bpred import cvw::*;  #(parameter cvw_t P) (
   input  logic [P.XLEN-1:0] IEUAdrE,                   // The branch/jump target address
   input  logic [P.XLEN-1:0] IEUAdrM,                   // The branch/jump target address
   input  logic [P.XLEN-1:0] PCLinkE,                   // The address following the branch instruction. (AKA Fall through address)
-  output logic [3:0]       InstrClassM,               // The valid instruction class. 1-hot encoded as call, return, jr (not return), j, br
+  output logic [3:0]       IClassM,               // The valid instruction class. 1-hot encoded as call, return, jr (not return), j, br
 
   // Report branch prediction status
   output logic             BPWrongE,                  // Prediction is wrong
@@ -157,17 +157,17 @@ module bpred import cvw::*;  #(parameter cvw_t P) (
       .BPBTAF, .BPBTAD, .BPBTAE,
       .BTBIClassF({BTBCallF, BTBReturnF, BTBJumpF, BTBBranchF}),
       .BPBTAWrongM,
-      .IClassWrongM, .IClassWrongE,
+      .IClassWrongM,
       .IEUAdrE, .IEUAdrM,
-      .InstrClassD({CallD, ReturnD, JumpD, BranchD}), 
-      .InstrClassE({CallE, ReturnE, JumpE, BranchE}), 
-      .InstrClassM({CallM, ReturnM, JumpM, BranchM}),
-      .InstrClassW({CallW, ReturnW, JumpW, BranchW}));
+      .IClassD({CallD, ReturnD, JumpD, BranchD}), 
+      .IClassE({CallE, ReturnE, JumpE, BranchE}), 
+      .IClassM({CallM, ReturnM, JumpM, BranchM}),
+      .IClassW({CallW, ReturnW, JumpW, BranchW}));
 
   icpred #(P, `INSTR_CLASS_PRED) icpred(.clk, .reset, .StallD, .StallE, .StallM, .StallW, .FlushD, .FlushE, .FlushM, 
     .PostSpillInstrRawF, .InstrD, .BranchD, .BranchE, .JumpD, .JumpE, .BranchM, .BranchW, .JumpM, .JumpW,
     .CallD, .CallE, .CallM, .CallW, .ReturnD, .ReturnE, .ReturnM, .ReturnW, .BTBCallF, .BTBReturnF, .BTBJumpF,
-    .BTBBranchF, .BPCallF, .BPReturnF, .BPJumpF, .BPBranchF, .IClassWrongM, .IClassWrongE, .BPReturnWrongD);
+    .BTBBranchF, .BPCallF, .BPReturnF, .BPJumpF, .BPBranchF, .IClassWrongM, .BPReturnWrongD);
 
   // Part 3 RAS
   RASPredictor #(P) RASPredictor(.clk, .reset, .StallF, .StallD, .StallE, .StallM, .FlushD, .FlushE, .FlushM,
@@ -227,6 +227,6 @@ module bpred import cvw::*;  #(parameter cvw_t P) (
   end
 
   // **** Fix me
-  assign InstrClassM = {CallM, ReturnM, JumpM, BranchM};
+  assign IClassM = {CallM, ReturnM, JumpM, BranchM};
   
 endmodule

--- a/src/ifu/bpred/btb.sv
+++ b/src/ifu/bpred/btb.sv
@@ -42,18 +42,17 @@ module btb import cvw::*;  #(parameter cvw_t P,
   output logic BPBTAWrongM,
   // update
   input  logic             IClassWrongM,                // BTB's instruction class guess was wrong
-  input  logic             IClassWrongE,
   input  logic [P.XLEN-1:0] IEUAdrE,                     // Branch/jump target address to insert into btb
   input  logic [P.XLEN-1:0] IEUAdrM,                     // Branch/jump target address to insert into btb
-  input  logic [3:0]       InstrClassD,                 // Instruction class to insert into btb
-  input  logic [3:0]       InstrClassE,                 // Instruction class to insert into btb
-  input  logic [3:0]       InstrClassM,                 // Instruction class to insert into btb
-  input  logic [3:0]       InstrClassW
+  input  logic [3:0]       IClassD,                 // Instruction class to insert into btb
+  input  logic [3:0]       IClassE,                 // Instruction class to insert into btb
+  input  logic [3:0]       IClassM,                 // Instruction class to insert into btb
+  input  logic [3:0]       IClassW
 );
 
   logic [Depth-1:0]        PCNextFIndex, PCFIndex, PCDIndex, PCEIndex, PCMIndex, PCWIndex;
   logic                    MatchD, MatchE, MatchM, MatchW, MatchX;
-  logic [P.XLEN+3:0]        ForwardBTBPrediction, ForwardBTBPredictionF;
+  logic [P.XLEN+3:0]        ForwardBTBPredF;
   logic [P.XLEN+3:0]        TableBTBPredF;
   logic [P.XLEN-1:0]        IEUAdrW;
   logic [P.XLEN-1:0]        PCW;
@@ -79,18 +78,18 @@ module btb import cvw::*;  #(parameter cvw_t P,
   assign MatchW = PCFIndex == PCWIndex;
   assign MatchX = MatchD | MatchE | MatchM | MatchW;
 
-  assign ForwardBTBPredictionF = MatchD ? {InstrClassD, BPBTAD} :
-                                 MatchE ? {InstrClassE, IEUAdrE} :
-                                 MatchM ? {InstrClassM, IEUAdrM} :
-                                 {InstrClassW, IEUAdrW} ;
+  assign ForwardBTBPredF = MatchD ? {IClassD, BPBTAD} :
+                                 MatchE ? {IClassE, IEUAdrE} :
+                                 MatchM ? {IClassM, IEUAdrM} :
+                                 {IClassW, IEUAdrW} ;
 
-  assign {BTBIClassF, BPBTAF} = MatchX ? ForwardBTBPredictionF : {TableBTBPredF};
+  assign {BTBIClassF, BPBTAF} = MatchX ? ForwardBTBPredF : {TableBTBPredF};
 
 
   // An optimization may be using a PC relative address.
   ram2p1r1wbe #(.USE_SRAM(P.USE_SRAM), .DEPTH(2**Depth), .WIDTH(P.XLEN+4)) memory(
     .clk, .ce1(~StallF | reset), .ra1(PCNextFIndex), .rd1(TableBTBPredF),
-     .ce2(~StallW & ~FlushW), .wa2(PCMIndex), .wd2({InstrClassM, IEUAdrM}), .we2(BTBWrongM), .bwe2('1));
+     .ce2(~StallW & ~FlushW), .wa2(PCMIndex), .wd2({IClassM, IEUAdrM}), .we2(BTBWrongM), .bwe2('1));
 
   flopenrc #(P.XLEN) BTBD(clk, reset, FlushD, ~StallD, BPBTAF, BPBTAD);
 
@@ -98,7 +97,7 @@ module btb import cvw::*;  #(parameter cvw_t P,
   // 1. It gates updates to the BTB when the prediction does not change.  This save power.
   // 2. BPBTAWrongE is used by the performance counters to track when the BTB's BPBTA or instruction class is wrong.
   flopenrc #(P.XLEN) BTBTargetEReg(clk, reset, FlushE, ~StallE, BPBTAD, BPBTAE);
-  assign BPBTAWrongE = (BPBTAE != IEUAdrE) & (InstrClassE[0] | InstrClassE[1] & ~InstrClassE[2]);
+  assign BPBTAWrongE = (BPBTAE != IEUAdrE) & (IClassE[0] | IClassE[1] & ~IClassE[2]);
 
   flopenrc #(1) BPBTAWrongMReg(clk, reset, FlushM, ~StallM, BPBTAWrongE, BPBTAWrongM);  
   assign BTBWrongM = BPBTAWrongM | IClassWrongM;

--- a/src/ifu/bpred/icpred.sv
+++ b/src/ifu/bpred/icpred.sv
@@ -41,12 +41,13 @@ module icpred import cvw::*;  #(parameter cvw_t P,
   output logic             ReturnD, ReturnE, ReturnM, ReturnW,
   input  logic             BTBCallF, BTBReturnF, BTBJumpF, BTBBranchF,
   output logic             BPCallF, BPReturnF, BPJumpF, BPBranchF,
-  output logic             IClassWrongM, BPReturnWrongD, IClassWrongE
+  output logic             IClassWrongM, BPReturnWrongD
 );
 
   logic                    IClassWrongD;
   logic                    BPBranchD, BPJumpD, BPReturnD, BPCallD;
-
+  logic                    IClassWrongE;
+  
   if (!INSTR_CLASS_PRED) begin : DirectClassDecode
     // This section is mainly for testing, verification, and PPA comparison.
     // An alternative to using the BTB to store the instruction class is to partially decode

--- a/src/ifu/bpred/twoBitPredictor.sv
+++ b/src/ifu/bpred/twoBitPredictor.sv
@@ -54,7 +54,7 @@ module twoBitPredictor import cvw::*; #(parameter cvw_t P, parameter XLEN,
   assign IndexM = {PCM[k+1] ^ PCM[1], PCM[k:2]};  
 
 
-  ram2p1r1wbe #(.USE_SRAM(P.USE_SRAM), .DEPTH(2**k), .WIDTH(2)) PHT(.clk(clk),
+  ram2p1r1wbe #(.USE_SRAM(P.USE_SRAM), .DEPTH(2**k), .WIDTH(2)) BHT(.clk(clk),
     .ce1(~StallF), .ce2(~StallW & ~FlushW),
     .ra1(IndexNextF),
     .rd1(BPDirPredF),

--- a/src/ifu/ifu.sv
+++ b/src/ifu/ifu.sv
@@ -65,7 +65,7 @@ module ifu import cvw::*;  #(parameter cvw_t P) (
   output logic [31:0]          InstrOrigM,                               // Original compressed or uncompressed instruction in Memory stage for Illegal Instruction MTVAL
   output logic [P.XLEN-1:0]    PCM,                                      // Memory stage instruction address
   // branch predictor
-  output logic [3:0]           InstrClassM,                              // The valid instruction class. 1-hot encoded as jalr, ret, jr (not ret), j, br
+  output logic [3:0]           IClassM,                              // The valid instruction class. 1-hot encoded as jalr, ret, jr (not ret), j, br
   output logic                 BPDirPredWrongM,                          // Prediction direction is wrong
   output logic                 BTAWrongM,                                // Prediction target wrong
   output logic                 RASPredPCWrongM,                          // RAS prediction is wrong
@@ -342,7 +342,7 @@ module ifu import cvw::*;  #(parameter cvw_t P) (
                 .FlushD, .FlushE, .FlushM, .FlushW, .InstrValidD, .InstrValidE, 
                 .BranchD, .BranchE, .JumpD, .JumpE,
                 .InstrD, .PCNextF, .PCPlus2or4F, .PC1NextF, .PCE, .PCM, .PCSrcE, .IEUAdrE, .IEUAdrM, .PCF, .NextValidPCE,
-                .PCD, .PCLinkE, .InstrClassM, .BPWrongE, .PostSpillInstrRawF, .BPWrongM,
+                .PCD, .PCLinkE, .IClassM, .BPWrongE, .PostSpillInstrRawF, .BPWrongM,
                 .BPDirPredWrongM, .BTAWrongM, .RASPredPCWrongM, .IClassWrongM);
 
   end else begin : bpred
@@ -356,12 +356,12 @@ module ifu import cvw::*;  #(parameter cvw_t P) (
       .CallD, .CallE, .CallM, .CallW, .ReturnD, .ReturnE, .ReturnM, .ReturnW, 
       .BTBCallF(1'b0), .BTBReturnF(1'b0), .BTBJumpF(1'b0),
       .BTBBranchF(1'b0), .BPCallF(), .BPReturnF(), .BPJumpF(), .BPBranchF(), .IClassWrongM,
-      .IClassWrongE(), .BPReturnWrongD());
+      .BPReturnWrongD());
     flopenrc #(1) PCSrcMReg(clk, reset, FlushM, ~StallM, PCSrcE, BPWrongM);
     assign RASPredPCWrongM = 1'b0;
     assign BPDirPredWrongM = BPWrongM;
     assign BTAWrongM = BPWrongM;
-    assign InstrClassM = {CallM, ReturnM, JumpM, BranchM};
+    assign IClassM = {CallM, ReturnM, JumpM, BranchM};
     assign NextValidPCE = PCE;
   end      
 

--- a/src/ifu/ifu.sv
+++ b/src/ifu/ifu.sv
@@ -148,7 +148,7 @@ module ifu import cvw::*;  #(parameter cvw_t P) (
   /////////////////////////////////////////////////////////////////////////////////////////////
 
   if(P.ZCA_SUPPORTED) begin : Spill
-    spill #(P) spill(.clk, .reset, .StallD, .FlushD, .PCF, .PCPlus4F, .PCNextF, .InstrRawF, .InstrUpdateDAF, .CacheableF, 
+    spill #(P) spill(.clk, .reset, .StallF, .FlushD, .PCF, .PCPlus4F, .PCNextF, .InstrRawF, .InstrUpdateDAF, .CacheableF, 
       .IFUCacheBusStallF, .ITLBMissF, .PCSpillNextF, .PCSpillF, .SelSpillNextF, .PostSpillInstrRawF, .CompressedF);
   end else begin : NoSpill
     assign PCSpillNextF = PCNextF;

--- a/src/ifu/spill.sv
+++ b/src/ifu/spill.sv
@@ -33,7 +33,7 @@
 module spill import cvw::*;  #(parameter cvw_t P) (
   input logic               clk,               
   input logic               reset,
-  input logic               StallD, FlushD,
+  input logic               StallF, FlushD,
   input logic [P.XLEN-1:0]  PCF,               // 2 byte aligned PC in Fetch stage
   input logic [P.XLEN-1:2]  PCPlus4F,          // PCF + 4
   input logic [P.XLEN-1:0]  PCNextF,           // The next PCF
@@ -96,7 +96,7 @@ module spill import cvw::*;  #(parameter cvw_t P) (
     case (CurrState)
       STATE_READY: if (TakeSpillF)                NextState = STATE_SPILL;
                    else                           NextState = STATE_READY;
-      STATE_SPILL: if(StallD)                     NextState = STATE_SPILL;
+      STATE_SPILL: if(StallF)                     NextState = STATE_SPILL;
                    else                           NextState = STATE_READY;
       default:                                    NextState = STATE_READY;
     endcase

--- a/src/privileged/csr.sv
+++ b/src/privileged/csr.sv
@@ -62,7 +62,7 @@ module csr import cvw::*;  #(parameter cvw_t P) (
   input  logic                     RASPredPCWrongM,
   input  logic                     IClassWrongM,
   input  logic                     BPWrongM,                  // branch predictor is wrong
-  input  logic [3:0]               InstrClassM,
+  input  logic [3:0]               IClassM,
   input  logic                     DCacheMiss,
   input  logic                     DCacheAccess,
   input  logic                     ICacheMiss,
@@ -277,7 +277,7 @@ module csr import cvw::*;  #(parameter cvw_t P) (
     csrc #(P) counters(.clk, .reset, .StallE, .StallM, .FlushM,
       .InstrValidNotFlushedM, .LoadStallD, .StoreStallD, .CSRWriteM, .CSRMWriteM,
       .BPDirPredWrongM, .BTAWrongM, .RASPredPCWrongM, .IClassWrongM, .BPWrongM,
-      .InstrClassM, .DCacheMiss, .DCacheAccess, .ICacheMiss, .ICacheAccess, .sfencevmaM,
+      .IClassM, .DCacheMiss, .DCacheAccess, .ICacheMiss, .ICacheAccess, .sfencevmaM,
       .InterruptM, .ExceptionM, .InvalidateICacheM, .ICacheStallF, .DCacheStallM, .DivBusyE, .FDivBusyE,
       .CSRAdrM, .PrivilegeModeW, .CSRWriteValM,
       .MCOUNTINHIBIT_REGW, .MCOUNTEREN_REGW, .SCOUNTEREN_REGW,

--- a/src/privileged/csrc.sv
+++ b/src/privileged/csrc.sv
@@ -40,7 +40,7 @@ module csrc  import cvw::*;  #(parameter cvw_t P) (
   input  logic              RASPredPCWrongM,
   input  logic              IClassWrongM,
   input  logic              BPWrongM,                                  // branch predictor is wrong
-  input  logic [3:0]        InstrClassM,
+  input  logic [3:0]        IClassM,
   input  logic              DCacheMiss,
   input  logic              DCacheAccess,
   input  logic              ICacheMiss,
@@ -95,9 +95,9 @@ module csrc  import cvw::*;  #(parameter cvw_t P) (
   assign CounterEvent[1]    = 1'b0;                                                      // Counter 1 doesn't exist
   assign CounterEvent[2]    = InstrValidNotFlushedM;                                     // MINSTRET instructions retired
   if (P.ZIHPM_SUPPORTED) begin: cevent                                                   // User-defined counters
-    assign CounterEvent[3]  = InstrClassM[0] & InstrValidNotFlushedM;                    // branch instruction
-    assign CounterEvent[4]  = InstrClassM[1] & ~InstrClassM[2] & InstrValidNotFlushedM;  // jump and not return instructions
-    assign CounterEvent[5]  = InstrClassM[2] & InstrValidNotFlushedM;                    // return instructions
+    assign CounterEvent[3]  = IClassM[0] & InstrValidNotFlushedM;                    // branch instruction
+    assign CounterEvent[4]  = IClassM[1] & ~IClassM[2] & InstrValidNotFlushedM;  // jump and not return instructions
+    assign CounterEvent[5]  = IClassM[2] & InstrValidNotFlushedM;                    // return instructions
     assign CounterEvent[6]  = BPWrongM & InstrValidNotFlushedM;                          // branch predictor wrong
     assign CounterEvent[7]  = BPDirPredWrongM & InstrValidNotFlushedM;                   // Branch predictor wrong direction
     assign CounterEvent[8]  = BTAWrongM & InstrValidNotFlushedM;                         // branch predictor wrong target

--- a/src/privileged/privileged.sv
+++ b/src/privileged/privileged.sv
@@ -54,7 +54,7 @@ module privileged import cvw::*;  #(parameter cvw_t P) (
   input  logic              RASPredPCWrongM,                                // return adddress stack guessed wrong target
   input  logic              IClassWrongM,                                   // branch predictor guessed wrong instruction class
   input  logic              BPWrongM,                                       // branch predictor is wrong
-  input  logic [3:0]        InstrClassM,                                    // actual instruction class
+  input  logic [3:0]        IClassM,                                    // actual instruction class
   input  logic              DCacheMiss,                                     // data cache miss
   input  logic              DCacheAccess,                                   // data cache accessed (hit or miss)
   input  logic              ICacheMiss,                                     // instruction cache miss
@@ -139,7 +139,7 @@ module privileged import cvw::*;  #(parameter cvw_t P) (
     .MTIME_CLINT, .InstrValidM, .FRegWriteM, .LoadStallD, .StoreStallD,
     .BPDirPredWrongM, .BTAWrongM, .RASPredPCWrongM, .BPWrongM,
     .sfencevmaM, .ExceptionM, .InvalidateICacheM, .ICacheStallF, .DCacheStallM, .DivBusyE, .FDivBusyE,
-    .IClassWrongM, .InstrClassM, .DCacheMiss, .DCacheAccess, .ICacheMiss, .ICacheAccess,
+    .IClassWrongM, .IClassM, .DCacheMiss, .DCacheAccess, .ICacheMiss, .ICacheAccess,
     .NextPrivilegeModeM, .PrivilegeModeW, .CauseM, .SelHPTW,
     .STATUS_MPP, .STATUS_SPP, .STATUS_TSR, .STATUS_TVM,
     .STATUS_MIE, .STATUS_SIE, .STATUS_MXR, .STATUS_SUM, .STATUS_MPRV, .STATUS_TW, .STATUS_FS,

--- a/src/wally/wallypipelinedcore.sv
+++ b/src/wally/wallypipelinedcore.sv
@@ -150,7 +150,7 @@ module wallypipelinedcore import cvw::*; #(parameter cvw_t P) (
   logic                          BTAWrongM;
   logic                          RASPredPCWrongM;
   logic                          IClassWrongM;
-  logic [3:0]                    InstrClassM;
+  logic [3:0]                    IClassM;
   logic                          InstrAccessFaultF, HPTWInstrAccessFaultF, HPTWInstrPageFaultF;
   logic [2:0]                    LSUHSIZE;
   logic [2:0]                    LSUHBURST;
@@ -181,7 +181,7 @@ module wallypipelinedcore import cvw::*; #(parameter cvw_t P) (
     .PCLinkE, .PCSrcE, .IEUAdrE, .IEUAdrM, .PCE, .BPWrongE,  .BPWrongM, 
     // Mem
     .CommittedF, .EPCM, .TrapVectorM, .RetM, .TrapM, .InvalidateICacheM, .CSRWriteFenceM,
-    .InstrD, .InstrM, .InstrOrigM, .PCM, .InstrClassM, .BPDirPredWrongM,
+    .InstrD, .InstrM, .InstrOrigM, .PCM, .IClassM, .BPDirPredWrongM,
     .BTAWrongM, .RASPredPCWrongM, .IClassWrongM,
     // Faults out
     .IllegalBaseInstrD, .IllegalFPUInstrD, .InstrPageFaultF, .IllegalIEUFPUInstrD, .InstrMisalignedFaultM,
@@ -293,7 +293,7 @@ module wallypipelinedcore import cvw::*; #(parameter cvw_t P) (
       .FRegWriteM, .LoadStallD, .StoreStallD,
       .BPDirPredWrongM, .BTAWrongM, .BPWrongM,
       .RASPredPCWrongM, .IClassWrongM, .DivBusyE, .FDivBusyE,
-      .InstrClassM, .DCacheMiss, .DCacheAccess, .ICacheMiss, .ICacheAccess, .PrivilegedM,
+      .IClassM, .DCacheMiss, .DCacheAccess, .ICacheMiss, .ICacheAccess, .PrivilegedM,
       .InstrPageFaultF, .LoadPageFaultM, .StoreAmoPageFaultM,
       .InstrMisalignedFaultM, .IllegalIEUFPUInstrD, 
       .LoadMisalignedFaultM, .StoreAmoMisalignedFaultM,


### PR DESCRIPTION
- Changed name of cache parameter NUMLINES to NUMSETS to better match book.
- Changed name CacheWriteData to WriteData.
- Fixed bug so that wsim can start logging after a given number of instructions.
- Simplified wsim so it automatically figures out if the second parameter is a testsuite or an elf file.
- Updated readme to reflect changes to wsim.
- Got the directory mode wsim working!
- Updated readme.
- Updated spill logic to reflect changes in textbook.
