### PR TITLE
Install Sail from binary (No more Opam!)

### DIFF
--- a/bin/wally-package-install.sh
+++ b/bin/wally-package-install.sh
@@ -55,10 +55,9 @@ if [ "$FAMILY" == rhel ]; then
     SPIKE_PACKAGES+=(dtc boost-regex boost-system)
     VERILATOR_PACKAGES+=(help2man perl clang ccache gperftools numactl mold)
     BUILDROOT_PACKAGES+=(ncurses-base ncurses ncurses-libs ncurses-devel gcc-gfortran cpio) # gcc-gfortran is only needed for compiling spec benchmarks on buildroot linux
-    # Extra packages not availale in rhel8, nice for Verilator and needed for sail respectively
+    # Extra packages not availale in rhel8, nice for Verilator
     if (( RHEL_VERSION >= 9 )); then
         VERILATOR_PACKAGES+=(perl-doc)
-        SAIL_PACKAGES=(z3)
     fi
     # A newer version of gcc is required for qemu
     OTHER_PACKAGES=(gcc-toolset-13)
@@ -80,7 +79,6 @@ elif [ "$FAMILY" == ubuntu ]; then
     QEMU_PACKAGES+=(libfdt-dev libpixman-1-dev)
     SPIKE_PACKAGES+=(device-tree-compiler libboost-regex-dev libboost-system-dev)
     VERILATOR_PACKAGES+=(help2man perl g++ clang ccache libunwind-dev libgoogle-perftools-dev numactl perl-doc libfl2 libfl-dev zlib1g)
-    SAIL_PACKAGES+=(z3)
     BUILDROOT_PACKAGES+=(ncurses-base ncurses-bin libncurses-dev gfortran cpio) # gfortran is only needed for compiling spec benchmarks on buildroot linux
     VIVADO_PACKAGES+=(libncurses*) # Vivado hangs on the third stage of installation without this
 fi
@@ -90,11 +88,11 @@ fi
 if [ "${1}" == "--check" ]; then
     section_header "Checking Dependencies from Package Manager"
     if [ "$FAMILY" == rhel ]; then
-        for pack in "${GENERAL_PACKAGES[@]}" "${GNU_PACKAGES[@]}" "${QEMU_PACKAGES[@]}" "${SPIKE_PACKAGES[@]}" "${VERILATOR_PACKAGES[@]}" "${SAIL_PACKAGES[@]}" "${BUILDROOT_PACKAGES[@]}" "${OTHER_PACKAGES[@]}"; do
+        for pack in "${GENERAL_PACKAGES[@]}" "${GNU_PACKAGES[@]}" "${QEMU_PACKAGES[@]}" "${SPIKE_PACKAGES[@]}" "${VERILATOR_PACKAGES[@]}" "${BUILDROOT_PACKAGES[@]}" "${OTHER_PACKAGES[@]}"; do
             rpm -q "$pack" > /dev/null || (echo -e "${FAIL_COLOR}Missing packages detected (${WARNING_COLOR}$pack${FAIL_COLOR}). Run as root to auto-install or run wally-package-install.sh first.${ENDC}" && exit 1)
         done
     elif [ "$FAMILY" == ubuntu ]; then
-        for pack in "${GENERAL_PACKAGES[@]}" "${GNU_PACKAGES[@]}" "${QEMU_PACKAGES[@]}" "${SPIKE_PACKAGES[@]}" "${VERILATOR_PACKAGES[@]}" "${SAIL_PACKAGES[@]}" "${BUILDROOT_PACKAGES[@]}" "${OTHER_PACKAGES[@]}"; do
+        for pack in "${GENERAL_PACKAGES[@]}" "${GNU_PACKAGES[@]}" "${QEMU_PACKAGES[@]}" "${SPIKE_PACKAGES[@]}" "${VERILATOR_PACKAGES[@]}" "${BUILDROOT_PACKAGES[@]}" "${OTHER_PACKAGES[@]}"; do
             dpkg -l "$pack" | grep "ii" > /dev/null || (echo -e "${FAIL_COLOR}Missing packages detected (${WARNING_COLOR}$pack${FAIL_COLOR}). Run as root to auto-install or run wally-package-install.sh first." && exit 1)
         done
     fi
