### PR TITLE
Fflag Fix

### DIFF
--- a/src/fpu/fcmp.sv
+++ b/src/fpu/fcmp.sv
@@ -75,6 +75,7 @@ module fcmp import cvw::*;  #(parameter cvw_t P) (
         3'b0?1: if (P.ZFA_SUPPORTED) 
                   CmpNV = Zfa ? EitherSNaN : EitherNaN; // fltq,fleq / flt,fle perform CompareQuietLess / CompareSignalingLess differing on when to set invalid
                 else CmpNV = EitherNaN;                 // flt, fle
+        3'b100: CmpNV = 1'b0;
         default: CmpNV = 1'bx;
     endcase
   end 

--- a/src/fpu/fround.sv
+++ b/src/fpu/fround.sv
@@ -147,6 +147,6 @@ module fround import cvw::*;  #(parameter cvw_t P) (
 
   // Flags
   assign FRoundNV = XSNaN;                               // invalid if input is signaling NaN
-  assign FRoundNX = ZfaFRoundNX & ~EgeNf & (Rp | Tp);    // Inexact if Round or Sticky bit set for FRoundNX instruction
+  assign FRoundNX = ZfaFRoundNX & ~EgeNf & (Rp | Tp) & ~XNaN;    // Inexact if Round or Sticky bit set for FRoundNX instruction
 
 endmodule

--- a/src/fpu/fround.sv
+++ b/src/fpu/fround.sv
@@ -146,7 +146,8 @@ module fround import cvw::*;  #(parameter cvw_t P) (
   packoutput #(P) packoutput(W, Fmt, FRound); // pack and NaN-box based on selected format.
 
   // Flags
-  assign FRoundNV = XSNaN;                               // invalid if input is signaling NaN
+  assign FRoundNV = XSNaN;                                       // invalid if input is signaling NaN
   assign FRoundNX = ZfaFRoundNX & ~EgeNf & (Rp | Tp) & ~XNaN;    // Inexact if Round or Sticky bit set for FRoundNX instruction
+                                                                 // Note: NX must not be raised if input is invalid
 
 endmodule


### PR DESCRIPTION
* Added handling to pull `CMPNv` low when OpD = 100 (mul / fround instructions don't use the comperator
* Changed the logic for `FRoundNX` to ensure that the input is valid (per the spec, NX shouldn't be raised if input is NaN)

Resolves #1066 