### PR TITLE
Enable assertions in Verilator

### DIFF
--- a/sim/verilator/Makefile
+++ b/sim/verilator/Makefile
@@ -6,7 +6,7 @@ SHELL := /bin/bash
 .PHONY: profile run questa clean
 
 # verilator configurations
-OPT=
+OPT=--assert
 PARAMS?=--no-trace-top
 NONPROF?=--stats
 VERILATOR_DIR=${WALLY}/sim/verilator


### PR DESCRIPTION
Discovered while working on fetch buffer. Assertions in riscvassertions.sv were not being checked by Verilator. This enables them to avoid invalid configs from being simulated.