@@ -124,6 +122,6 @@ else
     # Update and Upgrade tools
     eval "$UPDATE_COMMAND"
     # Install packages listed above using appropriate package manager
-    sudo $PACKAGE_MANAGER install -y "${GENERAL_PACKAGES[@]}" "${GNU_PACKAGES[@]}" "${QEMU_PACKAGES[@]}" "${SPIKE_PACKAGES[@]}" "${VERILATOR_PACKAGES[@]}" "${SAIL_PACKAGES[@]}" "${BUILDROOT_PACKAGES[@]}" "${OTHER_PACKAGES[@]}" "${VIVADO_PACKAGES[@]}"
+    sudo $PACKAGE_MANAGER install -y "${GENERAL_PACKAGES[@]}" "${GNU_PACKAGES[@]}" "${QEMU_PACKAGES[@]}" "${SPIKE_PACKAGES[@]}" "${VERILATOR_PACKAGES[@]}" "${BUILDROOT_PACKAGES[@]}" "${OTHER_PACKAGES[@]}" "${VIVADO_PACKAGES[@]}"
     echo -e "${SUCCESS_COLOR}Packages successfully installed.${ENDC}"
 fi

--- a/bin/wally-package-install.sh
+++ b/bin/wally-package-install.sh
@@ -80,7 +80,7 @@ elif [ "$FAMILY" == ubuntu ]; then
     QEMU_PACKAGES+=(libfdt-dev libpixman-1-dev)
     SPIKE_PACKAGES+=(device-tree-compiler libboost-regex-dev libboost-system-dev)
     VERILATOR_PACKAGES+=(help2man perl g++ clang ccache libunwind-dev libgoogle-perftools-dev numactl perl-doc libfl2 libfl-dev zlib1g)
-    SAIL_PACKAGES+=(opam z3)
+    SAIL_PACKAGES+=(z3)
     BUILDROOT_PACKAGES+=(ncurses-base ncurses-bin libncurses-dev gfortran cpio) # gfortran is only needed for compiling spec benchmarks on buildroot linux
     VIVADO_PACKAGES+=(libncurses*) # Vivado hangs on the third stage of installation without this
 fi

--- a/bin/wally-tool-chain-install.sh
+++ b/bin/wally-tool-chain-install.sh
@@ -317,9 +317,7 @@ fi
 # Sail is a formal specification language designed for describing the semantics of an ISA.
 # It is used to generate the RISC-V Sail Model, which is the golden reference model for RISC-V.
 # The Sail Compiler is written in OCaml, which is an object-oriented extension of ML, which in turn
-# is a functional programming language suited to formal verification. The Sail compiler is installed
-# with the opam OCaml package manager. It has so many dependencies that it can be difficult to install,
-# but a binary release of it should be available soon, removing the need to use opam.
+# is a functional programming language suited to formal verification.
 section_header "Installing/Updating Sail Compiler"
 STATUS="Sail Compiler"
 if [ ! -e "$RISCV"/bin/sail ]; then
@@ -336,7 +334,6 @@ STATUS="RISC-V Sail Model"
 if git_check "sail-riscv" "https://github.com/riscv/sail-riscv.git" "$RISCV/bin/riscv_sim_RV32"; then
     cd sail-riscv
     git reset --hard && git clean -f && git checkout master && git pull
-    export OPAMCLI=2.0  # Sail is not compatible with opam 2.1 as of 4/16/24
     ARCH=RV64 make -j "${NUM_THREADS}" c_emulator/riscv_sim_RV64  2>&1 | logger sailModel; [ "${PIPESTATUS[0]}" == 0 ]
     ARCH=RV32 make -j "${NUM_THREADS}" c_emulator/riscv_sim_RV32 2>&1 | logger sailModel; [ "${PIPESTATUS[0]}" == 0 ]
     cp -f c_emulator/riscv_sim_RV64 "$RISCV"/bin/riscv_sim_RV64
@@ -344,7 +341,6 @@ if git_check "sail-riscv" "https://github.com/riscv/sail-riscv.git" "$RISCV/bin/
     if [ "$clean" ]; then
         cd "$RISCV"
         rm -rf sail-riscv
