### PR TITLE
Testbench cleanup

### DIFF
--- a/sim/vcs/run_vcs
+++ b/sim/vcs/run_vcs
@@ -90,7 +90,7 @@ RTL_FILES="$INCLUDE_DIRS $(find ${SRC} -name "*.sv" ! -path "${SRC}/generic/mem/
 
 # Simulation and Coverage Commands
 OUTPUT="sim_out"
-VCS_CMD="vcs +lint=all,noGCWM,noUI,noSVA-UA,noIDTS,noNS,noULCO,noCAWM-L,noWMIA-L,noSV-PIU,noSTASKW_CO,noSTASKW_CO1,noSTASKW_RMCOF +vcs+vcdpluson -suppress +warn -sverilog +vc -Mupdate -line -full64 -kdb -lca -debug_access+all+reverse  -ntb_opts sensitive_dyn +define+SIM_VCS ${INCLUDE_PATH} $RTL_FILES"
+VCS_CMD="vcs +lint=all,noGCWM,noUI,noSVA-UA,noIDTS,noNS,noULCO,noCAWM-L,noWMIA-L,noSV-PIU,noSTASKW_CO,noSTASKW_CO1,noSTASKW_RMCOF +vcs+vcdpluson -suppress +warn -sverilog +vc -Mupdate -line -full64 -kdb -lca -debug_access+all+reverse  -ntb_opts sensitive_dyn ${INCLUDE_PATH} $RTL_FILES"
 SIMV_CMD="./${WKDIR}/$OUTPUT +TEST=${TESTSUITE} ${PLUSARGS}" 
 COV_FILES="${TB}/coverage/test_pmp_coverage.sv"
 COV_OPTIONS="-cm line+cond+branch+fsm+tgl -cm_log ${WKDIR}/coverage.log -cm_dir ${WKDIR}/COVERAGE"

--- a/testbench/testbench.sv
+++ b/testbench/testbench.sv
@@ -419,12 +419,10 @@ module testbench;
         $display("Coverage tests don't get checked");
       end else if (ElfFile != "none") begin
         $display("Single Elf file tests are not signatured verified.");
-`ifdef VERILATOR // this macro is defined when verilator is used
-        $finish; // Simulator Verilator needs $finish to terminate simulation.
-`elsif VCS // this macro is defined when vcs is used
-        $finish; // Simulator VCS needs $finish to terminate simulation.
+`ifdef QUESTA
+        $stop;  // if this is changed to $finish for Questa, wally-batch.do does not go to the next step to run coverage, and wally.do terminates without allowing GUI debug
 `else
-         $stop; // if this is changed to $finish for Questa, wally-batch.do does not go to the next step to run coverage, and wally.do terminates without allowing GUI debug
+        $finish;
 `endif
       end else begin 
         // for tests with no self checking mechanism, read .signature.output file and compare to check for errors
@@ -440,12 +438,10 @@ module testbench;
       if (test == tests.size()) begin
         if (totalerrors == 0) $display("SUCCESS! All tests ran without failures.");
         else $display("FAIL: %d test programs had errors", totalerrors);
-`ifdef VERILATOR // this macro is defined when verilator is used
-        $finish; // Simulator Verilator needs $finish to terminate simulation.
-`elsif VCS // this macro is defined when vcs is used
-        $finish; // Simulator VCS needs $finish to terminate simulation.
+`ifdef QUESTA
+        $stop;  // if this is changed to $finish for Questa, wally-batch.do does not go to the next step to run coverage, and wally.do terminates without allowing GUI debug
 `else
-         $stop; // if this is changed to $finish for Questa, wally-batch.do does not go to the next step to run coverage, and wally.do terminates without allowing GUI debug
+        $finish;
 `endif
       end
     end

--- a/testbench/testbench.sv
+++ b/testbench/testbench.sv
@@ -54,7 +54,7 @@ module testbench;
   `ifdef VERILATOR
       import "DPI-C" function string getenvval(input string env_name);
       string       RISCV_DIR = getenvval("RISCV"); // "/opt/riscv";
-  `elsif SIM_VCS 
+  `elsif VCS
       import "DPI-C" function string getenv(input string env_name);
       string       RISCV_DIR = getenv("RISCV"); // "/opt/riscv";
   `else
@@ -421,7 +421,7 @@ module testbench;
         $display("Single Elf file tests are not signatured verified.");
 `ifdef VERILATOR // this macro is defined when verilator is used
         $finish; // Simulator Verilator needs $finish to terminate simulation.
-`elsif SIM_VCS // this macro is defined when vcs is used
+`elsif VCS // this macro is defined when vcs is used
         $finish; // Simulator VCS needs $finish to terminate simulation.
 `else
          $stop; // if this is changed to $finish for Questa, wally-batch.do does not go to the next step to run coverage, and wally.do terminates without allowing GUI debug
@@ -442,7 +442,7 @@ module testbench;
         else $display("FAIL: %d test programs had errors", totalerrors);
 `ifdef VERILATOR // this macro is defined when verilator is used
         $finish; // Simulator Verilator needs $finish to terminate simulation.
-`elsif SIM_VCS // this macro is defined when vcs is used
+`elsif VCS // this macro is defined when vcs is used
         $finish; // Simulator VCS needs $finish to terminate simulation.
 `else
          $stop; // if this is changed to $finish for Questa, wally-batch.do does not go to the next step to run coverage, and wally.do terminates without allowing GUI debug

