### PR TITLE
Adding regression for RVVI FC 

### DIFF
--- a/sim/Makefile
+++ b/sim/Makefile
@@ -38,6 +38,14 @@ QuestaFunctCoverage: ${SIM}/questa/fcov_ucdb/rv64gc_WALLY-COV-add.elf.ucdb
 	vcover report ${SIM}/questa/fcov_ucdb/fcov.ucdb -details -cvg | egrep "Coverpoint|Covergroup|Cross|TYPE"  > ${SIM}/questa/fcov/fcov.summary.log
 	grep "TOTAL COVERGROUP COVERAGE" ${SIM}/questa/fcov/fcov.log
 
+QuestaFunctCoverageRvvi: ${WALLY}/addins/cvw-arch-verif/work/rv64gc_arch64i.ucdb 
+	vcover merge -out ${SIM}/questa/fcovrvvi_ucdb/fcovrvvi.ucdb ${WALLY}/addins/cvw-arch-verif/work/rv64gc_arch64i.ucdb ${WALLY}/addins/cvw-arch-verif/work/rv64gc_*.ucdb -logfile ${SIM}/questa/fcovrvvi/log
+	vcover report -details -html ${SIM}/questa/fcovrvvi_ucdb/fcovrvvi.ucdb
+	vcover report ${SIM}/questa/fcovrvvi_ucdb/fcovrvvi.ucdb -details -cvg > ${SIM}/questa/fcovrvvi/fcovrvvi.log
+	vcover report ${SIM}/questa/fcovrvvi_ucdb/fcovrvvi.ucdb -testdetails -cvg > ${SIM}/questa/fcovrvvi/fcovrvvi.testdetails.log
+	vcover report ${SIM}/questa/fcovrvvi_ucdb/fcovrvvi.ucdb -details -cvg | egrep "Coverpoint|Covergroup|Cross|TYPE"  > ${SIM}/questa/fcovrvvi/fcovrvvi.summary.log
+	grep "TOTAL COVERGROUP COVERAGE" ${SIM}/questa/fcovrvvi/fcovrvvi.log
+
 imperasdv_cov:
 	touch ${SIM}/seed0.txt
 	echo "0" > ${SIM}/seed0.txt

--- a/tests/riscof/Makefile
+++ b/tests/riscof/Makefile
@@ -4,8 +4,6 @@ work_dir = ./riscof_work
 work = ./work
 arch_workdir = $(work)/riscv-arch-test
 wally_workdir = $(work)/wally-riscv-arch-test
-custom_test_dir = ../../addins/cvw-arch-verif/test
-submodule_work_dir = ../../addins/cvw-arch-verif/riscof_work
 nproc = $(shell nproc --ignore=1)
 
 current_dir = $(shell pwd)
@@ -14,8 +12,6 @@ current_dir = $(shell pwd)
 all: root arch32 wally32 arch32e arch64 wally64
 
 wally-riscv-arch-test: root wally64 wally32
-
-custom: new_test
 
 root:
 	mkdir -p $(work_dir)
@@ -54,9 +50,6 @@ wally64:
 quad64:
 	riscof run --work-dir=$(work_dir) --config=config64.ini --suite=$(wally_dir)/riscv-test-suite/rv64i_m/Q/riscv-ctg/tests/ --env=$(wally_dir)/riscv-test-suite/env
 	
-new_test:
-	riscof run --work-dir=$(submodule_work_dir) --config=config64.ini --suite=$(custom_test_dir)/ --env=$(wally_dir)/riscv-test-suite/env --no-browser
-
 #wally32e:
 #	riscof run --work-dir=$(work_dir) --config=config32e.ini --suite=$(wally_dir)/riscv-test-suite/ --env=$(wally_dir)/riscv-test-suite/env --no-browser --no-dut-run
 #	rsync -a $(work_dir)/rv32i_m/ $(wally_workdir)/rv32i_m/ || echo "error suppressed"


### PR DESCRIPTION
Removed custom tests from riscof Makefile as it was no longer needed (All tests will run on Imperas)
Updated sim/Makefile to add RVVI FC regression commands
Updated cvw-arch-verif submodule