### PR TITLE
Adding RVVI Functional Coverage Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -193,6 +193,9 @@ config/deriv
 docs/docker/buildroot-config-src
 docs/docker/testvector-generation
 sim/questa/cov
+sim/questa/fcovrvvi
+sim/questa/fcovrvvi_logs
+sim/questa/fcovrvvi_ucdb
 sim/covhtmlreport/
 sim/questa/logs
 sim/questa/wkdir

--- a/.gitmodules
+++ b/.gitmodules
@@ -34,3 +34,6 @@
 	sparseCheckout = true
 	path = addins/verilog-ethernet
 	url = https://github.com/ross144/verilog-ethernet.git
+[submodule "cvw-arch-verif"]
+	path = cvw-arch-verif
+	url = https://github.com/openhwgroup/cvw-arch-verif

--- a/bin/regression-wally
+++ b/bin/regression-wally
@@ -340,6 +340,7 @@ defaultsim = "verilator"   # Default simulator for all other tests
 parser = argparse.ArgumentParser()
 parser.add_argument("--ccov", help="Code Coverage", action="store_true")
 parser.add_argument("--fcov", help="Functional Coverage", action="store_true")
+parser.add_argument("--fcovrvvi", help="Functional Coverage RVVI", action="store_true")
 parser.add_argument("--nightly", help="Run large nightly regression", action="store_true")
 parser.add_argument("--buildroot", help="Include Buildroot Linux boot test (takes many hours, done along with --nightly)", action="store_true")
 parser.add_argument("--testfloat", help="Include Testfloat floating-point unit tests", action="store_true")
@@ -357,6 +358,8 @@ if (args.ccov):  # only run RV64GC tests in coverage mode
     coverStr = '--ccov'
 elif (args.fcov):  # only run RV64GC tests in lockstep in coverage mode
     coverStr = '--fcov'
+elif (args.fcovrvvi):  # only run RV64GC tests in rvvi coverage mode
+    coverStr = '--fcovrvvi'
 else:
    coverStr = ''
 
@@ -392,6 +395,10 @@ elif (args.fcov):  # only run RV64GC tests on Questa in lockstep in functional c
     #        grepstr="SUCCESS! All tests ran without failures",
     #        grepfile = sim_log)
     #configs.append(tc)
+elif (args.fcovrvvi):  # only run RV64GC tests on Questa in rvvi coverage mode
+    addTests(tests64gc_nofp, coveragesim)
+    if (args.fp):
+        addTests(tests64gc_fp, coveragesim)
 else: 
     for sim in sims:
         if (not (args.buildroot and sim == defaultsim)):  # skip short buildroot sim if running long one
@@ -501,6 +508,9 @@ def main():
     if args.ccov:
         TIMEOUT_DUR = 20*60 # seconds
         os.system('rm -f questa/cov/*.ucdb')
+    elif args.fcovrvvi:
+        TIMEOUT_DUR = 20*60
+        os.system('rm -f questa/fcovrvvi_ucdb/* questa/fcovrvvi_logs/* questa/fcovrvvi/*')
     elif args.fcov:
         TIMEOUT_DUR = 1*60
         os.system('rm -f questa/fcov_ucdb/* questa/fcov_logs/* questa/fcov/*')
@@ -535,6 +545,8 @@ def main():
        os.system('make QuestaCodeCoverage')
     if args.fcov:
        os.system('make QuestaFunctCoverage')
+    if args.fcovrvvi:
+        os.system('make QuestaFunctCoverageRvvi')
     # Count the number of failures
     if num_fail:
         print(f"{bcolors.FAIL}Regression failed with %s failed configurations{bcolors.ENDC}" % num_fail)

