### PR TITLE
Regression Improvements

### DIFF
--- a/bin/regression-wally
+++ b/bin/regression-wally
@@ -313,8 +313,8 @@ os.chdir(regressionDir)
 
 coveragesim = "questa"  # Questa is required for code/functional coverage
 #defaultsim = "vcs"   # Default simulator for all other tests; change to Verilator when flow is ready
-defaultsim = "questa"   # Default simulator for all other tests; change to Verilator when flow is ready
-#defaultsim = "verilator"   # Default simulator for all other tests
+#defaultsim = "questa"   # Default simulator for all other tests; change to Verilator when flow is ready
+defaultsim = "verilator"   # Default simulator for all other tests
 
 coverage = '--coverage' in sys.argv
 fp = '--fp' in sys.argv
@@ -323,9 +323,8 @@ testfloat = '--testfloat' in sys.argv
 
 if (nightly):
     nightMode = "--nightly";
-#    sims = [defaultsim] 
-    sims = ["questa", "vcs"] 
-#    sims = ["questa", "verilator", "vcs"] # *** uncomment to exercise all simulators
+#    sims = [defaultsim]                    # uncomment to use only the default simulator
+    sims = ["questa", "verilator", "vcs"] # uncomment to exercise all simulators
 else:
     nightMode = ""
     sims = [defaultsim]
@@ -352,6 +351,7 @@ if (coverage):  # only run RV64GC tests on Questa in coverage mode
         addTests(tests64gc_fp, "questa")
 else:
     for sim in sims:
+        addTests(tests_buildrootshort, sim)
         addTests(tests, sim)
         addTests(tests64gc_nofp, sim)
         addTests(tests64gc_fp, sim)
@@ -359,10 +359,7 @@ else:
     # run derivative configurations in nightly regression
 if (nightly):
 #    addTests(tests_buildrootboot, defaultsim)
-    addTests(tests_buildrootshort, defaultsim)
     addTests(derivconfigtests, defaultsim)
-else:
-    addTests(tests_buildrootshort, defaultsim)
 
 # testfloat tests
 if (testfloat): # for testfloat alone, just run testfloat tests
@@ -433,9 +430,10 @@ def main():
     """Run the tests and count the failures"""
     global configs, coverage
     os.chdir(regressionDir)
-    os.system('rm -rf questa/wkdir')
-    for d in ["questa/logs", "questa/wkdir", "verilator/logs", "verilator/wkdir", "vcs/logs", "vcs/wkdir"]:
+    dirs = ["questa/logs", "questa/wkdir", "verilator/logs", "verilator/wkdir", "vcs/logs", "vcs/wkdir"]
+    for d in dirs: 
         try:
+            os.system('rm -rf %s' % d)
             os.mkdir(d)
         except:
             pass

--- a/bin/wsim
+++ b/bin/wsim
@@ -14,38 +14,16 @@
 import argparse
 import os
 
-def LaunchSim(ElfFile):
-    # Launch selected simulator
+
+def LaunchSim(ElfFile, flags):
     cd = "cd $WALLY/sim/" +args.sim
-    # ugh.  can't have more than 9 arguments passed to vsim. why? I'll have to remove --lockstep when running
-    # functional coverage and imply it.
+
+    # per-simulator launch
     if (args.sim == "questa"):
-        if (args.lockstep):
-            prefix = "IMPERAS_TOOLS=" + WALLY + "/sim/imperas.ic"
-            if(int(args.locksteplog) >= 1): EnableLog = 1
-            else: EnableLog = 0
-            if(args.locksteplog != 0): ImperasPlusArgs = " +IDV_TRACE2LOG=" + str(EnableLog) + " +IDV_TRACE2LOG_AFTER=" + str(args.locksteplog) 
-            else: ImperasPlusArgs = ""
-            if(args.fcov):
-                CovEnableStr = "1" if int(args.covlog) > 0  else "0";
-                if(args.covlog >= 1): EnableLog = 1
-                else: EnableLog = 0
-                ImperasPlusArgs = " +IDV_TRACE2COV=" + str(EnableLog) + " +TRACE2LOG_AFTER=" + str(args.covlog) + " +TRACE2COV_ENABLE=" + CovEnableStr;
-                suffix = ""
-            else:
-                CovEnableStr = ""
-                suffix = "--lockstep"
-        else:
-            prefix = ""
-            ImperasPlusArgs = ""
-            suffix = ""
+        # Questa cannot accept more than 9 arguments.  fcov implies lockstep
         if (args.tb == "testbench_fp"):
             args.args = " -GTEST=\"" + args.testsuite + "\" " + args.args
