### PR TITLE
Removing old code (not in use anymore)

### DIFF
--- a/testbench/testbench.sv
+++ b/testbench/testbench.sv
@@ -33,12 +33,6 @@
     `include "idv/idv.svh"
 `endif
 
-`ifdef RVVI_COVERAGE
-    `include "RISCV_trace_data.svh"
-    `include "rvvicov.svh"
-    `include "wrapper.sv"
-`endif
-
 import cvw::*;
 
 module testbench;
@@ -972,12 +966,6 @@ test_pmp_coverage #(P) pmp_inst(clk);
 `endif
   /* verilator lint_on WIDTHTRUNC */
   /* verilator lint_on WIDTHEXPAND */
-
-`ifdef RVVI_COVERAGE
-    rvviTrace #(.XLEN(P.XLEN), .FLEN(P.FLEN)) rvvi();
-    wallyTracer #(P) wallyTracer(rvvi);
-    wrapper #(P) wrap(clk);
-`endif
 
 endmodule
 


### PR DESCRIPTION
This was previously used when rvvi coverage was separate from ISACOV, now that it has been combined this is not needed anymore.