### PR TITLE
Point installation CI badge at OpenHW repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Installation CI](https://github.com/jordancarlin/cvw/actions/workflows/install.yml/badge.svg?branch=main)
+![Installation CI](https://github.com/openhwgroup/cvw/actions/workflows/install.yml/badge.svg?branch=main)
 
 # core-v-wally
 


### PR DESCRIPTION
Accidentally left the README pointing at my fork from when I was testing. Switch it to this repo.