### PR TITLE
Fix Installation

### DIFF
--- a/bin/requirements.txt
+++ b/bin/requirements.txt
@@ -1,8 +1,8 @@
 adjustText>=1.2
 lief>=0.14.1
 Markdown>=3.6
-#matplotlib>=3.9.0
-PyYAML>=5.2
+# matplotlib>=3.9.0
+# PyYAML>=5.2
 riscv-isac @ git+https://github.com/riscv-non-isa/riscv-arch-test/#subdirectory=riscv-isac
 riscof @ git+https://github.com/riscv/riscof.git
 riscv-config>=3.18.3

--- a/bin/requirements.txt
+++ b/bin/requirements.txt
@@ -4,6 +4,7 @@ Markdown>=3.6
 # matplotlib>=3.9.0
 # PyYAML>=5.2
 # riscv-isac @ git+https://github.com/riscv-non-isa/riscv-arch-test/#subdirectory=riscv-isac
+setuptools
 riscof @ git+https://github.com/riscv/riscof.git
 # riscv-config>=3.18.3
 riscv-isac>=0.18.0

--- a/bin/requirements.txt
+++ b/bin/requirements.txt
@@ -3,13 +3,12 @@ lief>=0.14.1
 Markdown>=3.6
 matplotlib>=3.9.0
 PyYAML>=5.2
-riscv-isac @ git+https://github.com/jordancarlin/riscv-arch-test/#subdirectory=riscv-isac
-setuptools
 riscof @ git+https://github.com/riscv/riscof.git
 riscv-config>=3.18.3
-riscv-isac>=0.18.0
+riscv-isac @ git+https://github.com/jordancarlin/riscv-arch-test/#subdirectory=riscv-isac
 scikit-learn>=1.5.0
 scipy>=1.13.0
+setuptools
 Sphinx>=7.3.7
 sphinx-rtd-theme>=2.0.0
 testresources>=2.0.1

--- a/bin/requirements.txt
+++ b/bin/requirements.txt
@@ -3,9 +3,9 @@ lief>=0.14.1
 Markdown>=3.6
 # matplotlib>=3.9.0
 # PyYAML>=5.2
-riscv-isac @ git+https://github.com/riscv-non-isa/riscv-arch-test/#subdirectory=riscv-isac
+# riscv-isac @ git+https://github.com/riscv-non-isa/riscv-arch-test/#subdirectory=riscv-isac
 riscof @ git+https://github.com/riscv/riscof.git
-riscv-config>=3.18.3
+# riscv-config>=3.18.3
 riscv-isac>=0.18.0
 scikit-learn>=1.5.0
 scipy>=1.13.0

--- a/bin/requirements.txt
+++ b/bin/requirements.txt
@@ -5,7 +5,7 @@ matplotlib>=3.9.0
 PyYAML>=5.2
 riscof @ git+https://github.com/riscv/riscof.git
 riscv-config>=3.18.3
-riscv-isac @ git+https://github.com/jordancarlin/riscv-arch-test/#subdirectory=riscv-isac
+riscv-isac @ git+https://github.com/riscv-non-isa/riscv-arch-test/#subdirectory=riscv-isac
 scikit-learn>=1.5.0
 scipy>=1.13.0
 setuptools

--- a/bin/requirements.txt
+++ b/bin/requirements.txt
@@ -9,6 +9,6 @@ riscv-config>=3.18.3
 riscv-isac>=0.18.0
 scikit-learn>=1.5.0
 scipy>=1.13.0
-Sphinx>=7.3.7
+# Sphinx>=7.3.7
 sphinx-rtd-theme>=2.0.0
 testresources>=2.0.1

--- a/bin/requirements.txt
+++ b/bin/requirements.txt
@@ -9,6 +9,6 @@ riscv-isac @ git+https://github.com/jordancarlin/riscv-arch-test/#subdirectory=r
 scikit-learn>=1.5.0
 scipy>=1.13.0
 setuptools
-Sphinx>=7.3.7
+Sphinx>=7.3.7, ~=7 # QEMU fails to build with Sphinx 8
 sphinx-rtd-theme>=2.0.0
 testresources>=2.0.1

--- a/bin/requirements.txt
+++ b/bin/requirements.txt
@@ -10,5 +10,5 @@ riscv-isac>=0.18.0
 scikit-learn>=1.5.0
 scipy>=1.13.0
 # Sphinx>=7.3.7
