### PR TITLE
FPU without privilege modes + derived config fixes

### DIFF
--- a/bin/regression-wally
+++ b/bin/regression-wally
@@ -123,18 +123,14 @@ derivconfigtests = [
         ["zknh_rv64gc", ["arch64i", "arch64zknh"]],
 
 # No privilege modes variants
-        ["noS_rv32gc", ["arch32i", "arch32f", "arch32d", "arch32priv", "arch32c", "arch32m", "arch32a_amo",
-                        "arch32zifencei", "arch32zicond", "arch32zba", "arch32zfh", "arch32zfh_fma", "arch32zfh_divsqrt",
-                        "arch32zfaf", "arch32zfad", "wally32a_lrsc", "arch32zcb", "arch32zbkx", "arch32zknd"]],
-        ["noS_rv64gc", ["arch64i", "arch64f", "arch64d", "arch64priv", "arch64c", "arch64m", "arch64a_amo",
-                "arch64zifencei", "arch64zicond", "arch64zba", "arch64zfh", "arch64zfh_fma", "arch64zfh_divsqrt",
-                "arch64zfaf", "arch64zfad", "wally64a_lrsc", "arch64zcb", "arch64zbkx", "arch64zknd"]],
-        ["noU_rv32gc", ["arch32i", "arch32f", "arch32d", "arch32priv", "arch32c", "arch32m", "arch32a_amo",
-                        "arch32zifencei", "arch32zicond", "arch32zba", "arch32zfh", "arch32zfh_fma", "arch32zfh_divsqrt",
-                        "arch32zfaf", "arch32zfad", "wally32a_lrsc", "arch32zcb", "arch32zbkx", "arch32zknd"]],
-        ["noU_rv64gc", ["arch64i", "arch64f", "arch64d", "arch64priv", "arch64c", "arch64m", "arch64a_amo",
-                "arch64zifencei", "arch64zicond", "arch64zba", "arch64zfh", "arch64zfh_fma", "arch64zfh_divsqrt",
-                "arch64zfaf", "arch64zfad", "wally64a_lrsc", "arch64zcb", "arch64zbkx", "arch64zknd"]],
+        ["noS_rv32gc", ["arch32i", "arch32f", "arch32priv", "arch32c", "arch32m", "arch32a_amo", "arch32zifencei", "arch32zicond",
+                        "arch32zba", "arch32zfaf", "arch32zfad", "wally32a_lrsc", "arch32zcb", "arch32zbkx", "arch32zknd"]],
+        ["noS_rv64gc", ["arch64i", "arch64f", "arch64priv", "arch64c", "arch64m", "arch64a_amo", "arch64zifencei", "arch64zicond",
+                        "arch64zba", "arch64zfaf", "arch64zfad", "wally64a_lrsc", "arch64zcb", "arch64zbkx", "arch64zknd"]],
+        ["noU_rv32gc", ["arch32i", "arch32f", "arch32priv", "arch32c", "arch32m", "arch32a_amo", "arch32zifencei", "arch32zicond",
+                        "arch32zba", "arch32zfaf", "arch32zfad", "wally32a_lrsc", "arch32zcb", "arch32zbkx", "arch32zknd"]],
+        ["noU_rv64gc", ["arch64i", "arch64f", "arch64priv", "arch64c", "arch64m", "arch64a_amo", "arch64zifencei", "arch64zicond",
+                        "arch64zba", "arch64zfaf", "arch64zfad", "wally64a_lrsc", "arch64zcb", "arch64zbkx", "arch64zknd"]],
 
         ### add misaligned tests
 

--- a/bin/regression-wally
+++ b/bin/regression-wally
@@ -93,7 +93,7 @@ derivconfigtests = [
         ["nodcache_rv64gc", ["ahb64"]],
         ["nocache_rv64gc", ["ahb64"]],
 
-# Atomic variatnts
+# Atomic variants
         ["zaamo_rv64gc", ["arch64i", "arch64a_amo"]],
         ["zalrsc_rv64gc", ["arch64i", "wally64a_lrsc"]],
         ["zaamo_rv32gc", ["arch32i", "arch32a_amo"]],
@@ -121,6 +121,20 @@ derivconfigtests = [
         ["zkne_rv64gc", ["arch64i", "arch64zkne"]],
         ["zknd_rv64gc", ["arch64i", "arch64zknd"]],
         ["zknh_rv64gc", ["arch64i", "arch64zknh"]],
+
+# No privilege modes variants
+        ["noS_rv32gc", ["arch32i", "arch32f", "arch32d", "arch32priv", "arch32c", "arch32m", "arch32a_amo",
+                        "arch32zifencei", "arch32zicond", "arch32zba", "arch32zfh", "arch32zfh_fma", "arch32zfh_divsqrt",
+                        "arch32zfaf", "arch32zfad", "wally32a_lrsc", "arch32zcb", "arch32zbkx", "arch32zknd"]],
+        ["noS_rv64gc", ["arch64i", "arch64f", "arch64d", "arch64priv", "arch64c", "arch64m", "arch64a_amo",
+                "arch64zifencei", "arch64zicond", "arch64zba", "arch64zfh", "arch64zfh_fma", "arch64zfh_divsqrt",
+                "arch64zfaf", "arch64zfad", "wally64a_lrsc", "arch64zcb", "arch64zbkx", "arch64zknd"]],
+        ["noU_rv32gc", ["arch32i", "arch32f", "arch32d", "arch32priv", "arch32c", "arch32m", "arch32a_amo",
+                        "arch32zifencei", "arch32zicond", "arch32zba", "arch32zfh", "arch32zfh_fma", "arch32zfh_divsqrt",
+                        "arch32zfaf", "arch32zfad", "wally32a_lrsc", "arch32zcb", "arch32zbkx", "arch32zknd"]],
+        ["noU_rv64gc", ["arch64i", "arch64f", "arch64d", "arch64priv", "arch64c", "arch64m", "arch64a_amo",
+                "arch64zifencei", "arch64zicond", "arch64zba", "arch64zfh", "arch64zfh_fma", "arch64zfh_divsqrt",
+                "arch64zfaf", "arch64zfad", "wally64a_lrsc", "arch64zcb", "arch64zbkx", "arch64zknd"]],
 
         ### add misaligned tests
 

--- a/config/derivlist.txt
+++ b/config/derivlist.txt
@@ -786,6 +786,28 @@ ZKND_SUPPORTED     0
 ZKNE_SUPPORTED     0     
 ZKNH_SUPPORTED     1     
 
+deriv noS_rv32gc rv32gc
+S_SUPPORTED        0
+SSTC_SUPPORTED     0
+VIRTMEM_SUPPORTED  0
+SVINVAL_SUPPORTED  0
+SVADU_SUPPORTED    0
+
+deriv noS_rv64gc rv64gc
+S_SUPPORTED       0
+SSTC_SUPPORTED    0
+VIRTMEM_SUPPORTED 0
+SVPBMT_SUPPORTED  0
+SVNAPOT_SUPPORTED 0
+SVINVAL_SUPPORTED 0
+SVADU_SUPPORTED   0
+
+deriv noU_rv32gc noS_rv32gc
+U_SUPPORTED    0
+
+deriv noU_rv64gc noS_rv64gc
+U_SUPPORTED    0
+
 # Floating-point modes supported
 
 deriv f_rv32gc rv32gc

--- a/config/derivlist.txt
+++ b/config/derivlist.txt
@@ -106,6 +106,7 @@ F_SUPPORTED         0
 ZCF_SUPPORTED       0
 D_SUPPORTED         0
 ZCD_SUPPORTED       0
+
 deriv syn_sram_rv64gc_noFPU syn_sram_rv64gc_noPriv
 F_SUPPORTED         0
 ZCF_SUPPORTED       0
@@ -395,22 +396,24 @@ VIRTMEM_SUPPORTED    0
 deriv nodcache_rv32gc rv32gc
 DCACHE_SUPPORTED    0
 D_SUPPORTED         0
+ZCD_SUPPORTED       0
 ZALRSC_SUPPORTED    0
 ZAAMO_SUPPORTED     0
 ZICBOM_SUPPORTED    0
 ZICBOZ_SUPPORTED    0
-VIRTMEM_SUPPORTED    0
+VIRTMEM_SUPPORTED   0
 
 # nocache_rv32gc must also disable several features incompatible with no cache
 deriv nocache_rv32gc rv32gc
 ICACHE_SUPPORTED    0
 DCACHE_SUPPORTED    0
 D_SUPPORTED         0
+ZCD_SUPPORTED       0
 ZALRSC_SUPPORTED    0
 ZAAMO_SUPPORTED     0
 ZICBOM_SUPPORTED    0
 ZICBOZ_SUPPORTED    0
-VIRTMEM_SUPPORTED    0
+VIRTMEM_SUPPORTED   0
 
 deriv noicache_rv64gc rv64gc
 ICACHE_SUPPORTED    0
@@ -787,10 +790,12 @@ ZKNH_SUPPORTED     1
 
 deriv f_rv32gc rv32gc
 D_SUPPORTED     0
+ZCD_SUPPORTED   0
 ZFH_SUPPORTED   0
 
 deriv fh_rv32gc rv32gc
 D_SUPPORTED     0
+ZCD_SUPPORTED   0
 ZFH_SUPPORTED   1
 
 deriv fd_rv32gc rv32gc
@@ -809,10 +814,12 @@ ZFH_SUPPORTED   1
 
 deriv f_rv64gc rv64gc
 D_SUPPORTED     0
+ZCD_SUPPORTED   0
 ZFH_SUPPORTED   0
 
 deriv fh_rv64gc rv64gc
 D_SUPPORTED     0
+ZCD_SUPPORTED   0
 ZFH_SUPPORTED   1
 
 deriv fd_rv64gc rv64gc
@@ -872,100 +879,124 @@ IEEE754     1
 #### F_only, RK variable
 deriv f_div_2_1_rv32gc    div_2_1_rv32gc    
 D_SUPPORTED     0
+ZCD_SUPPORTED   0
 ZFH_SUPPORTED   0
 
 deriv f_div_2_2_rv32gc    div_2_2_rv32gc    
 D_SUPPORTED     0
+ZCD_SUPPORTED   0
 ZFH_SUPPORTED   0
 
 deriv f_div_2_4_rv32gc    div_2_4_rv32gc
 D_SUPPORTED     0
+ZCD_SUPPORTED   0
 ZFH_SUPPORTED   0
 
 deriv f_div_4_1_rv32gc    div_4_1_rv32gc    
 D_SUPPORTED     0
+ZCD_SUPPORTED   0
 ZFH_SUPPORTED   0
 
 deriv f_div_4_2_rv32gc    div_4_2_rv32gc    
 D_SUPPORTED     0
+ZCD_SUPPORTED   0
 ZFH_SUPPORTED   0
 
 deriv f_div_4_4_rv32gc    div_4_4_rv32gc    
 D_SUPPORTED     0
+ZCD_SUPPORTED   0
 ZFH_SUPPORTED   0
 
 deriv f_div_2_1_rv64gc    div_2_1_rv64gc    
 D_SUPPORTED     0
+ZCD_SUPPORTED   0
 ZFH_SUPPORTED   0
 
 deriv f_div_2_2_rv64gc    div_2_2_rv64gc    
 D_SUPPORTED     0
+ZCD_SUPPORTED   0
 ZFH_SUPPORTED   0
 
 deriv f_div_2_4_rv64gc    div_2_4_rv64gc    
 D_SUPPORTED     0
+ZCD_SUPPORTED   0
 ZFH_SUPPORTED   0
 
 deriv f_div_4_1_rv64gc    div_4_1_rv64gc    
 D_SUPPORTED     0
+ZCD_SUPPORTED   0
 ZFH_SUPPORTED   0
 
 deriv f_div_4_2_rv64gc    div_4_2_rv64gc    
 D_SUPPORTED     0
+ZCD_SUPPORTED   0
 ZFH_SUPPORTED   0
 
 deriv f_div_4_4_rv64gc    div_4_4_rv64gc    
 D_SUPPORTED     0
+ZCD_SUPPORTED   0
 ZFH_SUPPORTED   0
 
 
 #### FH_only, RK variable
 deriv fh_div_2_1_rv32gc    div_2_1_rv32gc    
 D_SUPPORTED     0
+ZCD_SUPPORTED   0
 ZFH_SUPPORTED   1
 
 deriv fh_div_2_2_rv32gc    div_2_2_rv32gc    
 D_SUPPORTED     0
+ZCD_SUPPORTED   0
 ZFH_SUPPORTED   1
 
 deriv fh_div_2_4_rv32gc    div_2_4_rv32gc
 D_SUPPORTED     0
+ZCD_SUPPORTED   0
 ZFH_SUPPORTED   1
 
 deriv fh_div_4_1_rv32gc    div_4_1_rv32gc    
 D_SUPPORTED     0
+ZCD_SUPPORTED   0
 ZFH_SUPPORTED   1
 
 deriv fh_div_4_2_rv32gc    div_4_2_rv32gc    
 D_SUPPORTED     0
+ZCD_SUPPORTED   0
 ZFH_SUPPORTED   1
 
 deriv fh_div_4_4_rv32gc    div_4_4_rv32gc    
 D_SUPPORTED     0
+ZCD_SUPPORTED   0
 ZFH_SUPPORTED   1
 
 deriv fh_div_2_1_rv64gc    div_2_1_rv64gc    
 D_SUPPORTED     0
+ZCD_SUPPORTED   0
 ZFH_SUPPORTED   1
 
 deriv fh_div_2_2_rv64gc    div_2_2_rv64gc    
 D_SUPPORTED     0
+ZCD_SUPPORTED   0
 ZFH_SUPPORTED   1
 
 deriv fh_div_2_4_rv64gc    div_2_4_rv64gc    
 D_SUPPORTED     0
+ZCD_SUPPORTED   0
 ZFH_SUPPORTED   1
 
 deriv fh_div_4_1_rv64gc    div_4_1_rv64gc    
 D_SUPPORTED     0
+ZCD_SUPPORTED   0
 ZFH_SUPPORTED   1
 
 deriv fh_div_4_2_rv64gc    div_4_2_rv64gc    
 D_SUPPORTED     0
+ZCD_SUPPORTED   0
 ZFH_SUPPORTED   1
 
 deriv fh_div_4_4_rv64gc    div_4_4_rv64gc    
 D_SUPPORTED     0
+ZCD_SUPPORTED   0
 ZFH_SUPPORTED   1
 
 # FD only , rk variable

--- a/src/privileged/csr.sv
+++ b/src/privileged/csr.sv
@@ -259,6 +259,8 @@ module csr import cvw::*;  #(parameter cvw_t P) (
     assign SCOUNTEREN_REGW = '0;
     assign SATP_REGW = '0;
     assign IllegalCSRSAccessM = 1'b1;
+    assign STimerInt = '0;
+    assign SENVCFG_REGW = '0;
   end
 
   // Floating Point CSRs in User Mode only needed if Floating Point is supported

--- a/src/privileged/csr.sv
+++ b/src/privileged/csr.sv
@@ -262,7 +262,7 @@ module csr import cvw::*;  #(parameter cvw_t P) (
   end
 
   // Floating Point CSRs in User Mode only needed if Floating Point is supported
-  if (P.F_SUPPORTED | P.D_SUPPORTED) begin:csru
+  if (P.F_SUPPORTED) begin:csru
     csru #(P) csru(.clk, .reset, .InstrValidNotFlushedM, 
       .CSRUWriteM, .CSRAdrM, .CSRWriteValM, .STATUS_FS, .CSRUReadValM,  
       .SetFflagsM, .FRM_REGW, .WriteFRMM, .WriteFFLAGSM,

--- a/src/privileged/csri.sv
+++ b/src/privileged/csri.sv
@@ -73,6 +73,7 @@ module csri import cvw::*;  #(parameter cvw_t P) (
     assign MIP_WRITE_MASK = 12'h000;
     assign SIP_WRITE_MASK = 12'h000;
     assign MIE_WRITE_MASK = 12'h888;
+    assign STIP = '0;
   end
   always_ff @(posedge clk)
     if (reset)          MIP_REGW_writeable <= 12'b0;

--- a/src/privileged/csrm.sv
+++ b/src/privileged/csrm.sv
@@ -195,6 +195,9 @@ module csrm  import cvw::*;  #(parameter cvw_t P) (
       flopenr #(P.XLEN) MENVCFGHreg(clk, reset, WriteMENVCFGHM, MENVCFG_WriteValM[63:32], MENVCFG_REGW[63:32]);
       assign MENVCFGH_REGW = MENVCFG_REGW[63:32];
     end
+  end else begin
+    assign MENVCFG_REGW = '0;
+    assign MENVCFGH_REGW = '0;
   end
 
   // Read machine mode CSRs

--- a/src/privileged/csrsr.sv
+++ b/src/privileged/csrsr.sv
@@ -99,7 +99,7 @@ module csrsr import cvw::*;  #(parameter cvw_t P) (
   assign STATUS_UXL  = P.U_SUPPORTED ? 2'b10 : 2'b00; // 10 if user mode supported
   assign STATUS_SUM  = P.S_SUPPORTED & P.VIRTMEM_SUPPORTED & STATUS_SUM_INT; // override reigster with 0 if supervisor mode not supported
   assign STATUS_MPRV = P.U_SUPPORTED & STATUS_MPRV_INT; // override with 0 if user mode not supported
-  assign STATUS_FS   = (P.S_SUPPORTED & (P.F_SUPPORTED | P.D_SUPPORTED)) ? STATUS_FS_INT : 2'b00; // off if no FP  
+  assign STATUS_FS   = P.F_SUPPORTED ? STATUS_FS_INT : 2'b00; // off if no FP
   assign STATUS_SD   = (STATUS_FS == 2'b11) | (STATUS_XS == 2'b11); // dirty state logic
   assign STATUS_XS   = 2'b00; // No additional user-mode state to be dirty
 


### PR DESCRIPTION
- Fix derived configs with `D_SUPPORTED` after #853 stopped `ZCD_SUPPORTED` from being turned off
- Add derived configs for no privilege modes
- Fix #840 FPU failing when `S_SUPPORTED = 0` by adjusting logic for updating `STATUS_FS`