### PR TITLE
fix some missing hard-coded paths #647

### DIFF
--- a/bin/fparchtest.sh
+++ b/bin/fparchtest.sh
@@ -13,8 +13,6 @@
 # pip3 install git+https://github.com/riscv/riscv-isac.git
 # Put ~/.local/bin in $PATH to find riscv_isac and riscv_ctg
 
-RISCVCTG=/home/harris/repos/riscv-ctg
-
 #riscv_isac --verbose debug  normalize -c $RISCVCTG/sample_cgfs/dataset.cgf -c $RISCVCTG/sample_cgfs/sample_cgfs_fext/RV32F/fadd.s.cgf -o $RISCVCTG/tests/normalizedfadd.cgf -x 32
 #riscv_isac --verbose debug  normalize -c $RISCVCTG/sample_cgfs/dataset.cgf -c $RISCVCTG/sample_cgfs/sample_cgfs_fext/RV32H/fadd_b1.s.cgf -o $RISCVCTG/tests/normalizedfadd16_b1.cgf -x 32
 riscv_ctg -cf $RISCVCTG/tests/normalizedfadd16_b1.cgf -d $RISCVCTG/tests --base-isa rv32i --verbose debug

--- a/fpga/generator/wave_config.wcfg
+++ b/fpga/generator/wave_config.wcfg
@@ -3,7 +3,7 @@
    <wave_state>
    </wave_state>
    <db_ref_list>
-      <db_ref path="/home/ross/repos/active/cvw/fpga/generator/WallyFPGA.hw/hw_1/wave/hw_ila_data_1/hw_ila_data_1.wdb" id="1">
+      <db_ref>
          <top_modules>
          </top_modules>
       </db_ref>

--- a/linux/buildroot-packages/fpga-axi-sdc/fpga-axi-sdc.mk~
+++ b/linux/buildroot-packages/fpga-axi-sdc/fpga-axi-sdc.mk~
@@ -1,7 +1,0 @@
-FPGA_AXI_SDC_MODULE_VERSION = 1.0
-FPGA_AXI_SDC_SITE = /home/jpease/repos/fpga-axi-sdc
-FPGA_AXI_SDC_SITE_METHOD = local
-FPGA_AXI_SDC_LICENSE = GPLv2
-
-$(eval $(kernel-module))
-$(eval $(generic-package))

--- a/site-setup.sh
+++ b/site-setup.sh
@@ -30,6 +30,10 @@ export SYN_MW=/home/jstine/MW
 export SYN_memory=/home/jstine/WallyMem/rv64gc/
 #export osumemory=/import/yukari1/pdk/TSMC/WallyMem/rv64gc/
 
+# Environmental variables for FPGA
+export RISCVCTG=/home/harris/repos/riscv-ctg
+
+
 # GCC
 if [ -z "$LD_LIBRARY_PATH" ]; then
     export LD_LIBRARY_PATH=$RISCV/riscv64-unknown-elf/lib

--- a/site-setup.sh
+++ b/site-setup.sh
@@ -30,7 +30,7 @@ export SYN_MW=/home/jstine/MW
 export SYN_memory=/home/jstine/WallyMem/rv64gc/
 #export osumemory=/import/yukari1/pdk/TSMC/WallyMem/rv64gc/
 
-# Environmental variables for FPGA
+# Environmental variables for CTG (https://github.com/riscv-software-src/riscv-ctg)
 export RISCVCTG=/home/harris/repos/riscv-ctg
 
 


### PR DESCRIPTION
delete some more hard coded items - left RISCVCTG as is in terms of name as its pretty generic.  Put into site-setup.sh 