### PR TITLE
Fixed c.slli hint discovered by Lee (Issue 910)

### DIFF
--- a/sim/imperas.ic
+++ b/sim/imperas.ic
@@ -68,6 +68,9 @@
 --override cpu/PMP_registers=16
 --override cpu/PMP_undefined=T
 
+# mstatus.FS is set dirty on any write to a FPR, or when a fp operation signals an exception
+--override cpu/mstatus_fs_mode=rvfs_write_nz
+
 # PMA Settings 
 # 'r': read access allowed
 # 'w': write access allowed
@@ -101,7 +104,7 @@
 
 # Add Imperas simulator application instruction tracing
 # uncomment these to provide tracing
-#--verbose --trace --tracechange --traceshowicount --tracemode -tracemem ASX --monitornetschange # --traceafter 300000000
+--verbose --trace --tracechange --traceshowicount --tracemode -tracemem ASX --monitornetschange # --traceafter 300000000
 --override cpu/debugflags=6 --override cpu/verbose=1
 --override cpu/show_c_prefix=T
 

--- a/src/ifu/decompress.sv
+++ b/src/ifu/decompress.sv
@@ -148,9 +148,12 @@ module decompress import cvw::*;  #(parameter cvw_t P) (
         5'b01101:                                       LInstrD = {1'b1, immCJ, 5'b00000, 7'b1101111}; // c.j
         5'b01110:                                       LInstrD = {1'b1, immCB[11:5], 5'b00000, rs1p, 3'b000, immCB[4:0], 7'b1100011};    // c.beqz
         5'b01111:                                       LInstrD = {1'b1, immCB[11:5], 5'b00000, rs1p, 3'b001, immCB[4:0], 7'b1100011};    // c.bnez
