### PR TITLE
Modified riscv-isacov and riscv-ctg files to support some missing quad instructions.

### DIFF
--- a/tests/wally-riscv-arch-test/riscv-test-suite/rv64i_m/Q/riscv-ctg/riscv_ctg/generator.py
+++ b/tests/wally-riscv-arch-test/riscv-test-suite/rv64i_m/Q/riscv-ctg/riscv_ctg/generator.py
@@ -55,7 +55,7 @@ def toint(x: str):
         return int(x)
 
 def get_rm(opcode):
-    insns = ['fsgnj','fle','flt','feq','fclass','fmv','flw','fsw','fld','fsd','fmin','fmax',
+    insns = ['fsgnj','fle','flt','feq','fclass','fmv','flw','fsw','fld','fsd','flq','fsq','fmin','fmax',
              'fcvt.d.s', 'fcvt.d.w','fcvt.d.wu']
     insns += ['fminm', 'fmaxm']
     if any([x in opcode for x in insns]):
@@ -242,7 +242,7 @@ class Generator():
 
 
         is_nan_box = False
-        is_fext = any(['F' in x or 'D' in x for x in opnode['isa']])
+        is_fext = any(['F' in x or 'D' in x or 'Q' in x for x in opnode['isa']])
 
         if is_fext:
             if fl>ifl:
@@ -260,7 +260,7 @@ class Generator():
         self.is_fext = is_fext
         self.is_nan_box = is_nan_box
 
-        if opcode in ['sw', 'sh', 'sb', 'lw', 'lhu', 'lh', 'lb', 'lbu', 'ld', 'lwu', 'sd',"jal","beq","bge","bgeu","blt","bltu","bne","jalr","flw","fsw","fld","fsd"]:
+        if opcode in ['sw', 'sh', 'sb', 'lw', 'lhu', 'lh', 'lb', 'lbu', 'ld', 'lwu', 'sd',"jal","beq","bge","bgeu","blt","bltu","bne","jalr","flw","fsw","fld","fsd","flq","fsq"]:
             self.val_vars = self.val_vars + ['ea_align']
         self.template = opnode['template']
         self.opnode = opnode

--- a/tests/wally-riscv-arch-test/riscv-test-suite/rv64i_m/Q/riscv-isac/riscv_isac/cgf_normalize.py
+++ b/tests/wally-riscv-arch-test/riscv-test-suite/rv64i_m/Q/riscv-isac/riscv_isac/cgf_normalize.py
@@ -43,7 +43,7 @@ def simd_val_comb(xlen, bit_width, signed=True):
     :type signed: bool
     '''
 
-    fmt = {8: 'b', 16: 'h', 32: 'w', 64: 'd'}
+    fmt = {8: 'b', 16: 'h', 32: 'w', 64: 'd', 128: 'q'}
     sz = fmt[bit_width]
     var_num = xlen//bit_width
     coverpoints = []
@@ -78,7 +78,7 @@ def simd_base_val(rs, xlen, bit_width, signed=True):
     :type signed: bool
     '''
 
-    fmt = {8: 'b', 16: 'h', 32: 'w', 64: 'd'}
+    fmt = {8: 'b', 16: 'h', 32: 'w', 64: 'd', 128: 'q'}
 
     sz = fmt[bit_width]
     var_num = xlen//bit_width

--- a/tests/wally-riscv-arch-test/riscv-test-suite/rv64i_m/Q/riscv-isac/riscv_isac/coverage.py
+++ b/tests/wally-riscv-arch-test/riscv-test-suite/rv64i_m/Q/riscv-isac/riscv_isac/coverage.py
@@ -536,8 +536,10 @@ class archState:
 
         if flen == 32:
             self.f_rf = ['00000000']*32
-        else:
+        elif flen == 64:
             self.f_rf = ['0000000000000000']*32
+        else:
+            self.f_rf = ['00000000000000000000000000000']*32
         self.pc = 0
         self.flen = flen
 

--- a/tests/wally-riscv-arch-test/riscv-test-suite/rv64i_m/Q/riscv-isac/riscv_isac/data/rvopcodesdecoder.py
+++ b/tests/wally-riscv-arch-test/riscv-test-suite/rv64i_m/Q/riscv-isac/riscv_isac/data/rvopcodesdecoder.py
@@ -362,7 +362,7 @@ class disassembler():
                 if 'rs1' in arg:
                     treg = reg_type
                     if any([instr_name.startswith(x) for x in [
-                            'fsw','fsd','fcvt.s','fcvt.d','fmv.w','fmv.l']]):
+                            'fsw','fsd','fsq','fcvt.s','fcvt.d','fmv.w','fmv.l']]):
                         treg = 'x'
                     temp_instrobj.rs1 = (int(get_arg_val(arg)(mcode), 2), treg)
                 if 'rs2' in arg:

