### PR TITLE
Fixed rmm rounding mode bug

### DIFF
--- a/src/fpu/fround.sv
+++ b/src/fpu/fround.sv
@@ -126,7 +126,7 @@ module fround import cvw::*;  #(parameter cvw_t P) (
       3'b001:  RoundUp = 0;               // RZ
       3'b010:  RoundUp = Xs & (Rp | Tp);  // RN
       3'b011:  RoundUp = ~Xs & (Rp | Tp); // RP
-      3'b101:  RoundUp = Rp;              // RNTA
+      3'b100:  RoundUp = Rp;              // RNTA
       default: RoundUp = 0;               // should never happen
     endcase
 


### PR DESCRIPTION
Rounding logic case statement had 3'b101 (a reserved rounding mode value) associated with the rmm rounding mode instead of 3'b100. I changed this case to the correct value and fixed the ImperasDV mismatch for fround with explicit rmm rounding mode

close #1056 