### PR TITLE
Clean up verilator lint off commands and remove unnecessay ones

### DIFF
--- a/config/shared/config-shared.vh
+++ b/config/shared/config-shared.vh
@@ -122,9 +122,3 @@ localparam FMALEN = 3*NF + 6;
 localparam NORMSHIFTSZ = `max(`max((CVTLEN+NF+1), (DIVb + 1 + NF + 1)), (FMALEN + 2));
 
 localparam LOGNORMSHIFTSZ = ($clog2(NORMSHIFTSZ));                  // log_2(NORMSHIFTSZ)
-
-// Disable spurious Verilator warnings
-
-/* verilator lint_off STMTDLY */
-/* verilator lint_off ASSIGNDLY */
-/* verilator lint_off PINCONNECTEMPTY */

--- a/config/shared/parameter-defs.vh
+++ b/config/shared/parameter-defs.vh
@@ -95,11 +95,7 @@ localparam cvw_t P = '{
   PLIC_SPI_ID :        PLIC_SPI_ID,
   PLIC_SDC_ID :        PLIC_SDC_ID,
   BPRED_SUPPORTED :        BPRED_SUPPORTED,
-                       /* verilator lint_off ENUMVALUE */
-                       // *** definitely need to fix this.
-                       // it thinks we are casting from the enum type to BPRED_TYPE.
   BPRED_TYPE :        BPRED_TYPE,
-                       /* verilator lint_on ENUMVALUE */
   BPRED_SIZE :        BPRED_SIZE,
   BPRED_NUM_LHR : BPRED_NUM_LHR,                       
   BTB_SIZE :        BTB_SIZE,

--- a/src/fpu/fdivsqrt/fdivsqrtiter.sv
+++ b/src/fpu/fdivsqrt/fdivsqrtiter.sv
@@ -38,7 +38,6 @@ module fdivsqrtiter import cvw::*;  #(parameter cvw_t P) (
   output logic [P.DIVb+3:0] FirstWS, FirstWC       // Q4.DIVb
 );
 
-  /* verilator lint_off UNOPTFLAT */
   logic [P.DIVb+3:0]      WSNext[P.DIVCOPIES-1:0]; // Q4.DIVb
   logic [P.DIVb+3:0]      WCNext[P.DIVCOPIES-1:0]; // Q4.DIVb
   logic [P.DIVb+3:0]      WS[P.DIVCOPIES:0];       // Q4.DIVb
@@ -56,7 +55,6 @@ module fdivsqrtiter import cvw::*;  #(parameter cvw_t P) (
   logic [P.DIVb+1:0]      NextC;                   // Q2.DIVb
   logic [P.DIVb:0]        UMux, UMMux;             // U1.DIVb
   logic [P.DIVb:0]        initU, initUM;           // U1.DIVb
-  /* verilator lint_on UNOPTFLAT */
 
   // Top Muxes and Registers
   // When start is asserted, the inputs are loaded into the divider.

--- a/src/fpu/fdivsqrt/fdivsqrtpreproc.sv
+++ b/src/fpu/fdivsqrt/fdivsqrtpreproc.sv
@@ -136,7 +136,7 @@ module fdivsqrtpreproc import cvw::*;  #(parameter cvw_t P) (
     // calculate right shift amount RightShiftX to complete in discrete number of steps
     if (P.RK > 1) begin // more than 1 bit per cycle
       logic [$clog2(P.RK)-1:0] RightShiftX;
-      /* verilator lint_offf WIDTH */
+      /* verilator lint_off WIDTH */
       assign RightShiftX = P.RK - 1 - ((IntResultBitsE - 1) % P.RK); // Right shift amount
       assign DivXShifted = DivX >> RightShiftX;                     // shift X by up to R*K-1 to complete in n steps
       /* verilator lint_on WIDTH */

--- a/src/fpu/fdivsqrt/fdivsqrtstage2.sv
+++ b/src/fpu/fdivsqrt/fdivsqrtstage2.sv
@@ -28,7 +28,6 @@
 ////////////////////////////////////////////////////////////////////////////////////////////////
 
 
-/* verilator lint_off UNOPTFLAT */
 module fdivsqrtstage2 import cvw::*;  #(parameter cvw_t P) (
   input  logic [P.DIVb+3:0] D, DBar,        // Q4.DIVb
   input  logic [P.DIVb:0]   U, UM,          // U1.DIVb
@@ -40,7 +39,6 @@ module fdivsqrtstage2 import cvw::*;  #(parameter cvw_t P) (
   output logic [P.DIVb:0]   UNext, UMNext,  // U1.DIVb
   output logic [P.DIVb+3:0] WSNext, WCNext  // Q4.DIVb
 );
- /* verilator lint_on UNOPTFLAT */
 
   logic [P.DIVb+3:0]        Dsel;     // Q4.DIVb
   logic                     up, uz;

--- a/src/fpu/fround.sv
+++ b/src/fpu/fround.sv
@@ -115,9 +115,9 @@ module fround import cvw::*;  #(parameter cvw_t P) (
   ///////////////////////////
 
   // Exact logic
-  // verilator lint_off WIDTHEXPAND
+  /* verilator lint_off WIDTHEXPAND */
   assign EgeNf = (E >= Nf) & Xe[P.NE-1]; // Check if E >= Nf.  Also check that Xe is positive to avoid wraparound problems
-  // verilator lint_on WIDTHEXPAND
+  /* verilator lint_on WIDTHEXPAND */
 
   // Rounding logic: determine whether to round up in magnitude
   always_comb begin