-        rm -rf opam
     fi
     echo -e "${SUCCESS_COLOR}RISC-V Sail Model successfully installed/updated!${ENDC}"
 else

--- a/bin/wally-tool-chain-install.sh
+++ b/bin/wally-tool-chain-install.sh
@@ -347,14 +347,21 @@ fi
 # but a binary release of it should be available soon, removing the need to use opam.
 section_header "Installing/Updating Sail Compiler"
 STATUS="Sail Compiler"
-export OPAMROOTISOK=1 # Silence warnings about running opam as root
-export OPAMROOT="$RISCV"/opam
-cd "$RISCV"
-opam init -y --disable-sandboxing --no-setup --compiler=5.1.0
-eval "$(opam config env)"
-opam update -y
-opam upgrade -y
-opam install sail -y
+if [ ! -e "$RISCV"/bin/sail ]; then
+    cd "$RISCV"
+    rm -rf sail
+    wget https://github.com/rems-project/sail/releases/latest/download/sail.tar.gz
+    tar -xf sail.tar.gz
+    rm sail.tar.gz
+    cd sail
+    cp bin/* "$RISCV"/bin
+    cp share/* "$RISCV"/share
+    if [ "$clean" ]; then
+        cd "$RISCV"
+        rm -rf sail
+    fi
+    echo -e "${SUCCESS_COLOR}gmp successfully installed!${ENDC}"
+fi
 echo -e "${SUCCESS_COLOR}Sail Compiler successfully installed/updated!${ENDC}"
 
 # RISC-V Sail Model (https://github.com/riscv/sail-riscv)

--- a/bin/wally-tool-chain-install.sh
+++ b/bin/wally-tool-chain-install.sh
@@ -324,7 +324,7 @@ section_header "Installing/Updating Sail Compiler"
 STATUS="Sail Compiler"
 if [ ! -e "$RISCV"/bin/sail ]; then
     cd "$RISCV"
-    curl --location https://github.com/rems-project/sail/releases/latest/download/sail.tar.gz | tar xvz --directory="$RISCV"
+    curl --location https://github.com/rems-project/sail/releases/latest/download/sail.tar.gz | tar xvz --directory="$RISCV" --strip-components=1
     echo -e "${SUCCESS_COLOR}gmp successfully installed!${ENDC}"
 fi
 echo -e "${SUCCESS_COLOR}Sail Compiler successfully installed/updated!${ENDC}"

--- a/bin/wally-tool-chain-install.sh
+++ b/bin/wally-tool-chain-install.sh
@@ -161,15 +161,13 @@ if (( RHEL_VERSION == 8 )) || (( UBUNTU_VERSION == 20 )); then
         section_header "Installing glib"
         pip install -U meson # Meson is needed to build glib
         cd "$RISCV"
-        wget https://download.gnome.org/sources/glib/2.70/glib-2.70.5.tar.xz
-        tar -xJf glib-2.70.5.tar.xz
-        rm glib-2.70.5.tar.xz
-        cd glib-2.70.5
+        curl --location https://download.gnome.org/sources/glib/2.70/glib-2.70.5.tar.xz | tar xJf --directory="glib"
+        cd glib
         meson setup _build --prefix="$RISCV"
         meson compile -C _build
         meson install -C _build
         cd "$RISCV"
-        rm -rf glib-2.70.5
+        rm -rf glib
         echo -e "${SUCCESS_COLOR}glib successfully installed!${ENDC}"
     fi
 fi
@@ -180,15 +178,13 @@ if (( RHEL_VERSION == 8 )); then
     if [ ! -e "$RISCV"/include/gmp.h ]; then
         section_header "Installing gmp"
         cd "$RISCV"
-        wget https://ftp.gnu.org/gnu/gmp/gmp-6.3.0.tar.xz
-        tar -xJf gmp-6.3.0.tar.xz
-        rm gmp-6.3.0.tar.xz
-        cd gmp-6.3.0
+        curl --location https://ftp.gnu.org/gnu/gmp/gmp-6.3.0.tar.xz | tar xJf --directory="gmp"
+        cd gmp
         ./configure --prefix="$RISCV"
         make -j "${NUM_THREADS}"
         make install
         cd "$RISCV"
-        rm -rf gmp-6.3.0
+        rm -rf gmp
         echo -e "${SUCCESS_COLOR}gmp successfully installed!${ENDC}"
     fi
 fi
@@ -328,17 +324,7 @@ section_header "Installing/Updating Sail Compiler"
 STATUS="Sail Compiler"
 if [ ! -e "$RISCV"/bin/sail ]; then
     cd "$RISCV"
-    rm -rf sail
-    wget https://github.com/rems-project/sail/releases/latest/download/sail.tar.gz
-    tar -xf sail.tar.gz
-    rm sail.tar.gz
-    cd sail
-    cp -r bin/* "$RISCV"/bin
-    cp -r share/* "$RISCV"/share
-    if [ "$clean" ]; then
-        cd "$RISCV"
-        rm -rf sail
-    fi
+    curl --location https://github.com/rems-project/sail/releases/latest/download/sail.tar.gz | tar xvz --directory="$RISCV"
     echo -e "${SUCCESS_COLOR}gmp successfully installed!${ENDC}"
 fi
 echo -e "${SUCCESS_COLOR}Sail Compiler successfully installed/updated!${ENDC}"

--- a/bin/wally-tool-chain-install.sh
+++ b/bin/wally-tool-chain-install.sh
@@ -161,13 +161,13 @@ if (( RHEL_VERSION == 8 )) || (( UBUNTU_VERSION == 20 )); then
         section_header "Installing glib"
         pip install -U meson # Meson is needed to build glib
         cd "$RISCV"
-        curl --location https://download.gnome.org/sources/glib/2.70/glib-2.70.5.tar.xz | tar xJf --directory="glib"
-        cd glib
+        curl --location https://download.gnome.org/sources/glib/2.70/glib-2.70.5.tar.xz | tar xJf
+        cd glib-2.70.5
         meson setup _build --prefix="$RISCV"
         meson compile -C _build
         meson install -C _build
         cd "$RISCV"
-        rm -rf glib
+        rm -rf glib-2.70.5
         echo -e "${SUCCESS_COLOR}glib successfully installed!${ENDC}"
     fi
 fi
@@ -178,13 +178,13 @@ if (( RHEL_VERSION == 8 )); then
     if [ ! -e "$RISCV"/include/gmp.h ]; then
         section_header "Installing gmp"
         cd "$RISCV"
-        curl --location https://ftp.gnu.org/gnu/gmp/gmp-6.3.0.tar.xz | tar xJf --directory="gmp"
-        cd gmp
+        curl --location https://ftp.gnu.org/gnu/gmp/gmp-6.3.0.tar.xz | tar xJf
+        cd gmp-6.3.0
         ./configure --prefix="$RISCV"
         make -j "${NUM_THREADS}"
         make install
         cd "$RISCV"
-        rm -rf gmp
+        rm -rf gmp-6.3.0
         echo -e "${SUCCESS_COLOR}gmp successfully installed!${ENDC}"
     fi
 fi

--- a/bin/wally-tool-chain-install.sh
+++ b/bin/wally-tool-chain-install.sh
@@ -148,11 +148,6 @@ source "$RISCV"/riscv-python/bin/activate # activate python virtual environment
 STATUS="python packages"
 pip install --upgrade pip && pip install -r "$dir"/requirements.txt
 
-# z3 is needed for sail and not availabe from dnf for rhel 8
-if (( RHEL_VERSION == 8 )); then
-    pip install -U z3-solver
-fi
-
 source "$RISCV"/riscv-python/bin/activate # reload python virtual environment
 echo -e "${SUCCESS_COLOR}Python environment successfully configured!${ENDC}"
 

--- a/bin/wally-tool-chain-install.sh
+++ b/bin/wally-tool-chain-install.sh
@@ -322,22 +322,6 @@ else
 fi
 
 
-# Install opam from binary disribution on rhel as it is not available from dnf
-# Opam is needed to install the sail compiler
-if [ "$FAMILY" == rhel ]; then
-    section_header "Installing/Updating Opam"
-    STATUS="Opam"
-    export OPAMROOTISOK=1 # Silence warnings about running opam as root
-    cd "$RISCV"
-    mkdir -p opam
-    cd opam
-    wget https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh
-    printf '%s\n' "$RISCV"/bin Y | sh install.sh # the print command provides $RISCV/bin as the installation path when prompted
-    cd "$RISCV"
-    rm -rf opam
-    echo -e "${SUCCESS_COLOR}Opam successfully installed/updated!${ENDC}"
-fi
-
 # Sail Compiler (https://github.com/rems-project/sail)
 # Sail is a formal specification language designed for describing the semantics of an ISA.
 # It is used to generate the RISC-V Sail Model, which is the golden reference model for RISC-V.

--- a/bin/wally-tool-chain-install.sh
+++ b/bin/wally-tool-chain-install.sh
@@ -7,6 +7,7 @@
 ## Modified: 22 January 2023
 ## Modified: 23 March 2023
 ## Modified: 30 June 2024, Jordan Carlin jcarlin@hmc.edu
+## Modified: 1 September 2024
 ##
 ## Purpose: Open source tool chain installation script
 ##
@@ -161,7 +162,7 @@ if (( RHEL_VERSION == 8 )) || (( UBUNTU_VERSION == 20 )); then
         section_header "Installing glib"
         pip install -U meson # Meson is needed to build glib
         cd "$RISCV"
-        curl --location https://download.gnome.org/sources/glib/2.70/glib-2.70.5.tar.xz | tar xJf
+        curl --location https://download.gnome.org/sources/glib/2.70/glib-2.70.5.tar.xz | tar xJ
         cd glib-2.70.5
         meson setup _build --prefix="$RISCV"
         meson compile -C _build
@@ -178,7 +179,7 @@ if (( RHEL_VERSION == 8 )); then
     if [ ! -e "$RISCV"/include/gmp.h ]; then
         section_header "Installing gmp"
         cd "$RISCV"
-        curl --location https://ftp.gnu.org/gnu/gmp/gmp-6.3.0.tar.xz | tar xJf
+        curl --location https://ftp.gnu.org/gnu/gmp/gmp-6.3.0.tar.xz | tar xJ
         cd gmp-6.3.0
         ./configure --prefix="$RISCV"
         make -j "${NUM_THREADS}"

--- a/bin/wally-tool-chain-install.sh
+++ b/bin/wally-tool-chain-install.sh
@@ -333,8 +333,8 @@ if [ ! -e "$RISCV"/bin/sail ]; then
     tar -xf sail.tar.gz
     rm sail.tar.gz
     cd sail
-    cp bin/* "$RISCV"/bin
-    cp share/* "$RISCV"/share
+    cp -r bin/* "$RISCV"/bin
+    cp -r share/* "$RISCV"/share
     if [ "$clean" ]; then
         cd "$RISCV"
         rm -rf sail

--- a/bin/wally-tool-chain-install.sh
+++ b/bin/wally-tool-chain-install.sh
@@ -323,9 +323,10 @@ STATUS="Sail Compiler"
 if [ ! -e "$RISCV"/bin/sail ]; then
     cd "$RISCV"
     curl --location https://github.com/rems-project/sail/releases/latest/download/sail.tar.gz | tar xvz --directory="$RISCV" --strip-components=1
-    echo -e "${SUCCESS_COLOR}gmp successfully installed!${ENDC}"
+    echo -e "${SUCCESS_COLOR}Sail Compiler successfully installed/updated!${ENDC}"
+else
+    echo -e "${SUCCESS_COLOR}Sail Compiler already installed.${ENDC}"
 fi
-echo -e "${SUCCESS_COLOR}Sail Compiler successfully installed/updated!${ENDC}"
 
 # RISC-V Sail Model (https://github.com/riscv/sail-riscv)
 # The RISC-V Sail Model is the golden reference model for RISC-V. It is written in Sail (described above)


### PR DESCRIPTION
Install the Sail compiler directly from the binary release, avoiding the need for Opam entirely. Also simplify a few other aspects of the installation script.