### PR TITLE
fround* bug Fix 

### DIFF
--- a/src/fpu/fround.sv
+++ b/src/fpu/fround.sv
@@ -76,8 +76,7 @@ module fround import cvw::*;  #(parameter cvw_t P) (
   assign Eeqm1 = ($signed(E) == -1);
 
   // Logic for nonnegative mask and rounding bits
-  // assign IMask = {1'b1, {P.NF{1'b0}}} >>> E; /// if E > Nf, this produces all 0s instead of all 1s.  Hence exact handling is needed below.
-  assign IMask = $signed({1'b1, {P.NF{1'b0}}}) >>> E;
+  assign IMask = $signed({1'b1, {P.NF{1'b0}}}) >>> E; /// if E > Nf, this produces all 0s instead of all 1s.  Hence exact handling is needed below.
   assign Tmasknonneg = ~IMask >>> 1'b1;
   assign HotE = IMask & ~(IMask << 1'b1);
   assign HotEP1 = HotE >> 1'b1;

--- a/src/fpu/fround.sv
+++ b/src/fpu/fround.sv
@@ -76,7 +76,8 @@ module fround import cvw::*;  #(parameter cvw_t P) (
   assign Eeqm1 = ($signed(E) == -1);
 
   // Logic for nonnegative mask and rounding bits
-  assign IMask = {1'b1, {P.NF{1'b0}}} >>> E; /// if E > Nf, this produces all 0s instead of all 1s.  Hence exact handling is needed below.
+  // assign IMask = {1'b1, {P.NF{1'b0}}} >>> E; /// if E > Nf, this produces all 0s instead of all 1s.  Hence exact handling is needed below.
+  assign IMask = $signed({1'b1, {P.NF{1'b0}}}) >>> E;
   assign Tmasknonneg = ~IMask >>> 1'b1;
   assign HotE = IMask & ~(IMask << 1'b1);
   assign HotEP1 = HotE >> 1'b1;


### PR DESCRIPTION
Arithmetic right shift was being performed as a logical shift. Used the `$signed()` function to cause the initial value to be interpreted as signed, ensuring the MSB is copied into the upper bits, as intended. 

Resolves issue #1025 