### PR TITLE
Set RISCOF jobs based on number of cores

### DIFF
--- a/tests/riscof/Makefile
+++ b/tests/riscof/Makefile
@@ -6,6 +6,7 @@ arch_workdir = $(work)/riscv-arch-test
 wally_workdir = $(work)/wally-riscv-arch-test
 custom_test_dir = ../../addins/cvw-arch-verif/test
 submodule_work_dir = ../../addins/cvw-arch-verif/riscof_work
+nproc = $(shell nproc --ignore=1)
 
 current_dir = $(shell pwd)
 #XLEN    ?= 64
@@ -21,9 +22,9 @@ root:
 	mkdir -p $(work)
 	mkdir -p $(arch_workdir)
 	mkdir -p $(wally_workdir)
-	sed 's,{0},$(current_dir),g;s,{1},32gc,g' config.ini > config32.ini
-	sed 's,{0},$(current_dir),g;s,{1},64gc,g' config.ini > config64.ini
-	sed 's,{0},$(current_dir),g;s,{1},32e,g' config.ini > config32e.ini
+	sed 's,{0},$(current_dir),g;s,{1},32gc,g;s,{2},$(nproc),g' config.ini > config32.ini
+	sed 's,{0},$(current_dir),g;s,{1},64gc,g;s,{2},$(nproc),g' config.ini > config64.ini
+	sed 's,{0},$(current_dir),g;s,{1},32e,g;s,{2},$(nproc),g' config.ini > config32e.ini
 
 arch32e:
 	riscof run --work-dir=$(work_dir) --config=config32e.ini --suite=$(arch_dir)/riscv-test-suite/ --env=$(arch_dir)/riscv-test-suite/env --no-browser

--- a/tests/riscof/config.ini
+++ b/tests/riscof/config.ini
@@ -10,8 +10,8 @@ ispec={0}/spike/spike_rv{1}_isa.yaml
 pspec={0}/spike/spike_platform.yaml
 target_run=1
 # Optional as mentioned in https://riscof.readthedocs.io/en/latest/inputs.html#config-ini-syntax
-jobs=4
+jobs={2}
 
 [sail_cSim]
 pluginpath={0}/sail_cSim
-jobs=4
+jobs={2}


### PR DESCRIPTION
Automatically scale number of RISCOF jobs based on system core count. On chips this results in a 2x speedup from 12 minutes down to 6 for riscof.