-        5'b10000: if (rds1 != 5'b0) begin
-                    if (P.XLEN > 32 | ~immSH[5])        LInstrD = {1'b1, 6'b000000, immSH, rds1, 3'b001, rds1, 7'b0010011};               // c.slli; shamt[5] must be 0 in RV32C
-                  end else if (immSH != 0)              LInstrD = {1'b1, 25'b0, 7'b0010011};                                              // c.slli with rd = 0, immm != 0 is a HINT, treated as nop
+        5'b10000: if (immSH != 0) begin
+                    if (P.XLEN > 32 | ~immSH[5]) begin                                                                                    // shamt[5] = 1 is reserved in RV32C
+                      if (rds1 != 5'b0)                 LInstrD = {1'b1, 6'b000000, immSH, rds1, 3'b001, rds1, 7'b0010011};               // c.slli
+                      else                              LInstrD = {1'b1, 25'b0, 7'b0010011};                                              // c.slli with rd = 0 is a HINT, treated as nop
+                    end
+                  end else                              LInstrD = {1'b1, 25'b0, 7'b0010011};                                              // c.slli with immm = 0 is a HINT, treated as nop
         5'b10001: if (P.ZCD_SUPPORTED)                  LInstrD = {1'b1, immCILSPD, 5'b00010, 3'b011, rds1, 7'b0000111};                  // c.fldsp
         5'b10010: if (rds1 != 5'b0)                     LInstrD = {1'b1, immCILSP, 5'b00010, 3'b010, rds1, 7'b0000011};                   // c.lwsp
         5'b10011: if (P.XLEN == 32) begin 

--- a/src/privileged/csr.sv
+++ b/src/privileged/csr.sv
@@ -110,7 +110,7 @@ module csr import cvw::*;  #(parameter cvw_t P) (
   logic                    WriteMSTATUSM, WriteMSTATUSHM, WriteSSTATUSM;
   logic                    CSRMWriteM, CSRSWriteM, CSRUWriteM;
   logic                    UngatedCSRMWriteM;
-  logic                    WriteFRMM, WriteFFLAGSM;
+  logic                    WriteFRMM, SetOrWriteFFLAGSM;
   logic [P.XLEN-1:0]       UnalignedNextEPCM, NextEPCM, NextMtvalM;
   logic [4:0]              NextCauseM;
   logic [11:0]             CSRAdrM;
@@ -222,7 +222,7 @@ module csr import cvw::*;  #(parameter cvw_t P) (
   csrsr #(P) csrsr(.clk, .reset, .StallW, 
     .WriteMSTATUSM, .WriteMSTATUSHM, .WriteSSTATUSM, 
     .TrapM, .FRegWriteM, .NextPrivilegeModeM, .PrivilegeModeW,
-    .mretM, .sretM, .WriteFRMM, .WriteFFLAGSM, .CSRWriteValM, .SelHPTW,
+    .mretM, .sretM, .WriteFRMM, .SetOrWriteFFLAGSM, .CSRWriteValM, .SelHPTW,
     .MSTATUS_REGW, .SSTATUS_REGW, .MSTATUSH_REGW,
     .STATUS_MPP, .STATUS_SPP, .STATUS_TSR, .STATUS_TW,
     .STATUS_MIE, .STATUS_SIE, .STATUS_MXR, .STATUS_SUM, .STATUS_MPRV, .STATUS_TVM,
@@ -267,14 +267,14 @@ module csr import cvw::*;  #(parameter cvw_t P) (
   if (P.F_SUPPORTED) begin:csru
     csru #(P) csru(.clk, .reset, .InstrValidNotFlushedM, 
       .CSRUWriteM, .CSRAdrM, .CSRWriteValM, .STATUS_FS, .CSRUReadValM,  
-      .SetFflagsM, .FRM_REGW, .WriteFRMM, .WriteFFLAGSM,
+      .SetFflagsM, .FRM_REGW, .WriteFRMM, .SetOrWriteFFLAGSM,
       .IllegalCSRUAccessM);
   end else begin
     assign FRM_REGW = '0;
     assign CSRUReadValM = '0;
     assign IllegalCSRUAccessM = 1'b1;
     assign WriteFRMM = 1'b0;
-    assign WriteFFLAGSM = 1'b0;
+    assign SetOrWriteFFLAGSM = 1'b0;
   end
   
   if (P.ZICNTR_SUPPORTED) begin:counters

--- a/src/privileged/csrsr.sv
+++ b/src/privileged/csrsr.sv
@@ -34,7 +34,7 @@ module csrsr import cvw::*;  #(parameter cvw_t P) (
   input  logic              TrapM, FRegWriteM,
   input  logic [1:0]        NextPrivilegeModeM, PrivilegeModeW,
   input  logic              mretM, sretM, 
-  input  logic              WriteFRMM, WriteFFLAGSM,
+  input  logic              WriteFRMM, SetOrWriteFFLAGSM,
   input  logic [P.XLEN-1:0] CSRWriteValM,
   input  logic              SelHPTW,
   output logic [P.XLEN-1:0] MSTATUS_REGW, SSTATUS_REGW, MSTATUSH_REGW,
@@ -209,6 +209,6 @@ module csrsr import cvw::*;  #(parameter cvw_t P) (
         STATUS_SPIE     <= P.S_SUPPORTED & CSRWriteValM[5];
         STATUS_SIE      <= P.S_SUPPORTED & CSRWriteValM[1];
         STATUS_UBE      <= CSRWriteValM[6] & P.U_SUPPORTED & P.BIGENDIAN_SUPPORTED;
-      end else if (FRegWriteM | WriteFRMM | WriteFFLAGSM) STATUS_FS_INT <= 2'b11; 
+      end else if (FRegWriteM | WriteFRMM | SetOrWriteFFLAGSM) STATUS_FS_INT <= 2'b11; 
     end
 endmodule

--- a/src/privileged/csru.sv
+++ b/src/privileged/csru.sv
@@ -37,7 +37,7 @@ module csru import cvw::*;  #(parameter cvw_t P) (
   output logic [P.XLEN-1:0] CSRUReadValM,  
   input  logic [4:0]        SetFflagsM,
   output logic [2:0]        FRM_REGW,
-  output logic              WriteFRMM, WriteFFLAGSM,
+  output logic              WriteFRMM, SetOrWriteFFLAGSM,
   output logic              IllegalCSRUAccessM
 );
 
@@ -48,7 +48,7 @@ module csru import cvw::*;  #(parameter cvw_t P) (
   logic [4:0]               FFLAGS_REGW;
   logic [2:0]               NextFRMM;
   logic [4:0]               NextFFLAGSM;
-  logic                     SetOrWriteFFLAGSM;
+  logic                     WriteFFLAGSM;
   
   // Write enables
   assign WriteFRMM    = CSRUWriteM & (STATUS_FS != 2'b00) & (CSRAdrM == FRM | CSRAdrM == FCSR);


### PR DESCRIPTION
Also addressed Issue 886 about setting FS.  Configured imperas.ic to use rvfs_write_nz to update FS to dirty when a write sets any of the FP status flags.  Not yet tested against ImperasDV.