--- a/testbench/testbench_fp.sv
+++ b/testbench/testbench_fp.sv
@@ -1083,7 +1083,7 @@ module readvectors import cvw::*; #(parameter cvw_t P) (
                end
                Ans = {{P.FLEN-P.D_LEN{1'b1}}, TestVector[8+(P.D_LEN-1):8]};
             end
-            2'b00: if (P.S_SUPPORTED) begin // single
+            2'b00: if (P.F_SUPPORTED) begin // single
                if (OpCtrl === `FMA_OPCTRL) begin
 		  X = {{P.FLEN-P.S_LEN{1'b1}}, TestVector[8+4*(P.S_LEN)-1:8+3*(P.S_LEN)]};
 		  Y = {{P.FLEN-P.S_LEN{1'b1}}, TestVector[8+3*(P.S_LEN)-1:8+2*(P.S_LEN)]};
@@ -1125,7 +1125,7 @@ module readvectors import cvw::*; #(parameter cvw_t P) (
 		 X = {{P.FLEN-P.D_LEN{1'b1}}, TestVector[8+2*(P.D_LEN)-1:8+(P.D_LEN)]};
 		 Ans = {{P.FLEN-P.D_LEN{1'b1}}, TestVector[8+(P.D_LEN-1):8]};
               end
-              2'b00: if (P.S_SUPPORTED) begin // single
+              2'b00: if (P.F_SUPPORTED) begin // single
 		 X = {{P.FLEN-P.S_LEN{1'b1}}, TestVector[8+2*(P.S_LEN)-1:8+1*(P.S_LEN)]};
 		 Ans = {{P.FLEN-P.S_LEN{1'b1}}, TestVector[8+(P.S_LEN-1):8]};
               end
@@ -1146,7 +1146,7 @@ module readvectors import cvw::*; #(parameter cvw_t P) (
 		 Y = {{P.FLEN-P.D_LEN{1'b1}}, TestVector[8+2*(P.D_LEN)-1:8+(P.D_LEN)]};
 		 Ans = {{P.FLEN-P.D_LEN{1'b1}}, TestVector[8+(P.D_LEN-1):8]};
               end
-              2'b00: if (P.S_SUPPORTED) begin // single
+              2'b00: if (P.F_SUPPORTED) begin // single
 		 X = {{P.FLEN-P.S_LEN{1'b1}}, TestVector[8+3*(P.S_LEN)-1:8+2*(P.S_LEN)]};
 		 Y = {{P.FLEN-P.S_LEN{1'b1}}, TestVector[8+2*(P.S_LEN)-1:8+1*(P.S_LEN)]};
 		 Ans = {{P.FLEN-P.S_LEN{1'b1}}, TestVector[8+(P.S_LEN-1):8]};
@@ -1169,7 +1169,7 @@ module readvectors import cvw::*; #(parameter cvw_t P) (
                Y = {{P.FLEN-P.D_LEN{1'b1}}, TestVector[12+(P.D_LEN)-1:12]};
                Ans = {{P.FLEN-1{1'b0}}, TestVector[8]};
             end
-            2'b00: if (P.S_SUPPORTED) begin // single
+            2'b00: if (P.F_SUPPORTED) begin // single
                X = {{P.FLEN-P.S_LEN{1'b1}}, TestVector[12+2*(P.S_LEN)-1:12+(P.S_LEN)]};
                Y = {{P.FLEN-P.S_LEN{1'b1}}, TestVector[12+(P.S_LEN)-1:12]};
                Ans = {{P.FLEN-1{1'b0}}, TestVector[8]};
@@ -1222,7 +1222,7 @@ module readvectors import cvw::*; #(parameter cvw_t P) (
 		 end
                endcase
             end
-            2'b00: if (P.S_SUPPORTED) begin // single
+            2'b00: if (P.F_SUPPORTED) begin // single
                case (OpCtrl[1:0])
 		 2'b11: begin // quad
 		    X = {{P.FLEN-P.S_LEN{1'b1}}, TestVector[8+P.S_LEN+P.Q_LEN-1:8+(P.Q_LEN)]};
@@ -1252,7 +1252,7 @@ module readvectors import cvw::*; #(parameter cvw_t P) (
 		    X = {{P.FLEN-P.H_LEN{1'b1}}, TestVector[8+P.H_LEN+P.D_LEN-1:8+(P.D_LEN)]};
 		    Ans = {{P.FLEN-P.D_LEN{1'b1}}, TestVector[8+(P.D_LEN-1):8]};
 		 end
-		 2'b00:	if (P.S_SUPPORTED) begin // single
+		 2'b00:	if (P.F_SUPPORTED) begin // single
 		    X = {{P.FLEN-P.H_LEN{1'b1}}, TestVector[8+P.H_LEN+P.S_LEN-1:8+(P.S_LEN)]};
 		    Ans = {{P.FLEN-P.S_LEN{1'b1}}, TestVector[8+(P.S_LEN-1):8]};
 		 end
@@ -1317,7 +1317,7 @@ module readvectors import cvw::*; #(parameter cvw_t P) (
 		 end
                endcase
             end
-            2'b00: if (P.S_SUPPORTED) begin // single
+            2'b00: if (P.F_SUPPORTED) begin // single
                // {is the integer a long, is the opperation to an integer}
                casez ({OpCtrl[2:1]})
 		 2'b11: begin // long -> single


### PR DESCRIPTION
- Use `VCS` instead of `SIM_VCS` for vas related ifdefs in testbench as `VCS` is enabled by default in the simulator and does not need to be passed as an argument
- Base `$stop` vs `$finish` off of the `QUESTA` macro instead of `VCS` and `VERILATOR` since Questa seems to be the odd one out and this only requires one ifdef instead of two
- Correct usage of `S_SUPPORTED` in testbench_fp and replace with `F_SUPPORTED`