### PR TITLE
More lint cleanup: remove unused params

### DIFF
--- a/bin/lint-wally
+++ b/bin/lint-wally
@@ -30,7 +30,7 @@ for config in ${configs[@]}; do
     if !($verilator --lint-only --quiet --top-module wallywrapper \
          "-I$basepath/config/shared" "-I$basepath/config/$config" "-I$basepath/config/deriv/$config" \
          $basepath/src/cvw.sv $basepath/testbench/wallywrapper.sv $basepath/src/*/*.sv $basepath/src/*/*/*.sv \
-         -Wall -Wno-UNUSEDSIGNAL -Wno-UNUSEDPARAM -Wno-VARHIDDEN -Wno-GENUNNAMED -Wno-PINCONNECTEMPTY); then
+         -Wall -Wno-UNUSEDSIGNAL -Wno-VARHIDDEN -Wno-GENUNNAMED -Wno-PINCONNECTEMPTY); then
         if [ "$1" == "-nightly" ]; then
             echo -e "${RED}$config failed lint${NC}"
             fails=$((fails+1))

--- a/src/cache/cache.sv
+++ b/src/cache/cache.sv
@@ -29,7 +29,7 @@
 ////////////////////////////////////////////////////////////////////////////////////////////////
 
 module cache import cvw::*; #(parameter cvw_t P,
-                              parameter PA_BITS, XLEN, LINELEN,  NUMSETS,  NUMWAYS, LOGBWPL, WORDLEN, MUXINTERVAL, READ_ONLY_CACHE) (
+                              parameter PA_BITS, LINELEN,  NUMSETS,  NUMWAYS, LOGBWPL, WORDLEN, MUXINTERVAL, READ_ONLY_CACHE) (
   input  logic                   clk,
   input  logic                   reset,
   input  logic                   Stall,             // Stall the cache, preventing new accesses. In-flight access finished but does not return to READY
@@ -66,11 +66,7 @@ module cache import cvw::*; #(parameter cvw_t P,
   localparam                     SETLEN = $clog2(NUMSETS);          // Number of set bits
   localparam                     SETTOP = SETLEN+OFFSETLEN;          // Number of set plus offset bits
   localparam                     TAGLEN = PA_BITS - SETTOP;          // Number of tag bits
-  localparam                     CACHEWORDSPERLINE = LINELEN/WORDLEN;// Number of words in cache line
-  localparam                     LOGCWPL = $clog2(CACHEWORDSPERLINE);// Log2 of ^
   localparam                     FLUSHADRTHRESHOLD = NUMSETS - 1;   // Used to determine when flush is complete
-  localparam                     LOGLLENBYTES = $clog2(WORDLEN/8);   // Number of bits to address a word
-
 
   logic                          SelAdrData;
   logic                          SelAdrTag;
@@ -122,14 +118,14 @@ module cache import cvw::*; #(parameter cvw_t P,
     AdrSelMuxSelLRU, CacheSetLRU);
 
   // Array of cache ways, along with victim, hit, dirty, and read merging logic
-  cacheway #(P, PA_BITS, XLEN, NUMSETS, LINELEN, TAGLEN, OFFSETLEN, SETLEN, READ_ONLY_CACHE) CacheWays[NUMWAYS-1:0](
+  cacheway #(P, PA_BITS, NUMSETS, LINELEN, TAGLEN, OFFSETLEN, SETLEN, READ_ONLY_CACHE) CacheWays[NUMWAYS-1:0](
     .clk, .reset, .CacheEn, .CacheSetData, .CacheSetTag, .PAdr, .LineWriteData, .LineByteMask, .SelVictim,
     .SetValid, .ClearValid, .SetDirty, .ClearDirty, .VictimWay,
     .FlushWay, .FlushCache, .ReadDataLineWay, .HitWay, .ValidWay, .DirtyWay, .HitDirtyWay, .TagWay, .FlushStage, .InvalidateCache);
 
   // Select victim way for associative caches
   if(NUMWAYS > 1) begin:vict
-    cacheLRU #(NUMWAYS, SETLEN, OFFSETLEN, NUMSETS) cacheLRU(
+    cacheLRU #(NUMWAYS, SETLEN, NUMSETS) cacheLRU(
       .clk, .reset, .FlushStage, .CacheEn, .HitWay, .ValidWay, .VictimWay, .CacheSetLRU, .LRUWriteEn,
       .SetValid, .PAdr(PAdr[SETTOP-1:OFFSETLEN]), .InvalidateCache);
   end else 
@@ -172,11 +168,7 @@ module cache import cvw::*; #(parameter cvw_t P,
   if(!READ_ONLY_CACHE) begin:WriteSelLogic
     logic [LINELEN/8-1:0]          DemuxedByteMask, FetchBufferByteSel;
 
-    // Adjust byte mask from word to cache line
-
-    localparam                     CACHEMUXINVERALPERLINE = LINELEN/MUXINTERVAL;// Number of words in cache line
-    localparam                     LOGMIPL = $clog2(CACHEMUXINVERALPERLINE);// Log2 of ^
-    
+    // Adjust byte mask from word to cache line    
     logic [LINELEN/8-1:0]          BlankByteMask;
     assign BlankByteMask[WORDLEN/8-1:0] = ByteMask;
     assign BlankByteMask[LINELEN/8-1:WORDLEN/8] = 0;
@@ -231,7 +223,7 @@ module cache import cvw::*; #(parameter cvw_t P,
   // Cache FSM
   /////////////////////////////////////////////////////////////////////////////////////////////
   
-  cachefsm #(P, READ_ONLY_CACHE) cachefsm(.clk, .reset, .CacheBusRW, .CacheBusAck, 
+  cachefsm #(READ_ONLY_CACHE) cachefsm(.clk, .reset, .CacheBusRW, .CacheBusAck, 
     .FlushStage, .CacheRW, .Stall,
     .Hit, .LineDirty, .HitLineDirty, .CacheStall, .CacheCommitted, 
     .CacheMiss, .CacheAccess, .SelAdrData, .SelAdrTag, .SelVictim,

--- a/src/cache/cacheLRU.sv
+++ b/src/cache/cacheLRU.sv
@@ -29,7 +29,7 @@
 ////////////////////////////////////////////////////////////////////////////////////////////////
 
 module cacheLRU
-  #(parameter NUMWAYS = 4, SETLEN = 9, OFFSETLEN = 5, NUMSETS = 128) (
+  #(parameter NUMWAYS = 4, SETLEN = 9, NUMSETS = 128) (
   input  logic                clk, 
   input  logic                reset,
   input  logic                FlushStage,

--- a/src/cache/cachefsm.sv
+++ b/src/cache/cachefsm.sv
@@ -28,8 +28,7 @@
 // and limitations under the License.
 ////////////////////////////////////////////////////////////////////////////////////////////////
 
-module cachefsm import cvw::*; #(parameter cvw_t P,
-                                 parameter READ_ONLY_CACHE = 0) (
+module cachefsm #(parameter READ_ONLY_CACHE = 0) (
   input  logic       clk,
   input  logic       reset,
   // hazard and privilege unit

--- a/src/cache/cacheway.sv
+++ b/src/cache/cacheway.sv
@@ -29,7 +29,7 @@
 ////////////////////////////////////////////////////////////////////////////////////////////////
 
 module cacheway import cvw::*; #(parameter cvw_t P, 
-                  parameter PA_BITS, XLEN, NUMSETS=512, LINELEN = 256, TAGLEN = 26,
+                  parameter PA_BITS, NUMSETS=512, LINELEN = 256, TAGLEN = 26,
                   OFFSETLEN = 5, INDEXLEN = 9, READ_ONLY_CACHE = 0) (
   input  logic                        clk,
   input  logic                        reset,
@@ -56,12 +56,6 @@ module cacheway import cvw::*; #(parameter cvw_t P,
   output logic                        HitDirtyWay,    // The hit way is dirty
   output logic                        DirtyWay   ,    // The selected way is dirty
   output logic [TAGLEN-1:0]           TagWay);        // This way's tag if valid
-
-  localparam                          WORDSPERLINE = LINELEN/XLEN;
-  localparam                          BYTESPERLINE = LINELEN/8;
-  localparam                          LOGWPL = $clog2(WORDSPERLINE);
-  localparam                          LOGXLENBYTES = $clog2(XLEN/8);
-  localparam                          BYTESPERWORD = XLEN/8;
 
   logic [NUMSETS-1:0]                ValidBits;
   logic [NUMSETS-1:0]                DirtyBits;
@@ -131,7 +125,6 @@ module cacheway import cvw::*; #(parameter cvw_t P,
 
   localparam           NUMSRAM = LINELEN/P.CACHE_SRAMLEN;
   localparam           SRAMLENINBYTES = P.CACHE_SRAMLEN/8;
-  localparam           LOGNUMSRAM = $clog2(NUMSRAM);
   
   for(words = 0; words < NUMSRAM; words++) begin: word
     if (READ_ONLY_CACHE) begin:wordram // no byte-enable needed for i$.

--- a/src/hazard/hazard.sv
+++ b/src/hazard/hazard.sv
@@ -27,7 +27,7 @@
 // and limitations under the License.
 ////////////////////////////////////////////////////////////////////////////////////////////////
 
-module hazard import cvw::*;  #(parameter cvw_t P) ( 
+module hazard ( 
   input  logic  BPWrongE, CSRWriteFenceM, RetM, TrapM,   
   input  logic  StructuralStallD,
   input  logic  LSUStallM, IFUStallF,

--- a/src/ifu/ifu.sv
+++ b/src/ifu/ifu.sv
@@ -236,7 +236,7 @@ module ifu import cvw::*;  #(parameter cvw_t P) (
       
       assign BusRW = ~ITLBMissF & ~CacheableF & ~SelIROM ? IFURWF : '0;
       assign CacheRWF = ~ITLBMissF & CacheableF & ~SelIROM ? IFURWF : '0;
-      cache #(.P(P), .PA_BITS(P.PA_BITS), .XLEN(P.XLEN), .LINELEN(P.ICACHE_LINELENINBITS),
+      cache #(.P(P), .PA_BITS(P.PA_BITS), .LINELEN(P.ICACHE_LINELENINBITS),
               .NUMSETS(P.ICACHE_WAYSIZEINBYTES*8/P.ICACHE_LINELENINBITS),
               .NUMWAYS(P.ICACHE_NUMWAYS), .LOGBWPL(AHBWLOGBWPL), .WORDLEN(32), .MUXINTERVAL(16), .READ_ONLY_CACHE(1))
       icache(.clk, .reset, .FlushStage(FlushD), .Stall(GatedStallD),

--- a/src/lsu/lsu.sv
+++ b/src/lsu/lsu.sv
@@ -324,7 +324,7 @@ module lsu import cvw::*;  #(parameter cvw_t P) (
       assign CacheRWM = (CacheableM & ~SelDTIM) ? LSURWM : '0;
       assign FlushDCache = FlushDCacheM & ~(SelHPTW);
       
-      cache #(.P(P), .PA_BITS(P.PA_BITS), .XLEN(P.XLEN), .LINELEN(P.DCACHE_LINELENINBITS), .NUMSETS(P.DCACHE_WAYSIZEINBYTES*8/LINELEN),
+      cache #(.P(P), .PA_BITS(P.PA_BITS), .LINELEN(P.DCACHE_LINELENINBITS), .NUMSETS(P.DCACHE_WAYSIZEINBYTES*8/LINELEN),
               .NUMWAYS(P.DCACHE_NUMWAYS), .LOGBWPL(LLENLOGBWPL), .WORDLEN(CACHEWORDLEN), .MUXINTERVAL(P.LLEN), .READ_ONLY_CACHE(0)) dcache(
         .clk, .reset, .Stall(GatedStallW & ~SelSpillE), .SelBusBeat, .FlushStage(LSUFlushW),
         .CacheRW(CacheRWM), 

--- a/src/privileged/csrs.sv
+++ b/src/privileged/csrs.sv
@@ -67,8 +67,6 @@ module csrs import cvw::*;  #(parameter cvw_t P) (
   localparam STIMECMPH  = 12'h15D;
   localparam SATP       = 12'h180;
   // Constants
-  localparam ZERO         = {(P.XLEN){1'b0}};
-  localparam SEDELEG_MASK = ~(ZERO | {{P.XLEN-3{1'b0}}, 3'b111} << 9);
 
   logic                    WriteSTVECM;
   logic                    WriteSSCRATCHM, WriteSEPCM;

--- a/src/uncore/ram_ahb.sv
+++ b/src/uncore/ram_ahb.sv
@@ -28,7 +28,7 @@
 ////////////////////////////////////////////////////////////////////////////////////////////////
 
 module ram_ahb import cvw::*;  #(parameter cvw_t P, 
-                                 parameter BASE=0, RANGE = 65535, PRELOAD = 0) (
+                                 parameter RANGE = 65535, PRELOAD = 0) (
   input  logic                 HCLK, HRESETn, 
   input  logic                 HSELRam,
   input  logic [P.PA_BITS-1:0] HADDR,

--- a/src/uncore/rom_ahb.sv
+++ b/src/uncore/rom_ahb.sv
@@ -28,7 +28,7 @@
 ////////////////////////////////////////////////////////////////////////////////////////////////
 
 module rom_ahb import cvw::*;  #(parameter cvw_t P, 
-                                 parameter BASE=0, RANGE = 65535, PRELOAD = 0) (
+                                 parameter RANGE = 65535, PRELOAD = 0) (
   input  logic                 HCLK, HRESETn, 
   input  logic                 HSELRom,
   input  logic [P.PA_BITS-1:0] HADDR,

--- a/src/uncore/uncore.sv
+++ b/src/uncore/uncore.sv
@@ -109,13 +109,13 @@ module uncore import cvw::*;  #(parameter cvw_t P)(
                 
   // on-chip RAM
   if (P.UNCORE_RAM_SUPPORTED) begin : ram
-    ram_ahb #(.P(P), .BASE(P.UNCORE_RAM_BASE), .RANGE(P.UNCORE_RAM_RANGE), .PRELOAD(P.UNCORE_RAM_PRELOAD)) ram (
+    ram_ahb #(.P(P), .RANGE(P.UNCORE_RAM_RANGE), .PRELOAD(P.UNCORE_RAM_PRELOAD)) ram (
       .HCLK, .HRESETn, .HSELRam, .HADDR, .HWRITE, .HREADY, 
       .HTRANS, .HWDATA, .HWSTRB, .HREADRam, .HRESPRam, .HREADYRam);
   end else assign {HREADRam, HRESPRam, HREADYRam} = '0;
 
  if (P.BOOTROM_SUPPORTED) begin : bootrom
-    rom_ahb #(.P(P), .BASE(P.BOOTROM_BASE), .RANGE(P.BOOTROM_RANGE), .PRELOAD(P.BOOTROM_PRELOAD))
+    rom_ahb #(.P(P), .RANGE(P.BOOTROM_RANGE), .PRELOAD(P.BOOTROM_PRELOAD))
     bootrom(.HCLK, .HRESETn, .HSELRom(HSELBootRom), .HADDR, .HREADY, .HTRANS, 
       .HREADRom(HREADBootRom), .HRESPRom(HRESPBootRom), .HREADYRom(HREADYBootRom));
   end else assign {HREADBootRom, HRESPBootRom, HREADYBootRom} = '0;

--- a/src/wally/wallypipelinedcore.sv
+++ b/src/wally/wallypipelinedcore.sv
@@ -271,7 +271,7 @@ module wallypipelinedcore import cvw::*; #(parameter cvw_t P) (
   end
 
   // global stall and flush control  
-  hazard #(P) hzu(
+  hazard hzu(
     .BPWrongE, .CSRWriteFenceM, .RetM, .TrapM,
     .StructuralStallD,
     .LSUStallM, .IFUStallF,

--- a/testbench/testbench.sv
+++ b/testbench/testbench.sv
@@ -564,7 +564,7 @@ module testbench;
   assign SPIIn = 1'b0;
 
   if(P.EXT_MEM_SUPPORTED) begin
-    ram_ahb #(.P(P), .BASE(P.EXT_MEM_BASE), .RANGE(P.EXT_MEM_RANGE))
+    ram_ahb #(.P(P), .RANGE(P.EXT_MEM_RANGE))
     ram (.HCLK, .HRESETn, .HADDR, .HWRITE, .HTRANS, .HWDATA, .HSELRam(HSELEXT),
       .HREADRam(HRDATAEXT), .HREADYRam(HREADYEXT), .HRESPRam(HRESPEXT), .HREADY, .HWSTRB);
   end else begin


### PR DESCRIPTION
Remove lots of unused localparams and parameters that probably used to be needed. Also means we no longer need to disable this lint warning. Passes `lint-wally --nightly`