### PR TITLE
Add exceptionsM to fcov

### DIFF
--- a/config/rv32gc/coverage.svh
+++ b/config/rv32gc/coverage.svh
@@ -9,7 +9,6 @@
 `define XLEN32 1
 
 // Define relevant addresses
-`define CLINT_BASE 64'h02000000
 `define ACCESS_FAULT_ADDRESS 32'h0000
 
 // Unprivileged extensions

--- a/config/rv32gc/coverage.svh
+++ b/config/rv32gc/coverage.svh
@@ -8,6 +8,10 @@
 // Define XLEN, used in covergroups
 `define XLEN32 1
 
+// Define relevant addresses
+`define CLINT_BASE 64'h02000000
+`define ACCESS_FAULT_ADDRESS 32'h0000
+
 // Unprivileged extensions
 `include "RV32I_coverage.svh"
 `include "RV32M_coverage.svh"
@@ -40,3 +44,4 @@
 `include "EndianU_coverage.svh"
 `include "EndianM_coverage.svh"
 `include "EndianS_coverage.svh"
+`include "ExceptionsM_coverage.svh"

--- a/config/rv32gc/coverage.svh
+++ b/config/rv32gc/coverage.svh
@@ -10,6 +10,7 @@
 
 // Define relevant addresses
 `define ACCESS_FAULT_ADDRESS 32'h0000
+`define CLINT_BASE 64'h02000000
 
 // Unprivileged extensions
 `include "RV32I_coverage.svh"

--- a/config/rv64gc/coverage.svh
+++ b/config/rv64gc/coverage.svh
@@ -9,7 +9,6 @@
 `define XLEN64 1
 
 // Define relevant addresses
-`define CLINT_BASE 64'h02000000
 `define ACCESS_FAULT_ADDRESS 64'h00000000
 
 // Unprivileged extensions

--- a/config/rv64gc/coverage.svh
+++ b/config/rv64gc/coverage.svh
@@ -10,6 +10,7 @@
 
 // Define relevant addresses
 `define ACCESS_FAULT_ADDRESS 64'h00000000
+`define CLINT_BASE 64'h02000000
 
 // Unprivileged extensions
 `include "RV64I_coverage.svh"

--- a/config/rv64gc/coverage.svh
+++ b/config/rv64gc/coverage.svh
@@ -8,6 +8,10 @@
 // Define XLEN, used in covergroups
 `define XLEN64 1
 
+// Define relevant addresses
+`define CLINT_BASE 64'h02000000
+`define ACCESS_FAULT_ADDRESS 64'h00000000
+
 // Unprivileged extensions
 `include "RV64I_coverage.svh"
 `include "RV64M_coverage.svh"
@@ -39,6 +43,7 @@
 `include "EndianU_coverage.svh"
 `include "EndianM_coverage.svh"
 `include "EndianS_coverage.svh"
+`include "ExceptionsM_coverage.svh"
 // `include "RV64VM_PMP_coverage.svh"
 // `include "RV64CBO_VM_coverage.svh"
 // `include "RV64CBO_PMP_coverage.svh"


### PR DESCRIPTION
Must be merged to prevent openhwgroup/cvw-arch-verif#321 from choking --fcov 