### PR TITLE
SPI fix, add csr functional coverage

### DIFF
--- a/config/rv32gc/coverage.svh
+++ b/config/rv32gc/coverage.svh
@@ -5,6 +5,7 @@
 // This file is needed in the config subdirectory for each config supporting coverage.
 // It defines which extensions are enabled for that config.
 
+// Unprivileged extensions
 `include "RV32I_coverage.svh"
 `include "RV32M_coverage.svh"
 `include "RV32F_coverage.svh"
@@ -16,3 +17,6 @@
 `include "RV32Zcb_coverage.svh"
 `include "RV32ZcbM_coverage.svh"
 `include "RV32ZcbZbb_coverage.svh"
+
+// Privileged extensions
+`include "ZicsrM_coverage.svh"

--- a/config/rv64gc/coverage.svh
+++ b/config/rv64gc/coverage.svh
@@ -12,7 +12,6 @@
 `include "RV64D_coverage.svh"
 `include "RV64ZfhD_coverage.svh"
 `include "RV64Zfh_coverage.svh"
-`include "RV64VM_coverage.svh"
 `include "RV64Zicond_coverage.svh"
 `include "RV64Zca_coverage.svh"
 `include "RV64Zcb_coverage.svh"
@@ -21,6 +20,7 @@
 `include "RV64ZcbZba_coverage.svh"
 
 // Privileged extensions
+`include "RV64VM_coverage.svh"
 `include "ZicsrM_coverage.svh"
 // `include "RV64VM_PMP_coverage.svh"
 // `include "RV64CBO_VM_coverage.svh"

--- a/src/uncore/spi_apb.sv
+++ b/src/uncore/spi_apb.sv
@@ -234,9 +234,9 @@ module spi_apb import cvw::*; #(parameter cvw_t P) (
     // SPI enable generation, where SCLK = PCLK/(2*(SckDiv + 1))
     // Asserts SCLKenable at the rising and falling edge of SCLK by counting from 0 to SckDiv
     // Active at 2x SCLK frequency to account for implicit half cycle delays and actions on both clock edges depending on phase
-    // When SckDiv is 0, count doesn't work and SCLKenable is simply PCLK
+    // When SckDiv is 0, count doesn't work and SCLKenable is simply PCLK  *** dh 10/26/24: this logic is seriously broken.  SCLK is not scaled to PCLK/(2*(SckDiv + 1)).  SCLKenableEarly doesn't work right for SckDiv=0
     assign ZeroDiv = ~|(SckDiv[10:0]);
-    assign SCLKenable = ZeroDiv ? PCLK : (DivCounter == SckDiv);
+    assign SCLKenable = ZeroDiv ? 1 : (DivCounter == SckDiv);
     assign SCLKenableEarly = ((DivCounter + 12'b1) == SckDiv);
     always_ff @(posedge PCLK)
         if (~PRESETn) DivCounter <= '0;

--- a/testbench/testbench.sv
+++ b/testbench/testbench.sv
@@ -540,7 +540,6 @@ module testbench;
     always @(posedge clk) begin
       if (LoadMem) begin
         $readmemh(memfilename, dut.core.lsu.dtim.dtim.ram.ram.RAM);
-        $display("Read memfile %s", memfilename);
       end
       if (CopyRAM) begin
         LogXLEN = (1 + P.XLEN/32); // 2 for rv32 and 3 for rv64

--- a/tests/wally-riscv-arch-test/riscv-test-suite/rv32i_m/privilege/references/WALLY-spi-01.reference_output
+++ b/tests/wally-riscv-arch-test/riscv-test-suite/rv32i_m/privilege/references/WALLY-spi-01.reference_output
@@ -32,59 +32,59 @@
 
 00000003
 
-00000074
+00000074    # spi_burst_send
 
-00000063
+00000063    # spi_burst_send
 
-00000052
+00000052    # spi_burst_send
 
-00000041
+00000041    # spi_burst_send
 
-000000A1
-
-00000003
-
-000000B2
-
-00000001
-
-000000C3
-
-000000D4
+000000A1    # spi_burst_send
 
 00000003
 
-000000A4
+000000B2    # spi_burst_send
 
 00000001
 
-000000B4
+000000C3    # spi_burst_send
 
-000000A5
+000000D4    # spi_burst_send
 
-000000B5
+00000003
 
-000000C5
+000000A4    # tx_data write test
 
-000000D5
+00000001
 
-000000A7
+000000B4    # tx_data write test
 
-000000B7
+000000A5    # spi_burst_send    
 
-000000C7
+000000B5    # spi_burst_send
+
+000000C5    # spi_burst_send
+
+000000D5    # spi_burst_send
+
+000000A7    # spi_burst_send
+
+000000B7    # spi_burst_send
+
+000000C7    # spi_burst_send
 
 00000002
 
-000000D7
+000000D7    # spi_burst_send
 
 00000000
 
 00000011 #basic read write
 
-000000FF
+000000FF    # first test sck_div
 
-000000AE
+000000AE    # min sck_div first spi_burst_send
 
 000000AD
 


### PR DESCRIPTION
Solved Issues 962/964 about SPI failing in VCS.  The SPI SCLK generation is still not logically correct, but no longer breaks VCS.

Added CSR functional coverage to the RV{32/64}GC configurations.
