### PR TITLE
FPGA Makefile refactoring

### DIFF
--- a/fpga/generator/Makefile
+++ b/fpga/generator/Makefile
@@ -1,43 +1,42 @@
 dst := IP
 
-# vcu118
-# export XILINX_PART := xcvu9p-flga2104-2L-e
-# export XILINX_BOARD := xilinx.com:vcu118:part0:2.4
-# export board := vcu118
+all: ArtyA7
 
-# vcu108
-# export XILINX_PART := xcvu095-ffva2104-2-e
-# export XILINX_BOARD := xilinx.com:vcu108:part0:1.7
-# export board := vcu108
+.PHONY: ArtyA7 vcu118 vcu108
 
-# Arty A7
-export XILINX_PART := xc7a100tcsg324-1
-export XILINX_BOARD := digilentinc.com:arty-a7-100:part0:1.1
-export board := ArtyA7
+ArtyA7: export XILINX_PART := xc7a100tcsg324-1
+ArtyA7: export XILINX_BOARD := digilentinc.com:arty-a7-100:part0:1.1
+ArtyA7: export board := ArtyA7
+ArtyA7: FPGA_Arty
 
-# for Arty A7 and S7 boards
-all: FPGA_Arty
+vcu118: export XILINX_PART := xcvu9p-flga2104-2L-e
+vcu118: export XILINX_BOARD := xilinx.com:vcu118:part0:2.4
+vcu118: export board := vcu118
+vcu118: FPGA_VCU
 
-# VCU 108 and VCU 118 boards
-#all: FPGA_VCU
+vcu108: export XILINX_PART := xcvu095-ffva2104-2-e
+vcu108: export XILINX_BOARD := xilinx.com:vcu108:part0:1.7
+vcu108: export board := vcu108
+vcu108: FPGA_VCU
 
+.PHONY: FPGA_Arty FPGA_VCU
 FPGA_Arty: PreProcessFiles IP_Arty
 	vivado -mode tcl -source wally.tcl 2>&1 | tee wally.log
-
 FPGA_VCU: PreProcessFiles IP_VCU
 	vivado -mode tcl -source wally.tcl 2>&1 | tee wally.log
 
+# Generate IP Blocks
+.PHONY: IP_Arty IP_VCU
 IP_VCU: $(dst)/xlnx_proc_sys_reset.log \
-	$(dst)/xlnx_ddr4-$(board).log \
+	MEM_VCU \
 	$(dst)/xlnx_axi_clock_converter.log \
 	$(dst)/xlnx_ahblite_axi_bridge.log \
 	$(dst)/xlnx_axi_crossbar.log \
 	$(dst)/xlnx_axi_dwidth_conv_32to64.log \
 	$(dst)/xlnx_axi_dwidth_conv_64to32.log \
 	$(dst)/xlnx_axi_prtcl_conv.log
-
 IP_Arty: $(dst)/xlnx_proc_sys_reset.log \
-	$(dst)/xlnx_ddr3-$(board).log \
+	MEM_Arty \
 	$(dst)/xlnx_mmcm.log \
 	$(dst)/xlnx_axi_clock_converter.log \
 	$(dst)/xlnx_ahblite_axi_bridge.log
@@ -46,7 +45,15 @@ IP_Arty: $(dst)/xlnx_proc_sys_reset.log \
 #$(dst)/xlnx_axi_dwidth_conv_64to32.log \
 #$(dst)/xlnx_axi_prtcl_conv.log
 
+# Generate Memory IP Blocks
+.PHONY: MEM_VCU MEM_Arty
+MEM_VCU:
+	$(MAKE) $(dst)/xlnx_ddr4-$(board).log
+MEM_Arty:
+	$(MAKE) $(dst)/xlnx_ddr3-$(board).log
 
+# Copy files and make necessary modifications
+.PHONY: PreProcessFiles
 PreProcessFiles:
 	$(MAKE) -C ../../sim deriv
 	rm -rf ../src/CopiedFiles_do_not_add_to_repo/
@@ -63,18 +70,24 @@ PreProcessFiles:
 	sed -i 's/$$WALLY/\.\.\/\.\.\/\.\.\//g' ../src/CopiedFiles_do_not_add_to_repo/generic/mem/rom1p1r.sv
 	sed -i 's/$$WALLY/\.\.\/\.\.\/\.\.\//g' ../src/CopiedFiles_do_not_add_to_repo/generic/mem/ram1p1rwbe.sv
 
+# Generate Individual IP Blocks
 $(dst)/%.log: %.tcl
 	mkdir -p IP
 	cd IP;\
 	vivado -mode batch -source ../$*.tcl | tee $*.log
 
+# Clean
+.PHONY: cleanIP cleanLogs cleanFPGA cleanAll
 cleanIP:
 	rm -rf IP
-
 cleanLogs:
 	rm -rf  *.jou *.log
-
 cleanFPGA:
 	rm -rf WallyFPGA.* reports sim .Xil
-
 cleanAll: cleanIP cleanLogs cleanFPGA
+
+# Aliases
+.PHONY: arty artya7 VCU118 VCU108
+arty artya7: ArtyA7
+VCU118: vcu118
+VCU108: vcu108


### PR DESCRIPTION
@ross144 If you're interested, this new version of the makefile allows you to run make for the different FPGA boards without having to comment out a variety of different lines. You can either just change the `all` target to point at the board you want or run `make [ArtyA7|vcu108|vcu118]` directly from the command line to compile for a specific board. I've kept the default board as the ArtyA7.