--- a/bin/wsim
+++ b/bin/wsim
@@ -28,6 +28,7 @@ parser.add_argument("--tb", "-t", help="Testbench", choices=["testbench", "testb
 parser.add_argument("--gui", "-g", help="Simulate with GUI", action="store_true")
 parser.add_argument("--ccov", "-c", help="Code Coverage", action="store_true")
 parser.add_argument("--fcov", "-f", help="Functional Coverage, implies lockstep", action="store_true")
+parser.add_argument("--fcovrvvi", "-fr", help="Functional Coverage RVVI", action="store_true")
 parser.add_argument("--args", "-a", help="Optional arguments passed to simulator via $value$plusargs", default="")
 parser.add_argument("--vcd", "-v", help="Generate testbench.vcd", action="store_true")
 parser.add_argument("--lockstep", "-l", help="Run ImperasDV lock, step, and compare.", action="store_true")
@@ -57,7 +58,7 @@ if(args.testsuite.endswith('.elf') and args.elf == ""): # No --elf argument; che
 
 
 # Validate arguments
-if (args.gui or args.ccov or args.fcov or args.lockstep):
+if (args.gui or args.ccov or args.fcov or args.fcovrvvi or args.lockstep):
     if args.sim not in ["questa", "vcs"]:
         print("Option only supported for Questa and VCS")
         exit(1)
@@ -95,10 +96,12 @@ if (args.ccov):
     flags += " --ccov"
 if (args.fcov):
     flags += " --fcov"
+if (args.fcovrvvi):
+    flags += "--fcovrvvi"
 
 #  create the output sub-directories.
 regressionDir = WALLY + '/sim/'
-for d in ["logs", "wkdir", "cov", "ucdb", "fcov", "fcov_ucdb"]:
+for d in ["logs", "wkdir", "cov", "ucdb", "fcov", "fcov_ucdb", "fcovrvvi", "fcovrvvi_ucdb"]:
     try:
         os.mkdir(regressionDir+args.sim+"/"+d)
     except:

--- a/testbench/testbench.sv
+++ b/testbench/testbench.sv
@@ -33,6 +33,12 @@
     `include "idv/idv.svh"
 `endif
 
+`ifdef RVVI_COVERAGE
+    `include "RISCV_trace_data.svh"
+    `include "rvvicov.svh"
+    `include "wrapper.sv"
+`endif
+
 import cvw::*;
 
 module testbench;
@@ -981,6 +987,12 @@ test_pmp_coverage #(P) pmp_inst(clk);
 `endif
   /* verilator lint_on WIDTHTRUNC */
   /* verilator lint_on WIDTHEXPAND */
+
+`ifdef RVVI_COVERAGE
+    rvviTrace #(.XLEN(P.XLEN), .FLEN(P.FLEN)) rvvi();
+    wallyTracer #(P) wallyTracer(rvvi);
+    wrapper #(P) wrap(clk);
+`endif
 
 endmodule
 

--- a/tests/riscof/Makefile
+++ b/tests/riscof/Makefile
@@ -4,12 +4,17 @@ work_dir = ./riscof_work
 work = ./work
 arch_workdir = $(work)/riscv-arch-test
 wally_workdir = $(work)/wally-riscv-arch-test
+custom_test_dir = ../../addins/cvw-arch-verif/test
+submodule_work_dir = ../../addins/cvw-arch-verif/riscof_work
 
 current_dir = $(shell pwd)
 #XLEN    ?= 64
 
 all: root arch32 wally32 arch32e arch64 wally64
+
 wally-riscv-arch-test: root wally64 wally32
+
+custom: new_test
 
 root:
 	mkdir -p $(work_dir)
@@ -47,6 +52,9 @@ wally64:
 
 quad64:
 	riscof run --work-dir=$(work_dir) --config=config64.ini --suite=$(wally_dir)/riscv-test-suite/rv64i_m/Q/riscv-ctg/tests/ --env=$(wally_dir)/riscv-test-suite/env
+	
+new_test:
+	riscof run --work-dir=$(submodule_work_dir) --config=config64.ini --suite=$(custom_test_dir)/ --env=$(wally_dir)/riscv-test-suite/env --no-browser
 
 #wally32e:
 #	riscof run --work-dir=$(work_dir) --config=config32e.ini --suite=$(wally_dir)/riscv-test-suite/ --env=$(wally_dir)/riscv-test-suite/env --no-browser --no-dut-run
@@ -66,3 +74,4 @@ clean:
 	rm -rf $(work_dir)
 	rm -rf $(wally_workdir)
 	rm -rf $(arch_workdir)
+	rm -rf $(submodule_wor_dir)


### PR DESCRIPTION
This PR adds the support for RVVI Functional Coverage by updating the scripts. It also adds cvw-arch-verif repo as a submodule. The following files have been modified:

**Testbench.sv**: has been modified to include and instantiate interfaces and some common RVVI Coverage files
**wsim:** Adds ‘fcovrvvi’ argument for RVVI Functional Coverage and creates its output sub-directories
**wally.do**: creates a work dir in the submodule for coverage reports and sets the ‘FCdfineRVVI_COVERAGE’ when the flag for RVVI functional coverage is set. It also creates a coverage report.
**regression-wally**: Added ‘fcovrvvi’ argument for RVVI Functional Coverage
**.gitignore**: modifies to ignore all these new output sub-directories
**Riscof Makefile**: has been modified to add a target ‘custom’ which runs all the tests in the submodule using the riscof framework
**.gitmodules**: Adds the cvw-arch-verif repo as a submodule