--- a/tests/wally-riscv-arch-test/riscv-test-suite/rv64i_m/Q/riscv-isac/riscv_isac/plugins/internaldecoder.py
+++ b/tests/wally-riscv-arch-test/riscv-test-suite/rv64i_m/Q/riscv-isac/riscv_isac/plugins/internaldecoder.py
@@ -18,8 +18,8 @@ class disassembler():
             0b0011011: self.rv64i_arithi_ops,
             0b0111011: self.rv64i_arith_ops,
             0b0101111: self.rv64_rv32_atomic_ops,
-            0b0000111: self.flw_fld,
-            0b0100111: self.fsw_fsd,
+            0b0000111: self.flw_fld_flq,
+            0b0100111: self.fsw_fsd_fsq,
             0b1000011: self.fmadd,
             0b1000111: self.fmsub,
             0b1001011: self.fnmsub,
@@ -1606,7 +1606,7 @@ class disassembler():
 
             return instrObj
 
-    def flw_fld(self, instrObj):
+    def flw_fld_flq(self, instrObj):
         instr = instrObj.instr
         rd = ((instr & self.RD_MASK) >> 7, 'f')
         rs1 = ((instr & self.RS1_MASK) >> 15, 'x')
@@ -1621,10 +1621,12 @@ class disassembler():
             instrObj.instr_name = 'flw'
         elif funct3 == 0b011:
             instrObj.instr_name = 'fld'
+        elif funct3 == 0b100:
+            instrObj.instr_name = 'flq'
 
         return instrObj
 
-    def fsw_fsd(self, instrObj):
+    def fsw_fsd_fsq(self, instrObj):
         instr = instrObj.instr
         imm_4_0 = (instr & self.RD_MASK) >> 7
         imm_11_5 = (instr >> 25) << 5
@@ -1642,6 +1644,8 @@ class disassembler():
             instrObj.instr_name = 'fsw'
         elif funct3 == 0b011:
             instrObj.instr_name = 'fsd'
+        elif funct3 == 0b100:
+            instrObj.instr_name = 'fsq'
 
         return instrObj
 
@@ -1766,6 +1770,14 @@ class disassembler():
             instrObj.instr_name = 'fmul.d'
         elif funct7 == 0b0001101:
             instrObj.instr_name = 'fdiv.d'
+        elif funct7 == 0b0000011:
+            instrObj.instr_name = 'fadd.q'
+        elif funct7 == 0b0000111:
+            instrObj.instr_name = 'fsub.q'
+        elif funct7 == 0b0001011:
+            instrObj.instr_name = 'fmul.q'
+        elif funct7 == 0b0001111:
+            instrObj.instr_name = 'fdiv.q'
 
         # fsqrt
         if funct7 == 0b0101100:
@@ -1774,6 +1786,10 @@ class disassembler():
             return instrObj
         elif funct7 == 0b0101101:
             instrObj.instr_name = 'fsqrt.d'
+            instrObj.rs2 = None
+            return instrObj
+        elif funct7 == 0b0101111:
+            instrObj.instr_name = 'fsqrt.q'
             instrObj.rs2 = None
             return instrObj
 


### PR DESCRIPTION
Some of the files in ISACOV and CTG were missing some quad instructions and FLEN support. These updated files fix that. Will be helpful once additional opcodes are included in the Quad suite.