-sphinx-rtd-theme>=2.0.0
+# sphinx-rtd-theme>=2.0.0
 testresources>=2.0.1

--- a/bin/requirements.txt
+++ b/bin/requirements.txt
@@ -9,6 +9,6 @@ riscv-isac @ git+https://github.com/jordancarlin/riscv-arch-test/#subdirectory=r
 scikit-learn>=1.5.0
 scipy>=1.13.0
 setuptools
-Sphinx>=7.3.7; ~=7 # QEMU fails to build with Sphinx 8
+Sphinx~=7.3.7 # QEMU fails to build with Sphinx 8
 sphinx-rtd-theme>=2.0.0
 testresources>=2.0.1

--- a/bin/requirements.txt
+++ b/bin/requirements.txt
@@ -1,15 +1,15 @@
 adjustText>=1.2
 lief>=0.14.1
 Markdown>=3.6
-# matplotlib>=3.9.0
-# PyYAML>=5.2
-# riscv-isac @ git+https://github.com/riscv-non-isa/riscv-arch-test/#subdirectory=riscv-isac
+matplotlib>=3.9.0
+PyYAML>=5.2
+riscv-isac @ git+https://github.com/jordancarlin/riscv-arch-test/#subdirectory=riscv-isac
 setuptools
 riscof @ git+https://github.com/riscv/riscof.git
-# riscv-config>=3.18.3
+riscv-config>=3.18.3
 riscv-isac>=0.18.0
 scikit-learn>=1.5.0
 scipy>=1.13.0
-# Sphinx>=7.3.7
-# sphinx-rtd-theme>=2.0.0
+Sphinx>=7.3.7
+sphinx-rtd-theme>=2.0.0
 testresources>=2.0.1

--- a/bin/requirements.txt
+++ b/bin/requirements.txt
@@ -9,6 +9,6 @@ riscv-isac @ git+https://github.com/jordancarlin/riscv-arch-test/#subdirectory=r
 scikit-learn>=1.5.0
 scipy>=1.13.0
 setuptools
-Sphinx>=7.3.7, ~=7 # QEMU fails to build with Sphinx 8
+Sphinx>=7.3.7; ~=7 # QEMU fails to build with Sphinx 8
 sphinx-rtd-theme>=2.0.0
 testresources>=2.0.1

--- a/bin/requirements.txt
+++ b/bin/requirements.txt
@@ -1,7 +1,7 @@
 adjustText>=1.2
 lief>=0.14.1
 Markdown>=3.6
-matplotlib>=3.9.0
+#matplotlib>=3.9.0
 PyYAML>=5.2
 riscv-isac @ git+https://github.com/riscv-non-isa/riscv-arch-test/#subdirectory=riscv-isac
 riscof @ git+https://github.com/riscv/riscof.git

--- a/bin/wally-package-install.sh
+++ b/bin/wally-package-install.sh
@@ -46,12 +46,7 @@ fi
 # Generate list of packages to install and package manager commands based on distro
 # Packages are grouped by which tool requires them. If multiple tools need a package, it is included in the first tool only
 if [ "$FAMILY" == rhel ]; then
-    if (( RHEL_VERSION == 8 )); then
-        PYTHON_VERSION=python3.11
-    elif (( RHEL_VERSION >= 9 )); then
-        PYTHON_VERSION=python3.12
-        VERILATOR_PACKAGES+=(perl-doc) # Not availale in rhel8, nice for Verilator
-    fi
+    PYTHON_VERSION=python3.12
     PACKAGE_MANAGER="dnf"
     UPDATE_COMMAND="sudo $PACKAGE_MANAGER update -y"
     GENERAL_PACKAGES+=(which rsync git make cmake "$PYTHON_VERSION" "$PYTHON_VERSION"-pip curl wget tar pkgconf-pkg-config dialog mutt ssmtp)
@@ -60,6 +55,10 @@ if [ "$FAMILY" == rhel ]; then
     SPIKE_PACKAGES+=(dtc boost-regex boost-system)
     VERILATOR_PACKAGES+=(help2man perl clang ccache gperftools numactl mold)
     BUILDROOT_PACKAGES+=(ncurses-base ncurses ncurses-libs ncurses-devel gcc-gfortran cpio) # gcc-gfortran is only needed for compiling spec benchmarks on buildroot linux