-        cmd = "do wally.do " + args.config + " " + args.testsuite + " " + args.tb + " " + args.args + " " + ElfFile + " " + suffix + " " + ImperasPlusArgs
-        if (args.coverage):
-            cmd += " --coverage"
-        if (args.fcov):
-            cmd += " --fcov"
+        cmd = "do wally.do " + args.config + " " + args.testsuite + " " + args.tb + " " + args.args + " " + ElfFile + " " + suffix + " " + flags
         if (args.gui):  # launch Questa with GUI; add +acc to keep variables accessible
             if(args.tb == "testbench"): 
                 cmd = cd + "; " + prefix + " vsim -do \"" + cmd + " +acc -GDEBUG=1\""
@@ -58,23 +36,19 @@ def LaunchSim(ElfFile):
     elif (args.sim == "verilator"):
         # PWD=${WALLY}/sim CONFIG=rv64gc TESTSUITE=arch64i
         print(f"Running Verilator on {args.config} {args.testsuite}")
-        if (args.coverage):
-            print("Coverage option not available for Verilator")
-            exit(1)
-        if (args.gui):
-            print("GUI option not available for Verilator")
-            exit(1)
         os.system(f"/usr/bin/make -C {regressionDir}/verilator WALLYCONF={args.config} TEST={args.testsuite} TESTBENCH={args.tb} EXTRA_ARGS='{args.args}'")
     elif (args.sim == "vcs"):
         print(f"Running VCS on " + args.config + " " + args.testsuite)
         if (args.gui):  
             args.args += "gui"
-        elif (args.coverage):
-            args.args += "coverage"
-        cmd = cd + "; ./run_vcs " + args.config + " " + args.testsuite + " " + args.args
+        cmd = cd + "; ./run_vcs " + args.config + " " + args.testsuite + " " + args.args + " " + flags
         print(cmd)
         os.system(cmd)
 
+
+########################
+# main wsim script
+########################
 
 # Parse arguments
 parser = argparse.ArgumentParser()