--- a/src/generic/prioritythermometer.sv
+++ b/src/generic/prioritythermometer.sv
@@ -39,11 +39,9 @@ module prioritythermometer #(parameter N = 8) (
   //  Rather than linear.
 
   // create thermometer code mask
-  /* verilator lint_off UNOPTFLAT */
   genvar i;
   assign y[0] = ~a[0];
   for (i=1; i<N; i++) begin:therm
     assign y[i] = y[i-1] & ~a[i];
   end
-  /* verilator lint_on UNOPTFLAT */
 endmodule

--- a/src/lsu/lsu.sv
+++ b/src/lsu/lsu.sv
@@ -121,11 +121,9 @@ module lsu import cvw::*;  #(parameter cvw_t P) (
   logic                  DCacheCommittedM;                       // D$ memory operation started, delay interrupts
 
   logic [P.LLEN-1:0]     DTIMReadDataWordM;                      // DTIM read data
-  /* verilator lint_off WIDTHEXPAND */  
   logic [MLEN-1:0]       DCacheReadDataWordM;                    // D$ read data
   logic [MLEN-1:0]       LSUWriteDataSpillM;                     // Final write data
   logic [MLEN/8-1:0]     ByteMaskSpillM;                         // Selects which bytes within a word to write
-  /* verilator lint_on WIDTHEXPAND */
   logic [P.LLEN-1:0]     DCacheReadDataWordSpillM;               // D$ read data
   logic [P.LLEN-1:0]     ReadDataWordMuxM;                       // DTIM or D$ read data
   logic [P.LLEN-1:0]     LittleEndianReadDataWordM;              // Endian-swapped read data

--- a/src/mdu/divstep.sv
+++ b/src/mdu/divstep.sv
@@ -27,8 +27,6 @@
 // and limitations under the License.
 ////////////////////////////////////////////////////////////////////////////////////////////////
 
-/* verilator lint_off UNOPTFLAT */
-
 module divstep #(parameter XLEN) (
   input  logic [XLEN-1:0] W,     // Residual in
   input  logic [XLEN-1:0] XQ,    // bits of dividend X and quotient Q in
@@ -46,5 +44,3 @@ module divstep #(parameter XLEN) (
   assign qi = ~qib;
   mux2 #(XLEN) wrestoremux(WShift, WPrime, qi, WOut); // if quotient is zero, restore W
 endmodule
-
-/* verilator lint_on UNOPTFLAT */

--- a/src/privileged/csrm.sv
+++ b/src/privileged/csrm.sv
@@ -88,6 +88,7 @@ module csrm  import cvw::*;  #(parameter cvw_t P) (
   // .. up to 15 more at consecutive addresses
   localparam PMPADDR0      = 12'h3B0;
   // ... up to 63 more at consecutive addresses
+  /* verilator lint_off UNUSEDPARAM */
   localparam TSELECT       = 12'h7A0;
   localparam TDATA1        = 12'h7A1;
   localparam TDATA2        = 12'h7A2;
@@ -96,6 +97,7 @@ module csrm  import cvw::*;  #(parameter cvw_t P) (
   localparam DPC           = 12'h7B1;
   localparam DSCRATCH0     = 12'h7B2;
   localparam DSCRATCH1     = 12'h7B3;
+  /* verilator lint_off UNUSEDPARAM */
   // Constants
   localparam ZERO = {(P.XLEN){1'b0}};
   // when compressed instructions are supported, there can't be misaligned instructions

--- a/src/uncore/spi_apb.sv
+++ b/src/uncore/spi_apb.sv
@@ -114,7 +114,7 @@ module spi_apb import cvw::*; #(parameter cvw_t P) (
   
   /* verilator lint_off UNDRIVEN */
   logic [2:0]  TransmitWriteWatermarkLevel, ReceiveReadWatermarkLevel; // unused generic FIFO outputs
-  /* verilator lint_off UNDRIVEN */
+  /* verilator lint_on UNDRIVEN */
   logic [7:0]  ReceiveShiftRegEndian;              // Reverses ReceiveShiftReg if Format[2] set (little endian transmission)
 
   // Shift reg signals
@@ -184,7 +184,7 @@ module spi_apb import cvw::*; #(parameter cvw_t P) (
         case(Entry)
           SPI_TXDATA:  if (~TransmitFIFOFull) TransmitData[7:0] <= Din[7:0];
         endcase
-      /* verilator lint_off CASEINCOMPLETE */
+      /* verilator lint_on CASEINCOMPLETE */
       
       // According to FU540 spec: Once interrupt is pending, it will remain set until number 
       // of entries in tx/rx fifo is strictly more/less than tx/rxmark

--- a/src/uncore/uartPC16550D.sv
+++ b/src/uncore/uartPC16550D.sv
@@ -335,10 +335,10 @@ module uartPC16550D #(parameter UART_PRESCALE) (
     end
 
   assign rxfifoempty = (rxfifohead == rxfifotail);
-  // verilator lint_off WIDTH
+  /* verilator lint_off WIDTH */
   assign rxfifoentries = (rxfifohead >= rxfifotail) ? (rxfifohead-rxfifotail) : 
                          (rxfifohead + 16 - rxfifotail);
-  // verilator lint_on WIDTH
+  /* verilator lint_on WIDTH */
   assign rxfifotriggered = rxfifoentries >= rxfifotriggerlevel;
   assign rxfifotimeout = rxtimeoutcnt == {rxbitsexpected, 6'b0}; // time out after 4 character periods; probably not right yet
   //assign rxfifotimeout = 0; // disabled pending fix


### PR DESCRIPTION
- Several spots had the lint_off command before and after the problematic code instead of turning it back on after
- Verilator seems to be better about determining circular logic and many of the onoptflat errors are no longer present