+    # Extra packages not availale in rhel8, nice for Verilator
+    if (( RHEL_VERSION >= 9 )); then
+        VERILATOR_PACKAGES+=(perl-doc)
+    fi
     # A newer version of gcc is required for qemu
     OTHER_PACKAGES=(gcc-toolset-13)
 elif [ "$FAMILY" == ubuntu ]; then

--- a/bin/wally-package-install.sh
+++ b/bin/wally-package-install.sh
@@ -46,7 +46,12 @@ fi
 # Generate list of packages to install and package manager commands based on distro
 # Packages are grouped by which tool requires them. If multiple tools need a package, it is included in the first tool only
 if [ "$FAMILY" == rhel ]; then
-    PYTHON_VERSION=python3.12
+    if (( RHEL_VERSION == 8 )); then
+        PYTHON_VERSION=python3.11
+    elif (( RHEL_VERSION >= 9 )); then
+        PYTHON_VERSION=python3.12
+        VERILATOR_PACKAGES+=(perl-doc) # Not availale in rhel8, nice for Verilator
+    fi
     PACKAGE_MANAGER="dnf"
     UPDATE_COMMAND="sudo $PACKAGE_MANAGER update -y"
     GENERAL_PACKAGES+=(which rsync git make cmake "$PYTHON_VERSION" "$PYTHON_VERSION"-pip curl wget tar pkgconf-pkg-config dialog mutt ssmtp)
@@ -55,10 +60,6 @@ if [ "$FAMILY" == rhel ]; then
     SPIKE_PACKAGES+=(dtc boost-regex boost-system)
     VERILATOR_PACKAGES+=(help2man perl clang ccache gperftools numactl mold)
     BUILDROOT_PACKAGES+=(ncurses-base ncurses ncurses-libs ncurses-devel gcc-gfortran cpio) # gcc-gfortran is only needed for compiling spec benchmarks on buildroot linux
-    # Extra packages not availale in rhel8, nice for Verilator
-    if (( RHEL_VERSION >= 9 )); then
-        VERILATOR_PACKAGES+=(perl-doc)
-    fi
     # A newer version of gcc is required for qemu
     OTHER_PACKAGES=(gcc-toolset-13)
 elif [ "$FAMILY" == ubuntu ]; then

--- a/bin/wally-tool-chain-install.sh
+++ b/bin/wally-tool-chain-install.sh
@@ -171,17 +171,10 @@ source "$RISCV"/riscv-python/bin/activate # activate python virtual environment
 # Install python packages, including RISCOF (https://github.com/riscv-software-src/riscof.git)
 # RISCOF is a RISC-V compliance test framework that is used to run the RISC-V Arch Tests.
 STATUS="python packages"
-pip install --upgrade pip && pip install -r "$dir"/requirements.txt
+pip install --upgrade pip && pip install --upgrade -r "$dir"/requirements.txt
 
 source "$RISCV"/riscv-python/bin/activate # reload python virtual environment
 echo -e "${SUCCESS_COLOR}Python environment successfully configured!${ENDC}"
-
-# Install riscv-isac
-cd $RISCV
-STATUS="riscv-isac"
-git clone https://github.com/riscv-non-isa/riscv-arch-test
-cd riscv-arch-test/riscv-isac
-pip install .
 
 # Extra dependecies needed for older distros that don't have new enough versions available from package manager
 if (( RHEL_VERSION == 8 )) || (( UBUNTU_VERSION == 20 )); then

--- a/bin/wally-tool-chain-install.sh
+++ b/bin/wally-tool-chain-install.sh
@@ -176,6 +176,12 @@ pip install --upgrade pip && pip install -r "$dir"/requirements.txt
 source "$RISCV"/riscv-python/bin/activate # reload python virtual environment
 echo -e "${SUCCESS_COLOR}Python environment successfully configured!${ENDC}"
 
+# Install riscv-isac
+cd $RISCV
+STATUS="riscv-isac"
+git clone https://github.com/riscv-non-isa/riscv-arch-test
+cd riscv-arch-test/riscv-isac
+pip install .
 
 # Extra dependecies needed for older distros that don't have new enough versions available from package manager
 if (( RHEL_VERSION == 8 )) || (( UBUNTU_VERSION == 20 )); then


### PR DESCRIPTION
Updates pip installation to resolve #1002 when combined with riscv-non-isa/riscv-arch-test#519.

Also adds a `--no-buildroot` flag to the installation script for faster testing.