### PR TITLE
Add ZicsrF coverage to fcov

### DIFF
--- a/config/rv32gc/coverage.svh
+++ b/config/rv32gc/coverage.svh
@@ -25,5 +25,6 @@
 
 // Privileged extensions
 `include "ZicsrM_coverage.svh"
+`include "ZicsrF_coverage.svh"
 `include "RV32VM_coverage.svh"
 `include "RV32VM_PMP_coverage.svh"

--- a/config/rv64gc/coverage.svh
+++ b/config/rv64gc/coverage.svh
@@ -26,6 +26,7 @@
 // Privileged extensions
 `include "RV64VM_coverage.svh"
 `include "ZicsrM_coverage.svh"
+`include "ZicsrF_coverage.svh"
 // `include "RV64VM_PMP_coverage.svh"
 // `include "RV64CBO_VM_coverage.svh"
 // `include "RV64CBO_PMP_coverage.svh"


### PR DESCRIPTION
PR 302 in openhwgroup/cvw-arch-verif adds ZicsrF covergroups, included in coverage.svh for rv32gc and rv64gc 