@@ -96,6 +70,7 @@ print("Config=" + args.config + " tests=" + args.testsuite + " sim=" + args.sim 
 ElfFile=""
 DirectorMode = 0
 ElfList = []
+WALLY = os.environ.get('WALLY')
 
 if(os.path.isfile(args.testsuite)):
     ElfFile = "+ElfFile=" + args.testsuite
@@ -111,21 +86,43 @@ elif(os.path.isdir(args.testsuite)):
 print(ElfList)
 
 # Validate arguments
-if (args.gui):
+if (args.gui or args.coverage or args.fcov or args.lockstep):
     if args.sim not in ["questa", "vcs"]:
-        print("GUI option only supported for Questa and VCS")
-        exit(1)
-
-if (args.coverage):
-    if args.sim not in ["questa", "vcs"]:
-        print("Coverage option only available for Questa and VCS")
+        print("Option only supported for Questa and VCS")
         exit(1)
 
 if (args.vcd):
     args.args += " -DMAKEVCD=1"
 
+# if lockstep is enabled, then we need to pass the Imperas lockstep arguments
+if(int(args.locksteplog) >= 1): EnableLog = 1
+else: EnableLog = 0
+if (args.lockstep):
+    prefix = "IMPERAS_TOOLS=" + WALLY + "/sim/imperas.ic"
+    if(args.locksteplog != 0): ImperasPlusArgs = " +IDV_TRACE2LOG=" + str(EnableLog) + " +IDV_TRACE2LOG_AFTER=" + str(args.locksteplog) 
+    else: ImperasPlusArgs = ""
+    if(args.fcov):
+        CovEnableStr = "1" if int(args.covlog) > 0  else "0";
+        if(args.covlog >= 1): EnableLog = 1
+        else: EnableLog = 0
+        ImperasPlusArgs = " +IDV_TRACE2COV=" + str(EnableLog) + " +TRACE2LOG_AFTER=" + str(args.covlog) + " +TRACE2COV_ENABLE=" + CovEnableStr;
+        suffix = ""
+    else:
+        CovEnableStr = ""
+        suffix = "--lockstep"
+else:
+    prefix = ""
+    ImperasPlusArgs = ""
+    suffix = ""
+flags = ImperasPlusArgs 
+
+# other flags
+if (args.coverage):
+    flags += " --coverage"
+if (args.fcov):
+    flags += " --fcov"
+
 #  create the output sub-directories.
-WALLY = os.environ.get('WALLY')
 regressionDir = WALLY + '/sim/'
 for d in ["logs", "wkdir", "cov"]:
     try:
@@ -135,7 +132,7 @@ for d in ["logs", "wkdir", "cov"]:
         
 if(DirectorMode):
     for ElfFile in ElfList:
-        LaunchSim(ElfFile)
+        LaunchSim(ElfFile, flags)
 
 else:
-    LaunchSim(ElfFile)
+    LaunchSim(ElfFile, flags)

--- a/bin/wsim
+++ b/bin/wsim
@@ -23,7 +23,7 @@ def LaunchSim(ElfFile, flags):
         # Questa cannot accept more than 9 arguments.  fcov implies lockstep
         if (args.tb == "testbench_fp"):
             args.args = " -GTEST=\"" + args.testsuite + "\" " + args.args
-        cmd = "do wally.do " + args.config + " " + args.testsuite + " " + args.tb + " " + args.args + " " + ElfFile + " " + suffix + " " + flags
+        cmd = "do wally.do " + args.config + " " + args.testsuite + " " + args.tb + " " + args.args + " " + ElfFile + " " + flags
         if (args.gui):  # launch Questa with GUI; add +acc to keep variables accessible
             if(args.tb == "testbench"): 
                 cmd = cd + "; " + prefix + " vsim -do \"" + cmd + " +acc -GDEBUG=1\""
@@ -114,7 +114,7 @@ else:
     prefix = ""
     ImperasPlusArgs = ""
     suffix = ""
-flags = ImperasPlusArgs 
+flags = suffix + " " + ImperasPlusArgs
 
 # other flags
 if (args.coverage):

--- a/config/derivlist.txt
+++ b/config/derivlist.txt
@@ -106,6 +106,7 @@ F_SUPPORTED         0
 ZCF_SUPPORTED       0
 D_SUPPORTED         0
 ZCD_SUPPORTED       0
+
 deriv syn_sram_rv64gc_noFPU syn_sram_rv64gc_noPriv
 F_SUPPORTED         0
 ZCF_SUPPORTED       0
@@ -788,10 +789,12 @@ ZKNH_SUPPORTED     1
 deriv f_rv32gc rv32gc
 D_SUPPORTED     0
 ZFH_SUPPORTED   0
+ZCD_SUPPORTED   0
 
 deriv fh_rv32gc rv32gc
 D_SUPPORTED     0
 ZFH_SUPPORTED   1
+ZCD_SUPPORTED   0
 
 deriv fd_rv32gc rv32gc
 ZFH_SUPPORTED   0
@@ -810,10 +813,12 @@ ZFH_SUPPORTED   1
 deriv f_rv64gc rv64gc
 D_SUPPORTED     0
 ZFH_SUPPORTED   0
+ZCD_SUPPORTED   0
 
 deriv fh_rv64gc rv64gc
 D_SUPPORTED     0
 ZFH_SUPPORTED   1
+ZCD_SUPPORTED   0
 
 deriv fd_rv64gc rv64gc
 ZFH_SUPPORTED   0

--- a/sim/vcs/run_vcs
+++ b/sim/vcs/run_vcs
@@ -92,24 +92,22 @@ RTL_FILES="$INCLUDE_DIRS $(find ${SRC} -name "*.sv" ! -path "${SRC}/generic/mem/
 OUTPUT="sim_out"
 VCS_CMD="vcs +lint=all,noGCWM,noUI,noSVA-UA,noIDTS,noNS,noULCO,noCAWM-L,noWMIA-L,noSV-PIU,noSTASKW_CO,noSTASKW_CO1,noSTASKW_RMCOF +vcs+vcdpluson -suppress +warn -sverilog +vc -Mupdate -line -full64 -kdb -lca -debug_access+all+reverse  -ntb_opts sensitive_dyn ${INCLUDE_PATH} $RTL_FILES"
 SIMV_CMD="./${WKDIR}/$OUTPUT +TEST=${TESTSUITE} ${PLUSARGS}" 
-COV_FILES="${TB}/coverage/test_pmp_coverage.sv"
-COV_OPTIONS="-cm line+cond+branch+fsm+tgl -cm_log ${WKDIR}/coverage.log -cm_dir ${WKDIR}/COVERAGE"
-### CODE COVERAGE REPORT in IndividualCovReport in XML format
-#COV_RUN="urg -dir ${WKDIR}/COVERAGE.vdb -report IndividualCovReport/${CONFIG_VARIANT}_${TESTSUITE}" 
-### CODE COVERAGE REPORT in IndividualCovReport in text format
-COV_RUN="urg -dir ./${WKDIR}/COVERAGE.vdb -format text -report IndividualCovReport/${CONFIG_VARIANT}_${TESTSUITE}"
-
 
 # Clean and run simulation with VCS
 
-if [ "$3" = "coverage" ]; then
+if [ "$3" = "--coverage" ]; then
     echo -e "${YELLOW}#### Running VCS Simulation with Coverage ####${NC}"
-    # Code Coverage.
+    COV_OPTIONS="-cm line+cond+branch+fsm+tgl -cm_log ${WKDIR}/coverage.log -cm_dir ${WKDIR}/COVERAGE"
+    COV_RUN="urg -dir ./${WKDIR}/COVERAGE.vdb -format text -report IndividualCovReport/${CONFIG_VARIANT}_${TESTSUITE}"
     $VCS_CMD -Mdir=${WKDIR} $COV_OPTIONS -o ${WKDIR}/$OUTPUT -Mlib ${WKDIR} -work ${WKDIR} -l "$LOGS/${CONFIG_VARIANT}_${TESTSUITE}.log"
-    $SIMV_CMD $COV_OPTIONS
+    $SIMV_CMD $COV_OPTIONS # dh 6/27/24 *** are COV_OPTIONS really needed?
     $COV_RUN
     #cp -rf urgReport $COV
-
+elif [ "$3" = "--lockstep" ]; then
+    echo -e "${YELLOW}#### Running VCS Simulation with Lockstep ####${NC}"
+    LOCKSTEPVOPTSTRING=" +define+USE_IMPERAS_DV +incdir+$env(IMPERAS_HOME)/ImpPublic/include/host  +incdir+$env(IMPERAS_HOME)/ImpProprietary/include/host  ${IMPERAS_HOME}/ImpPublic/source/host/rvvi/*.sv ${IMPERAS_HOME}/ImpProprietary/source/host/idv/*.sv -sv_lib ${IMPERAS_HOME}/lib/Linux64/ImperasLib/imperas.com/verification/riscv/1.0/model "
+    $VCS_CMD -Mdir=${WKDIR} $LOCKSTEP_OPTIONS -o ${WKDIR}/$OUTPUT -Mlib ${WKDIR} -work ${WKDIR} -l "$LOGS/${CONFIG_VARIANT}_${TESTSUITE}.log"
+    $SIMV_CMD 
 else
     echo -e "${YELLOW}#### Running VCS Simulation ####${NC}"
     $VCS_CMD -Mdir=${WKDIR} -o ${WKDIR}/$OUTPUT -work ${WKDIR} -Mlib ${WKDIR} -l "$LOGS/${CONFIG_VARIANT}_${TESTSUITE}.log"

--- a/sim/vcs/run_vcs
+++ b/sim/vcs/run_vcs
@@ -90,7 +90,7 @@ RTL_FILES="$INCLUDE_DIRS $(find ${SRC} -name "*.sv" ! -path "${SRC}/generic/mem/
 
 # Simulation and Coverage Commands
 OUTPUT="sim_out"
-VCS_CMD="vcs +lint=all,noGCWM,noUI,noSVA-UA,noIDTS,noNS,noULCO,noCAWM-L,noWMIA-L,noSV-PIU,noSTASKW_CO,noSTASKW_CO1,noSTASKW_RMCOF -suppress +warn -sverilog +vc -Mupdate -line -full64 -lca -ntb_opts sensitive_dyn ${INCLUDE_PATH} $RTL_FILES" # Disabled Debug flags; add them back for a GUI mode -debug_access+all+reverse  -kdb +vcs+vcdpluson 
+VCS_CMD="vcs +lint=all,noGCWM,noUI,noSVA-UA,noIDTS,noNS,noULCO,noCAWM-L,noWMIA-L,noSV-PIU,noSTASKW_CO,noSTASKW_CO1,noSTASKW_RMCOF -suppress +warn -sverilog +vc -Mupdate -line -full64 -lca +plusarg_save -ntb_opts sensitive_dyn ${INCLUDE_PATH} $RTL_FILES" # Disabled Debug flags; add them back for a GUI mode -debug_access+all+reverse  -kdb +vcs+vcdpluson 
 SIMV_CMD="./${WKDIR}/$OUTPUT +TEST=${TESTSUITE} ${PLUSARGS} -no_save" 
 
 # Clean and run simulation with VCS

--- a/sim/vcs/run_vcs
+++ b/sim/vcs/run_vcs
@@ -90,7 +90,7 @@ RTL_FILES="$INCLUDE_DIRS $(find ${SRC} -name "*.sv" ! -path "${SRC}/generic/mem/
 
 # Simulation and Coverage Commands
 OUTPUT="sim_out"
-VCS_CMD="vcs +lint=all,noGCWM,noUI,noSVA-UA,noIDTS,noNS,noULCO,noCAWM-L,noWMIA-L,noSV-PIU,noSTASKW_CO,noSTASKW_CO1,noSTASKW_RMCOF -suppress +warn -sverilog +vc -Mupdate -line -full64 -lca +plusarg_save -ntb_opts sensitive_dyn ${INCLUDE_PATH} " # Disabled Debug flags; add them back for a GUI mode -debug_access+all+reverse  -kdb +vcs+vcdpluson 
+VCS_CMD="vcs +lint=all,noGCWM,noUI,noSVA-UA,noIDTS,noNS,noULCO,noCAWM-L,noWMIA-L,noSV-PIU,noSTASKW_CO,noSTASKW_CO1,noSTASKW_RMCOF -suppress +warn -sverilog +vc -Mupdate -line -full64 -lca -ntb_opts sensitive_dyn ${INCLUDE_PATH} " # Disabled Debug flags; add them back for a GUI mode -debug_access+all+reverse  -kdb +vcs+vcdpluson 
 SIMV_CMD="./${WKDIR}/$OUTPUT +TEST=${TESTSUITE} ${PLUSARGS} -no_save" 
 
 # Clean and run simulation with VCS

--- a/sim/vcs/run_vcs
+++ b/sim/vcs/run_vcs
@@ -90,7 +90,7 @@ RTL_FILES="$INCLUDE_DIRS $(find ${SRC} -name "*.sv" ! -path "${SRC}/generic/mem/
 
 # Simulation and Coverage Commands
 OUTPUT="sim_out"
-VCS_CMD="vcs +lint=all,noGCWM,noUI,noSVA-UA,noIDTS,noNS,noULCO,noCAWM-L,noWMIA-L,noSV-PIU,noSTASKW_CO,noSTASKW_CO1,noSTASKW_RMCOF -suppress +warn -sverilog +vc -Mupdate -line -full64 -lca +plusarg_save -ntb_opts sensitive_dyn ${INCLUDE_PATH} $RTL_FILES" # Disabled Debug flags; add them back for a GUI mode -debug_access+all+reverse  -kdb +vcs+vcdpluson 
+VCS_CMD="vcs +lint=all,noGCWM,noUI,noSVA-UA,noIDTS,noNS,noULCO,noCAWM-L,noWMIA-L,noSV-PIU,noSTASKW_CO,noSTASKW_CO1,noSTASKW_RMCOF -suppress +warn -sverilog +vc -Mupdate -line -full64 -lca +plusarg_save -ntb_opts sensitive_dyn ${INCLUDE_PATH} " # Disabled Debug flags; add them back for a GUI mode -debug_access+all+reverse  -kdb +vcs+vcdpluson 
 SIMV_CMD="./${WKDIR}/$OUTPUT +TEST=${TESTSUITE} ${PLUSARGS} -no_save" 
 
 # Clean and run simulation with VCS
@@ -99,18 +99,19 @@ if [ "$3" = "--coverage" ]; then
     echo -e "${YELLOW}#### Running VCS Simulation with Coverage ####${NC}"
     COV_OPTIONS="-cm line+cond+branch+fsm+tgl -cm_log ${WKDIR}/coverage.log -cm_dir ${WKDIR}/COVERAGE"
     COV_RUN="urg -dir ./${WKDIR}/COVERAGE.vdb -format text -report IndividualCovReport/${CONFIG_VARIANT}_${TESTSUITE}"
-    $VCS_CMD -Mdir=${WKDIR} $COV_OPTIONS -o ${WKDIR}/$OUTPUT -Mlib ${WKDIR} -work ${WKDIR} -l "$LOGS/${CONFIG_VARIANT}_${TESTSUITE}.log"
+    $VCS_CMD -Mdir=${WKDIR} $COV_OPTIONS $RTL_FILES -o ${WKDIR}/$OUTPUT -Mlib ${WKDIR} -work ${WKDIR} -l "$LOGS/${CONFIG_VARIANT}_${TESTSUITE}.log"
     $SIMV_CMD $COV_OPTIONS # dh 6/27/24 *** are COV_OPTIONS really needed?
     $COV_RUN
     #cp -rf urgReport $COV
 elif [ "$3" = "--lockstep" ]; then
     echo -e "${YELLOW}#### Running VCS Simulation with Lockstep ####${NC}"
-    LOCKSTEPVOPTSTRING=" +define+USE_IMPERAS_DV +incdir+$env(IMPERAS_HOME)/ImpPublic/include/host  +incdir+$env(IMPERAS_HOME)/ImpProprietary/include/host  ${IMPERAS_HOME}/ImpPublic/source/host/rvvi/*.sv ${IMPERAS_HOME}/ImpProprietary/source/host/idv/*.sv -sv_lib ${IMPERAS_HOME}/lib/Linux64/ImperasLib/imperas.com/verification/riscv/1.0/model "
-    $VCS_CMD -Mdir=${WKDIR} $LOCKSTEP_OPTIONS -o ${WKDIR}/$OUTPUT -Mlib ${WKDIR} -work ${WKDIR} -l "$LOGS/${CONFIG_VARIANT}_${TESTSUITE}.log"
-    $SIMV_CMD 
+    LOCKSTEP_OPTIONS=" +define+USE_IMPERAS_DV +incdir+${IMPERAS_HOME}/ImpPublic/include/host  +incdir+${IMPERAS_HOME}/ImpProprietary/include/host  ${IMPERAS_HOME}/ImpPublic/source/host/rvvi/*.sv ${IMPERAS_HOME}/ImpProprietary/source/host/idv/*.sv ${TB}/common/wallyTracer.sv"
+    LOCKSTEP_SIMV="-sv_lib ${IMPERAS_HOME}/lib/Linux64/ImperasLib/imperas.com/verification/riscv/1.0/model"
+    $VCS_CMD -Mdir=${WKDIR} $LOCKSTEP_OPTIONS $RTL_FILES -o ${WKDIR}/$OUTPUT -Mlib ${WKDIR} -work ${WKDIR} -l "$LOGS/${CONFIG_VARIANT}_${TESTSUITE}.log"
+    $SIMV_CMD $LOCKSTEP_SIMV
 else
     echo -e "${YELLOW}#### Running VCS Simulation ####${NC}"
-    $VCS_CMD -Mdir=${WKDIR} -o ${WKDIR}/$OUTPUT -work ${WKDIR} -Mlib ${WKDIR} -l "$LOGS/${CONFIG_VARIANT}_${TESTSUITE}.log"
+    $VCS_CMD -Mdir=${WKDIR} $RTL_FILES -o ${WKDIR}/$OUTPUT -work ${WKDIR} -Mlib ${WKDIR} -l "$LOGS/${CONFIG_VARIANT}_${TESTSUITE}.log"
     $SIMV_CMD 
 fi
 

--- a/sim/vcs/run_vcs
+++ b/sim/vcs/run_vcs
@@ -90,8 +90,8 @@ RTL_FILES="$INCLUDE_DIRS $(find ${SRC} -name "*.sv" ! -path "${SRC}/generic/mem/
 
 # Simulation and Coverage Commands
 OUTPUT="sim_out"
-VCS_CMD="vcs +lint=all,noGCWM,noUI,noSVA-UA,noIDTS,noNS,noULCO,noCAWM-L,noWMIA-L,noSV-PIU,noSTASKW_CO,noSTASKW_CO1,noSTASKW_RMCOF +vcs+vcdpluson -suppress +warn -sverilog +vc -Mupdate -line -full64 -kdb -lca -debug_access+all+reverse  -ntb_opts sensitive_dyn ${INCLUDE_PATH} $RTL_FILES"
-SIMV_CMD="./${WKDIR}/$OUTPUT +TEST=${TESTSUITE} ${PLUSARGS}" 
+VCS_CMD="vcs +lint=all,noGCWM,noUI,noSVA-UA,noIDTS,noNS,noULCO,noCAWM-L,noWMIA-L,noSV-PIU,noSTASKW_CO,noSTASKW_CO1,noSTASKW_RMCOF -suppress +warn -sverilog +vc -Mupdate -line -full64 -lca -ntb_opts sensitive_dyn ${INCLUDE_PATH} $RTL_FILES" # Disabled Debug flags; add them back for a GUI mode -debug_access+all+reverse  -kdb +vcs+vcdpluson 
+SIMV_CMD="./${WKDIR}/$OUTPUT +TEST=${TESTSUITE} ${PLUSARGS} -no_save" 
 
 # Clean and run simulation with VCS
 

--- a/tests/wally-riscv-arch-test/riscv-test-suite/rv64i_m/Q/README.md
+++ b/tests/wally-riscv-arch-test/riscv-test-suite/rv64i_m/Q/README.md
@@ -22,7 +22,12 @@ riscv-ctg-> This folder consists of the CTG tool which is responsible for genera
 
 riscof -> The riscof directory in Wally was changed to include some Quad precision template files for compilation. Along with modification of scripts and yaml files to support FLEN=128
 
-
+TO DO: 
+    Debug why fadd.q_b1 doesn't match Sail vs. Spike
+    Run the q test on Wally RTL
+    Make more tests from the working datasets
+    Get other datasets working by using softfloat to do quad math
+    Push changes back to riscv-ctg and riscv-isac and remove them from wally-riscv-arch/tsts/riscv-test-suite/rv64i_m/Q
 
 
 Start by installing riscv-ctg via the following commands : 


### PR DESCRIPTION
regression-wally --nightly is now running all sims including short buildroot in Verilator, VCS, and Questa

Verilator is more than twice as fast as the commercial sims with our present optimization flags, so regression-wally is switched to run Verilator as the default sim.  This also makes Wally less reliant on commercial tools.

Some cleanup of testbench-fp, but not yet running in Verilator.

Some steps toward running VCS in lockstep.
