### PR TITLE
Update linker scripts to avoid hardcoded /opt/riscv

### DIFF
--- a/fpga/zsbl/Makefile
+++ b/fpga/zsbl/Makefile
@@ -24,7 +24,7 @@ LIBRARY_FILES	:=
 
 MARCH           :=-march=rv64imfdc_zifencei
 MABI            :=-mabi=lp64d
-LINK_FLAGS      :=$(MARCH) $(MABI) -nostartfiles
+LINK_FLAGS      :=$(MARCH) $(MABI) -nostartfiles -L $(RISCV)/riscv64-unknown-elf/lib
 LINKER		:=linker1000.x
 
 

--- a/fpga/zsbl/linker1000.x
+++ b/fpga/zsbl/linker1000.x
@@ -2,7 +2,6 @@ OUTPUT_FORMAT("elf64-littleriscv", "elf64-littleriscv",
 	      "elf64-littleriscv")
 OUTPUT_ARCH(riscv)
 ENTRY(_start)
-SEARCH_DIR("/opt/riscv/riscv64-unknown-elf/lib");
 SECTIONS
 {
   /* Read-only sections, merged into text segment: */

--- a/tests/custom/boot/Makefile
+++ b/tests/custom/boot/Makefile
@@ -23,7 +23,7 @@ LIBRARY_FILES	:=
 
 MARCH           :=-march=rv64imfdc
 MABI            :=-mabi=lp64d
-LINK_FLAGS      :=$(MARCH) $(MABI) -nostartfiles
+LINK_FLAGS      :=$(MARCH) $(MABI) -nostartfiles -L $(RISCV)/riscv64-unknown-elf/lib
 LINKER		:=$(ROOT)/linker1000.x
 
 

--- a/tests/custom/cacheTest/Makefile
+++ b/tests/custom/cacheTest/Makefile
@@ -7,7 +7,7 @@ LIBRARY_FILES	:= crt0
 MARCH           :=-march=rv64imfdc
 MABI            :=-mabi=lp64d
 LINKER          := ${ROOT}/linker8000-0000.x
-LINK_FLAGS      :=$(MARCH) $(MABI) -nostartfiles -Wl,-Map=$(TARGET).map
+LINK_FLAGS      :=$(MARCH) $(MABI) -nostartfiles -Wl,-Map=$(TARGET).map -L $(RISCV)/riscv64-unknown-elf/lib
 
 CFLAGS =$(MARCH) $(MABI) -Wa,-alhs -Wa,-L -mcmodel=medany  -mstrict-align -O2
 CC=riscv64-unknown-elf-gcc

--- a/tests/custom/crt0/Makefile
+++ b/tests/custom/crt0/Makefile
@@ -6,7 +6,7 @@ LIBRARY_FILES	:=
 
 MARCH           :=-march=rv64imfdc
 MABI            :=-mabi=lp64d
-LINK_FLAGS      :=$(MARCH) $(MABI) -nostartfiles
+LINK_FLAGS      :=$(MARCH) $(MABI) -nostartfiles -L $(RISCV)/riscv64-unknown-elf/lib
 LINKER          := ${ROOT}/linker.x
 
 AFLAGS =$(MARCH) $(MABI) -W

--- a/tests/custom/fpga-blink-led/Makefile
+++ b/tests/custom/fpga-blink-led/Makefile
@@ -23,7 +23,7 @@ LIBRARY_FILES	:=
 
 MARCH           :=-march=rv64imfdc
 MABI            :=-mabi=lp64d
-LINK_FLAGS      :=$(MARCH) $(MABI) -nostartfiles
+LINK_FLAGS      :=$(MARCH) $(MABI) -nostartfiles -L $(RISCV)/riscv64-unknown-elf/lib
 LINKER		:=$(ROOT)/linker1000.x
 
 

--- a/tests/custom/fpga-test-dram/Makefile
+++ b/tests/custom/fpga-test-dram/Makefile
@@ -23,7 +23,7 @@ LIBRARY_FILES	:=
 
 MARCH           :=-march=rv64imfdc
 MABI            :=-mabi=lp64d
-LINK_FLAGS      :=$(MARCH) $(MABI) -nostartfiles
+LINK_FLAGS      :=$(MARCH) $(MABI) -nostartfiles -L $(RISCV)/riscv64-unknown-elf/lib
 LINKER		:=$(ROOT)/linker1000.x
 
 

--- a/tests/custom/fpga-test-sdc/Makefile
+++ b/tests/custom/fpga-test-sdc/Makefile
@@ -23,7 +23,7 @@ LIBRARY_FILES	:=
 
 MARCH           :=-march=rv64imfdc
 MABI            :=-mabi=lp64d
-LINK_FLAGS      :=$(MARCH) $(MABI) -nostartfiles
+LINK_FLAGS      :=$(MARCH) $(MABI) -nostartfiles -L $(RISCV)/riscv64-unknown-elf/lib
 LINKER		:=$(ROOT)/linker1000.x
 
 

--- a/tests/custom/james_mm/Makefile
+++ b/tests/custom/james_mm/Makefile
@@ -6,7 +6,7 @@ LIBRARY_FILES	:= crt0
 
 MARCH           :=-march=rv64imfdc
 MABI            :=-mabi=lp64d
-LINK_FLAGS      :=$(MARCH) $(MABI) -nostartfiles -Wl,-Map=$(TARGET).map
+LINK_FLAGS      :=$(MARCH) $(MABI) -nostartfiles -Wl,-Map=$(TARGET).map -L $(RISCV)/riscv64-unknown-elf/lib
 LINKER          := ${ROOT}/linker8000-0000.x
 
 CFLAGS =$(MARCH) $(MABI) -Wa,-alhs -Wa,-L -mcmodel=medany  -mstrict-align -O2

--- a/tests/custom/linker.x
+++ b/tests/custom/linker.x
@@ -2,7 +2,6 @@ OUTPUT_FORMAT("elf64-littleriscv", "elf64-littleriscv",
 	      "elf64-littleriscv")
 OUTPUT_ARCH(riscv)
 ENTRY(_start)
-SEARCH_DIR("/opt/riscv/riscv64-unknown-elf/lib");
 SECTIONS
 {
   /* Read-only sections, merged into text segment: */

--- a/tests/custom/linker1000.x
+++ b/tests/custom/linker1000.x
@@ -2,7 +2,6 @@ OUTPUT_FORMAT("elf64-littleriscv", "elf64-littleriscv",
 	      "elf64-littleriscv")
 OUTPUT_ARCH(riscv)
 ENTRY(_start)
-SEARCH_DIR("/opt/riscv/riscv64-unknown-elf/lib");
 SECTIONS
 {
   /* Read-only sections, merged into text segment: */

--- a/tests/custom/linker8000-0000.x
+++ b/tests/custom/linker8000-0000.x
@@ -2,7 +2,6 @@ OUTPUT_FORMAT("elf64-littleriscv", "elf64-littleriscv",
 	      "elf64-littleriscv")
 OUTPUT_ARCH(riscv)
 ENTRY(_start)
-SEARCH_DIR("/opt/riscv/riscv64-unknown-elf/lib");
 SECTIONS
 {
   /* Read-only sections, merged into text segment: */

--- a/tests/custom/lpddrtest/Makefile
+++ b/tests/custom/lpddrtest/Makefile
@@ -7,7 +7,7 @@ LIBRARY_FILES	:= crt0
 MARCH           :=-march=rv64imfdczicbom
 MABI            :=-mabi=lp64d
 LINKER          := ${ROOT}/linker8000-0000.x
-LINK_FLAGS      :=$(MARCH) $(MABI) -nostartfiles -Wl,-Map=$(TARGET).map
+LINK_FLAGS      :=$(MARCH) $(MABI) -nostartfiles -Wl,-Map=$(TARGET).map -L $(RISCV)/riscv64-unknown-elf/lib
 
 CFLAGS =$(MARCH) $(MABI) -Wa,-alhs -Wa,-L -mcmodel=medany  -mstrict-align -O2
 CC=riscv64-unknown-elf-gcc

--- a/tests/custom/mibench_qsort/Makefile
+++ b/tests/custom/mibench_qsort/Makefile
@@ -6,7 +6,7 @@ LIBRARY_FILES	:= crt0
 
 MARCH           :=-march=rv64ic
 MABI            :=-mabi=lp64
-LINK_FLAGS      :=$(MARCH) $(MABI) -nostartfiles -Wl,-Map=$(TARGET).map
+LINK_FLAGS      :=$(MARCH) $(MABI) -nostartfiles -Wl,-Map=$(TARGET).map -L $(RISCV)/riscv64-unknown-elf/lib
 LINKER          := ${ROOT}/linker8000-0000.x
 
 CFLAGS =$(MARCH) $(MABI) -Wa,-alhs -Wa,-L -mcmodel=medany  -mstrict-align -O2

--- a/tests/custom/sieve/Makefile
+++ b/tests/custom/sieve/Makefile
@@ -6,7 +6,7 @@ LIBRARY_FILES	:= crt0
 
 MARCH           :=-march=rv64ic
 MABI            :=-mabi=lp64
-LINK_FLAGS      :=$(MARCH) $(MABI) -nostartfiles -Wl,-Map=$(TARGET).map
+LINK_FLAGS      :=$(MARCH) $(MABI) -nostartfiles -Wl,-Map=$(TARGET).map -L $(RISCV)/riscv64-unknown-elf/lib
 LINKER          := ${ROOT}/linker8000-0000.x
 
 CFLAGS =$(MARCH) $(MABI) -Wa,-alhs -Wa,-L -mcmodel=medany  -mstrict-align -O2

--- a/tests/custom/simple/Makefile
+++ b/tests/custom/simple/Makefile
@@ -7,7 +7,7 @@ LIBRARY_FILES	:= crt0
 MARCH           :=-march=rv64imfdczicbom
 MABI            :=-mabi=lp64d
 LINKER          := ${ROOT}/linker8000-0000.x
-LINK_FLAGS      :=$(MARCH) $(MABI) -nostartfiles -Wl,-Map=$(TARGET).map
+LINK_FLAGS      :=$(MARCH) $(MABI) -nostartfiles -Wl,-Map=$(TARGET).map -L $(RISCV)/riscv64-unknown-elf/lib
 
 CFLAGS =$(MARCH) $(MABI) -Wa,-alhs -Wa,-L -mcmodel=medany  -mstrict-align -O2
 CC=riscv64-unknown-elf-gcc


### PR DESCRIPTION
Remove `SEARCH_DIR` from linker scripts and pass `$RISCV/riscv64-unknown-elf/lib` as a command line flag in the makefile instead. Fixes #905 