### PR TITLE
Fixed basic support for open source riscvISACOV

### DIFF
--- a/bin/wsim
+++ b/bin/wsim
@@ -81,8 +81,13 @@ if (args.rvvi):
 # if lockstep is enabled, then we need to pass the Imperas lockstep arguments
 if(int(args.locksteplog) >= 1): EnableLog = 1
 else: EnableLog = 0
-if (args.lockstep):
+if((args.lockstep or args.fcov or args.fcov2) and args.sim == "questa"):
     prefix = "IMPERAS_TOOLS=" + WALLY + "/config/"+args.config+"/imperas.ic"
+    prefix = "MTI_VCO_MODE=64 " + prefix
+else:
+    prefix = ""
+
+if (args.lockstep):
     if(args.locksteplog != 0): ImperasPlusArgs = " +IDV_TRACE2LOG=" + str(EnableLog) + " +IDV_TRACE2LOG_AFTER=" + str(args.locksteplog) 
     else: ImperasPlusArgs = ""
     if(args.fcov):
@@ -101,13 +106,10 @@ if (args.lockstep):
         CovEnableStr = ""
         suffix = "--lockstep"
 else:
-    prefix = ""
     ImperasPlusArgs = ""
     suffix = ""
 flags = suffix + " " + ImperasPlusArgs
 
-if((args.lockstep or args.fcov) and args.sim == "questa"):
-    prefix = "MTI_VCO_MODE=64 " + prefix
 
 # other flags
 if (args.ccov):

--- a/sim/questa/wally.do
+++ b/sim/questa/wally.do
@@ -152,13 +152,13 @@ if {$FunctCoverageIndex >= 0} {
 set FunctCoverageIndex2 [lsearch -exact $lst "--fcov2"]
 if {$FunctCoverageIndex2 >= 0} {
     set FunctCoverage 1
-    set riscvISACOVsrc +incdir+$env(IMPERAS_HOME)/ImpProprietary/source/host/riscvISACOV/source
+    set riscvISACOVsrc +incdir+$env(WALLY)/addins/riscvISACOV/source
 
     set FCdefineINCLUDE_TRACE2COV "+define+INCLUDE_TRACE2COV"
-    set FCdefineCOVER_BASE_RV64I "+define+COVER_BASE_RV64I"
+    set FCdefineCOVER_BASE_RV64I "+define+COVER_BASE_RV32I"
     set FCdefineCOVER_LEVEL_DV_PR_EXT  "+define+COVER_LEVEL_DV_PR_EXT"
     # Uncomment various cover statements below to control which extensions get functional coverage
-    set FCdefineCOVER_RV64I "+define+COVER_RV64I"
+    set FCdefineCOVER_RV64I "+define+COVER_RV32I"
     #set FCdefineCOVER_RV64M "+define+COVER_RV64M"
     #set FCdefineCOVER_RV64A "+define+COVER_RV64A"
     #set FCdefineCOVER_RV64F "+define+COVER_RV64F"


### PR DESCRIPTION
The open source riscvISACOV now works when running the --fcov2 flag.