### PR TITLE
Add cvw-arch-verif to root Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,9 @@ MAKEFLAGS += --output-sync --no-print-directory
 
 SIM = ${WALLY}/sim
 
-.PHONY: all riscof testfloat combined_IF_vectors zsbl benchmarks coremark embench coverage clean
+.PHONY: all riscof testfloat combined_IF_vectors zsbl benchmarks coremark embench coverage cvw-arch-verif clean
 
-all: riscof	testfloat combined_IF_vectors zsbl coverage # benchmarks
+all: riscof	testfloat combined_IF_vectors zsbl coverage cvw-arch-verif # benchmarks
 
 # riscof builds the riscv-arch-test and wally-riscv-arch-test suites
 riscof:
@@ -36,6 +36,10 @@ embench:
 coverage:
 	$(MAKE) -C tests/coverage
 
+cvw-arch-verif:
+	$(MAKE) -C ${WALLY}/addins/cvw-arch-verif
+
 clean:
 	$(MAKE) clean -C sim
 	$(MAKE) clean -C ${WALLY}/tests/fp
+	$(MAKE) clean -C ${WALLY}/addins/cvw-arch-verif


### PR DESCRIPTION
Will be needed once we switch the coverage tests to use the cvw-arch-verif test suite.

Also updates to latest version of the submodule. We really should get Dependabot running so this can happen automatically in the future. The version we are currently pinned to was broken and doesn't even build