### PR TITLE
Partial fix for verilator +args. At least compiles.

### DIFF
--- a/sim/verilator/Makefile
+++ b/sim/verilator/Makefile
@@ -44,8 +44,8 @@ default: run
 
 run: wkdir/$(WALLYCONF)_$(TEST)/V${TESTBENCH}
 	mkdir -p $(VERILATOR_DIR)/logs
-	wkdir/$(WALLYCONF)_$(TEST)/V${TESTBENCH} ${ARGTEST} 
-	
+	wkdir/$(WALLYCONF)_$(TEST)/V${TESTBENCH} ${ARGTEST} $(EXTRA_ARGS) 
+
 profile: obj_dir_profiling/V${TESTBENCH}_$(WALLYCONF)
 	$(VERILATOR_DIR)/obj_dir_profiling/V${TESTBENCH}_$(WALLYCONF) ${ARGTEST}
 	mv gmon.out gmon_$(WALLYCONF).out
@@ -61,7 +61,6 @@ wkdir/$(WALLYCONF)_$(TEST)/V${TESTBENCH}: $(DEPENDENCIES)
 	--Mdir wkdir/$(WALLYCONF)_$(TEST) -o V${TESTBENCH} \
 	--binary --trace \
 	$(OPT) $(PARAMS) $(NONPROF) \
-	$(EXTRA_ARGS) \
 	--top-module ${TESTBENCH}  --relative-includes \
 	$(INCLUDE_PATH) \
 	${WRAPPER} \
@@ -74,7 +73,6 @@ obj_dir_profiling/V${TESTBENCH}_$(WALLYCONF): $(DEPENDENCIES)
 	--Mdir obj_dir_profiling -o V${TESTBENCH}_$(WALLYCONF) \
 	--binary \
 	--prof-cfuncs $(OPT) $(PARAMS) \
-	$(EXTRA_ARGS) \
 	--top-module ${TESTBENCH}  --relative-includes \
 	$(INCLUDE_PATH) \
 	${WRAPPER} \


### PR DESCRIPTION
- Updated more signal names to match book.
- Last of the branch predictor signal name updates.
- shiftcorrection cleanup
- shiftcorrection cleanup
- Formatting shiftcorrection
- Updated logger to new IClass signal name
- Remove stale questa wkdir before regression
- Removed redundant apt-get line
- Starting code cleanup
- Code cleanup: RAM, fdivsqrt
- Simplified outdated documentation pointers
- Code cleanup
- Fixed gettenvval when variable is undefined per verilator Issue 5179
- More code cleanup
- Fixed Issue #752 of Verilator simulation by changing LRUMemory to be nonblocking now that Verilator handles this construct properly
- Removed asynchronous reset causing lint issue in peripherals
- Lint cleanup
- Lint cleanup
- Lint cleanup
- Lint cleanup
- Lint cleanup of unused signals
- Removed unused signals
- Clean up unused signals
- Unused signal cleanup
- Update VCS RTL file exclusions with renamed ram
- Removed *** from fpga top.
- Removed *** from IFU, lrcs.
- Removed more *** from the ifu.
- Removed remaining *** from IFU.
- Removed *** and updated comments for bpred and align.
- Removed more *** from lsu and updated assertions for dtim.
- LSU no longer has ***.
- Added InstrUpdateDAF to the HPTW.
- Refactored TLBMiss and TLBMissOrUpdateA(D) to simplify spill, ifu, lsu, and hptw.
- Cleaned up hptw.
- Moved the *** from trap to an issue.
- Removed more *** from camline and csrc.
- Updated comments in uart.
- Removed *** from testbench.
- Updated wave to match changes in testbench.
- Updated wavefile to use new names.
- Removed the last of the ***.
- Updated verilator makefile.
