### PR TITLE
Pin GCC to 13.2.0 to avoid GCC 14 issue with Q extension

### DIFF
--- a/bin/wally-tool-chain-install.sh
+++ b/bin/wally-tool-chain-install.sh
@@ -208,9 +208,10 @@ fi
 section_header "Installing/Updating RISC-V GNU Toolchain"
 STATUS="RISC-V GNU Toolchain"
 cd "$RISCV"
-if git_check "riscv-gnu-toolchain" "https://github.com/riscv/riscv-gnu-toolchain" "$RISCV/riscv-gnu-toolchain/stamps/build-gcc-newlib-stage2"; then
+# Temporarily pin riscv-gnu-toolchain to use GCC 13.2.0. GCC 14 does not work with the Q extension.
+if git_check "riscv-gnu-toolchain" "https://github.com/riscv/riscv-gnu-toolchain" "$RISCV/riscv-gnu-toolchain/stamps/build-gcc-newlib-stage2" "b488ddb"; then
     cd riscv-gnu-toolchain
-    git reset --hard && git clean -f && git checkout master && git pull
+    git reset --hard && git clean -f && git checkout b488ddb #&& git pull
     ./configure --prefix="${RISCV}" --with-multilib-generator="rv32e-ilp32e--;rv32i-ilp32--;rv32im-ilp32--;rv32iac-ilp32--;rv32imac-ilp32--;rv32imafc-ilp32f--;rv32imafdc-ilp32d--;rv64i-lp64--;rv64ic-lp64--;rv64iac-lp64--;rv64imac-lp64--;rv64imafdc-lp64d--;rv64im-lp64--;"
     make -j "${NUM_THREADS}" 2>&1 | logger riscv-gnu-toolchain; [ "${PIPESTATUS[0]}" == 0 ]
     if [ "$clean" ]; then


### PR DESCRIPTION
Pin `riscv-gnu-toolchain` as temporary fix for #967