### PR TITLE
Installation updates + Debian support

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -50,6 +50,10 @@ jobs:
             os: ubuntu-latest
             image: debian:12
             imageFamily: debian
+          - name: debian-11
+            os: ubuntu-latest
+            image: debian:11
+            imageFamily: debian
           # Red Hat Installations
           - name: rocky-8
             os: ubuntu-latest

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -38,25 +38,37 @@ jobs:
           - name: ubuntu-20.04
             os: ubuntu-20.04
             container: null
+            regresssionFail: true
           - name: ubuntu-22.04
             os: ubuntu-22.04
             container: null
           - name: ubuntu-24.04
             os: ubuntu-24.04
             container: null
+          # Debian Installations
+          - name: debian-12
+            os: ubuntu-latest
+            image: debian:12
+            imageFamily: debian
           # Red Hat Installations
           - name: rocky-8
             os: ubuntu-latest
             image: rockylinux:8
+            imageFamily: redhat
+            regressionFail: true
           - name: rocky-9
             os: ubuntu-latest
             image: rockylinux:9
+            imageFamily: redhat
           - name: almalinux-8
             os: ubuntu-latest
             image: almalinux:8
+            imageFamily: redhat
+            regressionFail: true
           - name: almalinux-9
             os: ubuntu-latest
             image: almalinux:9
+            imageFamily: redhat
           # User level installation
           - name: user-install
             os: ubuntu-latest
@@ -82,11 +94,16 @@ jobs:
 
     steps:
       # Docker images need git installed or the checkout action fails
-      - name: Install Dependencies for Red Hat
+      - name: Install Dependencies for Container Image
         if: ${{ matrix.image != null }}
         run: |
-            dnf install -y sudo git
-            dnf install curl -y --allowerasing || true
+            if [ ${{ matrix.imageFamily }} == "debian" ]; then
+              apt-get update
+              apt-get install -y sudo git
+            elif [ ${{ matrix.imageFamily }} == "redhat" ]; then
+              dnf install -y sudo git
+              dnf install curl -y --allowerasing || true
+            fi
       # Only clone submodules needed for standard tests/regression to save space
       - uses: actions/checkout@v4
       - name: Clone Necessary Submodules
@@ -140,12 +157,12 @@ jobs:
               df -h
       # Run standard regression, skipping distros that are known to be broken with Verilator
       - name: Regression
-        if: ${{ matrix.name != 'ubuntu-20.04' && matrix.name != 'rocky-8' && matrix.name != 'almalinux-8'}}
+        if: ${{ matrix.regressionFail != true }}
         run: |
               source setup.sh
               regression-wally
       - name: Lint + wsim Test Only (for distros with broken Verilator sim)
-        if: ${{ matrix.name == 'ubuntu-20.04' || matrix.name == 'rocky-8' || matrix.name == 'almalinux-8'}}
+        if: ${{ matrix.regressionFail == true }}
         run: |
               source setup.sh
               mkdir -p $WALLY/sim/verilator/logs/

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -38,7 +38,7 @@ jobs:
           - name: ubuntu-20.04
             os: ubuntu-20.04
             container: null
-            regresssionFail: true
+            regressionFail: true
           - name: ubuntu-22.04
             os: ubuntu-22.04
             container: null

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Then fork and clone the repo, source setup, make the tests and run regression
 > This section describes the open source toolchain installation.
 
 ### Compatibility
-The current version of the toolchain has been tested on Ubuntu (versions 20.04 LTS, 22.04 LTS, and 24.04 LTS) and on Red Hat/Rocky/AlmaLinux (versions 8 and 9).
+The current version of the toolchain has been tested on Ubuntu (versions 20.04 LTS, 22.04 LTS, and 24.04 LTS), Debian (versions 11 and 12), and Red Hat/Rocky/AlmaLinux (versions 8 and 9). Only the latest minor release of each major version is tested.
 
 > [!WARNING]
 > - Ubuntu 22.04LTS is incompatible with Synopsys Design Compiler.

--- a/bin/wally-distro-check.sh
+++ b/bin/wally-distro-check.sh
@@ -91,8 +91,8 @@ elif [[ "$ID" == debian || "$ID_LIKE" == *debian* ]]; then
             "is $PRETTY_NAME. The regular Debian install will be attempted, but there may be issues."
     fi
     export DEBIAN_VERSION="$VERSION_ID"
-    if (( DEBIAN_VERSION < 12 )); then
-        printf "${FAIL_COLOR}%s\n${ENDC}" "The Wally install script has only been tested with Debian version 12. You have version $VERSION."
+    if (( DEBIAN_VERSION < 11 )); then
+        printf "${FAIL_COLOR}%s\n${ENDC}" "The Wally install script has only been tested with Debian versions 11 and 12. You have version $VERSION."
         exit 1
     fi
 else

--- a/bin/wally-distro-check.sh
+++ b/bin/wally-distro-check.sh
@@ -65,38 +65,38 @@ fi
 if [[ "$ID" == rhel || "$ID_LIKE" == *rhel* ]]; then
     export FAMILY=rhel
     if [ "$ID" != rhel ] && [ "$ID" != rocky ] && [ "$ID" != almalinux ]; then
-        printf "${WARNING_COLOR}%s%s\n${ENDC}" "For Red Hat family distros, the Wally install script has only been tested on RHEL, Rocky Linux," \
+        printf "${WARNING_COLOR}%s%s\n${ENDC}" "For Red Hat family distros, the Wally installation script has only been tested on RHEL, Rocky Linux," \
             " and AlmaLinux. Your distro is $PRETTY_NAME. The regular Red Hat install will be attempted, but there may be issues."
     fi
     export RHEL_VERSION="${VERSION_ID:0:1}"
     if (( RHEL_VERSION < 8 )); then
-        printf "${FAIL_COLOR}%s\n${ENDC}" "The Wally install script is only compatible with versions 8 and 9 of RHEL, Rocky Linux, and AlmaLinux. You have version $VERSION."
+        printf "${FAIL_COLOR}%s\n${ENDC}" "The Wally installation script is only compatible with versions 8 and 9 of RHEL, Rocky Linux, and AlmaLinux. You have version $VERSION."
         exit 1
     fi
 elif [[ "$ID" == ubuntu || "$ID_LIKE" == *ubuntu* ]]; then
     export FAMILY=ubuntu
     if [ "$ID" != ubuntu ]; then
-        printf "${WARNING_COLOR}%s\n${ENDC}" "For Ubuntu family distros, the Wally install script has only been tested on standard Ubuntu. Your distro " \
+        printf "${WARNING_COLOR}%s%s\n${ENDC}" "For Ubuntu family distros, the Wally installation script has only been tested on standard Ubuntu. Your distro " \
             "is $PRETTY_NAME. The regular Ubuntu install will be attempted, but there may be issues."
     fi
     export UBUNTU_VERSION="${VERSION_ID:0:2}"
     if (( UBUNTU_VERSION < 20 )); then
-        printf "${FAIL_COLOR}%s\n${ENDC}" "The Wally install script has only been tested with Ubuntu versions 20.04 LTS, 22.04 LTS, and 24.04 LTS. You have version $VERSION."
+        printf "${FAIL_COLOR}%s\n${ENDC}" "The Wally installation script has only been tested with Ubuntu versions 20.04 LTS, 22.04 LTS, and 24.04 LTS. You have version $VERSION."
         exit 1
     fi
 elif [[ "$ID" == debian || "$ID_LIKE" == *debian* ]]; then
     export FAMILY=debian
     if [ "$ID" != debian ]; then
-        printf "${WARNING_COLOR}%s\n${ENDC}" "For Debian family distros, the Wally install script has only been tested on standard Debian (and Ubuntu). Your distro " \
+        printf "${WARNING_COLOR}%s%s\n${ENDC}" "For Debian family distros, the Wally installation script has only been tested on standard Debian (and Ubuntu). Your distro " \
             "is $PRETTY_NAME. The regular Debian install will be attempted, but there may be issues."
     fi
     export DEBIAN_VERSION="$VERSION_ID"
     if (( DEBIAN_VERSION < 11 )); then
-        printf "${FAIL_COLOR}%s\n${ENDC}" "The Wally install script has only been tested with Debian versions 11 and 12. You have version $VERSION."
+        printf "${FAIL_COLOR}%s\n${ENDC}" "The Wally installation script has only been tested with Debian versions 11 and 12. You have version $VERSION."
         exit 1
     fi
 else
-    printf "${FAIL_COLOR}%s%s%s\n${ENDC}" "The Wally install script is currently only compatible with Ubuntu, Debian, and Red Hat family " \
+    printf "${FAIL_COLOR}%s%s%s\n${ENDC}" "The Wally installation script is currently only compatible with Ubuntu, Debian, and Red Hat family " \
         "(RHEL, Rocky Linux, or AlmaLinux) distros. Your detected distro is $PRETTY_NAME. You may try manually running the " \
         "commands in this script, but it is likely that some will need to be altered."
     exit 1

--- a/bin/wally-distro-check.sh
+++ b/bin/wally-distro-check.sh
@@ -96,7 +96,7 @@ elif [[ "$ID" == debian || "$ID_LIKE" == *debian* ]]; then
         exit 1
     fi
 else
-    printf "${FAIL_COLOR}%s%s%s\n${ENDC}" "The Wally install script is currently only compatible with Ubuntu and Red Hat family " \
+    printf "${FAIL_COLOR}%s%s%s\n${ENDC}" "The Wally install script is currently only compatible with Ubuntu, Debian, and Red Hat family " \
         "(RHEL, Rocky Linux, or AlmaLinux) distros. Your detected distro is $PRETTY_NAME. You may try manually running the " \
         "commands in this script, but it is likely that some will need to be altered."
     exit 1

--- a/bin/wally-distro-check.sh
+++ b/bin/wally-distro-check.sh
@@ -84,6 +84,17 @@ elif [[ "$ID" == ubuntu || "$ID_LIKE" == *ubuntu* ]]; then
         printf "${FAIL_COLOR}%s\n${ENDC}" "The Wally install script has only been tested with Ubuntu versions 20.04 LTS, 22.04 LTS, and 24.04 LTS. You have version $VERSION."
         exit 1
     fi
+elif [[ "$ID" == debian || "$ID_LIKE" == *debian* ]]; then
+    export FAMILY=debian
+    if [ "$ID" != debian ]; then
+        printf "${WARNING_COLOR}%s\n${ENDC}" "For Debian family distros, the Wally install script has only been tested on standard Debian (and Ubuntu). Your distro " \
+            "is $PRETTY_NAME. The regular Debian install will be attempted, but there may be issues."
+    fi
+    export DEBIAN_VERSION="$VERSION_ID"
+    if (( DEBIAN_VERSION < 12 )); then
+        printf "${FAIL_COLOR}%s\n${ENDC}" "The Wally install script has only been tested with Debian version 12. You have version $VERSION."
+        exit 1
+    fi
 else
     printf "${FAIL_COLOR}%s%s%s\n${ENDC}" "The Wally install script is currently only compatible with Ubuntu and Red Hat family " \
         "(RHEL, Rocky Linux, or AlmaLinux) distros. Your detected distro is $PRETTY_NAME. You may try manually running the " \

--- a/bin/wally-distro-check.sh
+++ b/bin/wally-distro-check.sh
@@ -41,32 +41,36 @@ ENDC='\033[0m' # Reset to default color
 # Print section header
 section_header() {
     if tput cols > /dev/null 2>&1; then
-        printf "${SECTION_COLOR}%$(tput cols)s" | tr ' ' '#'
-        printf "%$(tput cols)s" | tr ' ' '#'
-        echo -e "$1"
-        printf "%$(tput cols)s" | tr ' ' '#'
-        printf "%$(tput cols)s${ENDC}" | tr ' ' '#'
+        printf "${SECTION_COLOR}%$(tput cols)s\n" | tr ' ' '#'
+        printf "%$(tput cols)s\n" | tr ' ' '#'
+        printf "%s\n" "$1"
+        printf "%$(tput cols)s\n" | tr ' ' '#'
+        printf "%$(tput cols)s${ENDC}\n" | tr ' ' '#'
     else
-        echo -e "${SECTION_COLOR}$1${ENDC}"
+        printf "${SECTION_COLOR}%s\n${ENDC}" "$1"
     fi
 }
 
 section_header "Checking System Requirements and Configuring Installation"
 
 # Get distribution information
-test -e /etc/os-release && os_release="/etc/os-release" || os_release="/usr/lib/os-release"
-source "$os_release"
+if [ -f /etc/os-release ]; then
+    source /etc/os-release
+else
+    printf "${FAIL_COLOR}%s\n${ENDC}" "/etc/os-release file not found. Distribution unknown."
+    PRETTY_NAME=UNKNOWN
+fi
 
 # Check for compatible distro
 if [[ "$ID" == rhel || "$ID_LIKE" == *rhel* ]]; then
     export FAMILY=rhel
     if [ "$ID" != rhel ] && [ "$ID" != rocky ] && [ "$ID" != almalinux ]; then
-        printf "${WARNING_COLOR}%s\n${ENDC}" "For Red Hat family distros, the Wally install script has only been tested on RHEL, Rocky Linux," \
+        printf "${WARNING_COLOR}%s%s\n${ENDC}" "For Red Hat family distros, the Wally install script has only been tested on RHEL, Rocky Linux," \
             " and AlmaLinux. Your distro is $PRETTY_NAME. The regular Red Hat install will be attempted, but there may be issues."
     fi
     export RHEL_VERSION="${VERSION_ID:0:1}"
     if (( RHEL_VERSION < 8 )); then
-        echo "${FAIL_COLOR}The Wally install script is only compatible with versions 8 and 9 of RHEL, Rocky Linux, and AlmaLinux. You have version $VERSION.${ENDC}"
+        printf "${FAIL_COLOR}%s\n${ENDC}" "The Wally install script is only compatible with versions 8 and 9 of RHEL, Rocky Linux, and AlmaLinux. You have version $VERSION."
         exit 1
     fi
 elif [[ "$ID" == ubuntu || "$ID_LIKE" == *ubuntu* ]]; then
@@ -77,16 +81,16 @@ elif [[ "$ID" == ubuntu || "$ID_LIKE" == *ubuntu* ]]; then
     fi
     export UBUNTU_VERSION="${VERSION_ID:0:2}"
     if (( UBUNTU_VERSION < 20 )); then
-        echo "${FAIL_COLOR}The Wally install script has only been tested with versions 20.04 LTS, 22.04 LTS, and 24.04 LTS of Ubuntu. You have version $VERSION.${ENDC}"
+        printf "${FAIL_COLOR}%s\n${ENDC}" "The Wally install script has only been tested with Ubuntu versions 20.04 LTS, 22.04 LTS, and 24.04 LTS. You have version $VERSION."
         exit 1
     fi
 else
-    printf "${FAIL_COLOR}%s\n${ENDC}" "The Wally install script is currently only compatible with Ubuntu and Red Hat family " \
+    printf "${FAIL_COLOR}%s%s%s\n${ENDC}" "The Wally install script is currently only compatible with Ubuntu and Red Hat family " \
         "(RHEL, Rocky Linux, or AlmaLinux) distros. Your detected distro is $PRETTY_NAME. You may try manually running the " \
         "commands in this script, but it is likely that some will need to be altered."
     exit 1
 fi
 
-echo -e "${OK_COLOR}${UNDERLINE}Detected information${ENDC}"
+printf "${OK_COLOR}${UNDERLINE}%s\n${ENDC}" "Detected information"
 echo "Distribution: $PRETTY_NAME"
 echo "Version: $VERSION"

--- a/bin/wally-package-install.sh
+++ b/bin/wally-package-install.sh
@@ -43,18 +43,24 @@ if [ -z "$FAMILY" ]; then
 fi
 
 
-# Generate list of packages to install and package manager commands based on distro
 # Packages are grouped by which tool requires them. If multiple tools need a package, it is included in the first tool only
+# Packages that are constant across distros
+GENERAL_PACKAGES+=(rsync git make cmake curl wget tar unzip bzip2 dialog mutt ssmtp)
+GNU_PACKAGES+=(autoconf automake gawk bison flex texinfo gperf libtool ninja-build patchutils bc gcc)
+VERILATOR_PACKAGES+=(help2man perl clang ccache numactl)
+BUILDROOT_PACKAGES+=(ncurses-base cpio)
+
+# Distro specific packages and package manager
 if [ "$FAMILY" == rhel ]; then
     PYTHON_VERSION=python3.12
-    PACKAGE_MANAGER="dnf"
-    UPDATE_COMMAND="sudo $PACKAGE_MANAGER update -y"
-    GENERAL_PACKAGES+=(which rsync git make cmake "$PYTHON_VERSION" "$PYTHON_VERSION"-pip curl wget tar pkgconf-pkg-config dialog mutt ssmtp)
-    GNU_PACKAGES+=(autoconf automake  libmpc-devel mpfr-devel gmp-devel gawk bison flex texinfo gperf libtool patchutils bc gcc gcc-c++ zlib-devel expat-devel libslirp-devel)
-    QEMU_PACKAGES+=(glib2-devel libfdt-devel pixman-devel bzip2 ninja-build)
+    PACKAGE_MANAGER="dnf -y"
+    UPDATE_COMMAND="sudo $PACKAGE_MANAGER update"
+    GENERAL_PACKAGES+=(which "$PYTHON_VERSION" "$PYTHON_VERSION"-pip pkgconf-pkg-config gcc-c++)
+    GNU_PACKAGES+=(libmpc-devel mpfr-devel gmp-devel zlib-devel expat-devel libslirp-devel)
+    QEMU_PACKAGES+=(glib2-devel libfdt-devel pixman-devel)
     SPIKE_PACKAGES+=(dtc boost-regex boost-system)
-    VERILATOR_PACKAGES+=(help2man perl clang ccache gperftools numactl mold)
-    BUILDROOT_PACKAGES+=(ncurses-base ncurses ncurses-libs ncurses-devel gcc-gfortran cpio) # gcc-gfortran is only needed for compiling spec benchmarks on buildroot linux
+    VVERILATOR_PACKAGES+=(gperftools mold)
+    BUILDROOT_PACKAGES+=(ncurses ncurses-libs ncurses-devel gcc-gfortran) # gcc-gfortran is only needed for compiling spec benchmarks on buildroot linux
     # Extra packages not availale in rhel8, nice for Verilator
     if (( RHEL_VERSION >= 9 )); then
         VERILATOR_PACKAGES+=(perl-doc)
@@ -78,14 +84,14 @@ elif [[ "$FAMILY" == ubuntu || "$FAMILY" == debian ]]; then
     if (( UBUNTU_VERSION != 20 && DEBIAN_VERSION != 11 )); then
         VERILATOR_PACKAGES+=(mold)
     fi
-    PACKAGE_MANAGER="DEBIAN_FRONTEND=noninteractive apt-get"
-    UPDATE_COMMAND="sudo $PACKAGE_MANAGER update -y && sudo $PACKAGE_MANAGER upgrade -y --with-new-pkgs"
-    GENERAL_PACKAGES+=(rsync git make cmake "$PYTHON_VERSION" python3-pip "$PYTHON_VERSION"-venv curl wget tar unzip pkg-config dialog mutt ssmtp)
-    GNU_PACKAGES+=(autoconf automake autotools-dev libmpc-dev libmpfr-dev libgmp-dev gawk build-essential bison flex texinfo gperf libtool patchutils bc zlib1g-dev libexpat1-dev ninja-build libglib2.0-dev libslirp-dev)
+    PACKAGE_MANAGER="DEBIAN_FRONTEND=noninteractive apt-get -y"
+    UPDATE_COMMAND="sudo $PACKAGE_MANAGER update && sudo $PACKAGE_MANAGER upgrade --with-new-pkgs"
+    GENERAL_PACKAGES+=("$PYTHON_VERSION" python3-pip "$PYTHON_VERSION"-venv pkg-config g++)
+    GNU_PACKAGES+=(autotools-dev libmpc-dev libmpfr-dev libgmp-dev build-essential zlib1g-dev libexpat1-dev libglib2.0-dev libslirp-dev)
     QEMU_PACKAGES+=(libfdt-dev libpixman-1-dev)
     SPIKE_PACKAGES+=(device-tree-compiler libboost-regex-dev libboost-system-dev)
-    VERILATOR_PACKAGES+=(help2man perl g++ clang ccache libunwind-dev libgoogle-perftools-dev numactl perl-doc libfl2 libfl-dev zlib1g)
-    BUILDROOT_PACKAGES+=(ncurses-base ncurses-bin libncurses-dev gfortran cpio) # gfortran is only needed for compiling spec benchmarks on buildroot linux
+    VERILATOR_PACKAGES+=(libunwind-dev libgoogle-perftools-dev perl-doc libfl2 libfl-dev zlib1g)
+    BUILDROOT_PACKAGES+=(ncurses-bin libncurses-dev gfortran) # gfortran is only needed for compiling spec benchmarks on buildroot linux
     VIVADO_PACKAGES+=(libncurses*) # Vivado hangs on the third stage of installation without this
 fi
 
@@ -128,7 +134,7 @@ else
     # Update and Upgrade tools
     eval "$UPDATE_COMMAND"
     # Install packages listed above using appropriate package manager
-    sudo $PACKAGE_MANAGER install -y "${GENERAL_PACKAGES[@]}" "${GNU_PACKAGES[@]}" "${QEMU_PACKAGES[@]}" "${SPIKE_PACKAGES[@]}" "${VERILATOR_PACKAGES[@]}" "${BUILDROOT_PACKAGES[@]}" "${OTHER_PACKAGES[@]}" "${VIVADO_PACKAGES[@]}"
+    sudo $PACKAGE_MANAGER install "${GENERAL_PACKAGES[@]}" "${GNU_PACKAGES[@]}" "${QEMU_PACKAGES[@]}" "${SPIKE_PACKAGES[@]}" "${VERILATOR_PACKAGES[@]}" "${BUILDROOT_PACKAGES[@]}" "${OTHER_PACKAGES[@]}" "${VIVADO_PACKAGES[@]}"
 
     # Post install steps
     # Vivado looks for ncurses5 libraries, but Ubuntu 24.04 only has ncurses6

--- a/bin/wally-package-install.sh
+++ b/bin/wally-package-install.sh
@@ -71,8 +71,12 @@ elif [[ "$FAMILY" == ubuntu || "$FAMILY" == debian ]]; then
         OTHER_PACKAGES+=(gcc-10 g++-10 cpp-10) # Newer version of gcc needed for Verilator
     elif (( DEBIAN_VERSION >= 12 )); then
         PYTHON_VERSION=python3.11
-    if (( UBUNTU_VERSION != 20 )); then
-        VERILATOR_PACKAGES+=(mold) # Not availale in Ubuntu 20.04, binary will be downloaded instead
+    elif (( DEBIAN_VERSION >= 11 )); then
+        PYTHON_VERSION=python3.9
+    fi
+    # Mold not available in older distros for Verilator, will download binary instead
+    if (( UBUNTU_VERSION != 20 && DEBIAN_VERSION != 11 )); then
+        VERILATOR_PACKAGES+=(mold)
     fi
     PACKAGE_MANAGER="DEBIAN_FRONTEND=noninteractive apt-get"
     UPDATE_COMMAND="sudo $PACKAGE_MANAGER update -y && sudo $PACKAGE_MANAGER upgrade -y --with-new-pkgs"

--- a/bin/wally-package-install.sh
+++ b/bin/wally-package-install.sh
@@ -103,7 +103,7 @@ if [ "${1}" == "--check" ]; then
         for pack in "${GENERAL_PACKAGES[@]}" "${GNU_PACKAGES[@]}" "${QEMU_PACKAGES[@]}" "${SPIKE_PACKAGES[@]}" "${VERILATOR_PACKAGES[@]}" "${BUILDROOT_PACKAGES[@]}" "${OTHER_PACKAGES[@]}"; do
             rpm -q "$pack" > /dev/null || (echo -e "${FAIL_COLOR}Missing packages detected (${WARNING_COLOR}$pack${FAIL_COLOR}). Run as root to auto-install or run wally-package-install.sh first.${ENDC}" && exit 1)
         done
-    elif [ "$FAMILY" == ubuntu ]; then
+    elif [[ "$FAMILY" == ubuntu || "$FAMILY" == debian ]]; then
         for pack in "${GENERAL_PACKAGES[@]}" "${GNU_PACKAGES[@]}" "${QEMU_PACKAGES[@]}" "${SPIKE_PACKAGES[@]}" "${VERILATOR_PACKAGES[@]}" "${BUILDROOT_PACKAGES[@]}" "${OTHER_PACKAGES[@]}"; do
             dpkg -l "$pack" | grep "ii" > /dev/null || (echo -e "${FAIL_COLOR}Missing packages detected (${WARNING_COLOR}$pack${FAIL_COLOR}). Run as root to auto-install or run wally-package-install.sh first." && exit 1)
         done

--- a/bin/wally-package-install.sh
+++ b/bin/wally-package-install.sh
@@ -80,7 +80,7 @@ elif [[ "$FAMILY" == ubuntu || "$FAMILY" == debian ]]; then
     fi
     PACKAGE_MANAGER="DEBIAN_FRONTEND=noninteractive apt-get"
     UPDATE_COMMAND="sudo $PACKAGE_MANAGER update -y && sudo $PACKAGE_MANAGER upgrade -y --with-new-pkgs"
-    GENERAL_PACKAGES+=(rsync git make cmake "$PYTHON_VERSION" python3-pip "$PYTHON_VERSION"-venv curl wget tar pkg-config dialog mutt ssmtp)
+    GENERAL_PACKAGES+=(rsync git make cmake "$PYTHON_VERSION" python3-pip "$PYTHON_VERSION"-venv curl wget tar unzip pkg-config dialog mutt ssmtp)
     GNU_PACKAGES+=(autoconf automake autotools-dev libmpc-dev libmpfr-dev libgmp-dev gawk build-essential bison flex texinfo gperf libtool patchutils bc zlib1g-dev libexpat1-dev ninja-build libglib2.0-dev libslirp-dev)
     QEMU_PACKAGES+=(libfdt-dev libpixman-1-dev)
     SPIKE_PACKAGES+=(device-tree-compiler libboost-regex-dev libboost-system-dev)

--- a/bin/wally-package-install.sh
+++ b/bin/wally-package-install.sh
@@ -61,7 +61,7 @@ if [ "$FAMILY" == rhel ]; then
     fi
     # A newer version of gcc is required for qemu
     OTHER_PACKAGES=(gcc-toolset-13)
-elif [ "$FAMILY" == ubuntu ]; then
+elif [[ "$FAMILY" == ubuntu || "$FAMILY" == debian ]]; then
     if (( UBUNTU_VERSION >= 24 )); then
         PYTHON_VERSION=python3.12
         VERILATOR_PACKAGES+=(mold) # Not availale in Ubuntu 20.04, nice for Verilator
@@ -71,11 +71,14 @@ elif [ "$FAMILY" == ubuntu ]; then
     elif (( UBUNTU_VERSION >= 20 )); then
         PYTHON_VERSION=python3.9
         OTHER_PACKAGES+=(gcc-10 g++-10 cpp-10) # Newer version of gcc needed for Verilator
+    elif (( DEBIAN_VERSION >= 12 )); then
+        PYTHON_VERSION=python3.11
+        VERILATOR_PACKAGES+=(mold) # Not availale in Ubuntu 20.04, nice for Verilator
     fi
     PACKAGE_MANAGER="DEBIAN_FRONTEND=noninteractive apt-get"
     UPDATE_COMMAND="sudo $PACKAGE_MANAGER update -y && sudo $PACKAGE_MANAGER upgrade -y --with-new-pkgs"
     GENERAL_PACKAGES+=(rsync git make cmake "$PYTHON_VERSION" python3-pip "$PYTHON_VERSION"-venv curl wget tar pkg-config dialog mutt ssmtp)
-    GNU_PACKAGES+=(autoconf automake autotools-dev curl libmpc-dev libmpfr-dev libgmp-dev gawk build-essential bison flex texinfo gperf libtool patchutils bc zlib1g-dev libexpat1-dev ninja-build libglib2.0-dev libslirp-dev)
+    GNU_PACKAGES+=(autoconf automake autotools-dev libmpc-dev libmpfr-dev libgmp-dev gawk build-essential bison flex texinfo gperf libtool patchutils bc zlib1g-dev libexpat1-dev ninja-build libglib2.0-dev libslirp-dev)
     QEMU_PACKAGES+=(libfdt-dev libpixman-1-dev)
     SPIKE_PACKAGES+=(device-tree-compiler libboost-regex-dev libboost-system-dev)
     VERILATOR_PACKAGES+=(help2man perl g++ clang ccache libunwind-dev libgoogle-perftools-dev numactl perl-doc libfl2 libfl-dev zlib1g)

--- a/bin/wally-package-install.sh
+++ b/bin/wally-package-install.sh
@@ -64,16 +64,15 @@ if [ "$FAMILY" == rhel ]; then
 elif [[ "$FAMILY" == ubuntu || "$FAMILY" == debian ]]; then
     if (( UBUNTU_VERSION >= 24 )); then
         PYTHON_VERSION=python3.12
-        VERILATOR_PACKAGES+=(mold) # Not availale in Ubuntu 20.04, nice for Verilator
     elif (( UBUNTU_VERSION >= 22 )); then
         PYTHON_VERSION=python3.11
-        VERILATOR_PACKAGES+=(mold) # Not availale in Ubuntu 20.04, nice for Verilator
     elif (( UBUNTU_VERSION >= 20 )); then
         PYTHON_VERSION=python3.9
         OTHER_PACKAGES+=(gcc-10 g++-10 cpp-10) # Newer version of gcc needed for Verilator
     elif (( DEBIAN_VERSION >= 12 )); then
         PYTHON_VERSION=python3.11
-        VERILATOR_PACKAGES+=(mold) # Not availale in Ubuntu 20.04, nice for Verilator
+    if (( UBUNTU_VERSION != 20 )); then
+        VERILATOR_PACKAGES+=(mold) # Not availale in Ubuntu 20.04, binary will be downloaded instead
     fi
     PACKAGE_MANAGER="DEBIAN_FRONTEND=noninteractive apt-get"
     UPDATE_COMMAND="sudo $PACKAGE_MANAGER update -y && sudo $PACKAGE_MANAGER upgrade -y --with-new-pkgs"

--- a/bin/wally-tool-chain-install.sh
+++ b/bin/wally-tool-chain-install.sh
@@ -118,7 +118,7 @@ if [ "$1" == "--clean" ] || [ "$2" == "--clean" ]; then
     shift
 fi
 
-# Check for clean flag
+# Check for no-buildroot flag
 if [ "$1" == "--no-buildroot" ] || [ "$2" == "--no-buildroot" ]; then
     no_buidroot=true
     shift
@@ -269,11 +269,10 @@ fi
 # and the GNU Debugger Project (gdb). It is a collection of tools used to compile RISC-V programs.
 # To install GCC from source can take hours to compile.
 # This configuration enables multilib to target many flavors of RISC-V.
-# This book is tested with GCC 13.2.0
+# This book is tested with GCC 13.2.0 and 14.2.0.
 section_header "Installing/Updating RISC-V GNU Toolchain"
 STATUS="riscv-gnu-toolchain"
 cd "$RISCV"
-# Temporarily pin riscv-gnu-toolchain to use GCC 13.2.0. GCC 14 does not work with the Q extension.
 if git_check "riscv-gnu-toolchain" "https://github.com/riscv/riscv-gnu-toolchain" "$RISCV/riscv-gnu-toolchain/stamps/build-gcc-newlib-stage2"; then
     cd "$RISCV"/riscv-gnu-toolchain
     git reset --hard && git clean -f && git checkout master && git pull && git submodule update

--- a/bin/wally-tool-chain-install.sh
+++ b/bin/wally-tool-chain-install.sh
@@ -269,7 +269,12 @@ if (( UBUNTU_VERSION == 20  || DEBIAN_VERSION == 11 )); then
     if [ ! -e "$RISCV"/bin/mold ]; then
         section_header "Installing mold"
         cd "$RISCV"
-        wget -nv --retry-connrefused $retry_on_host_error https://github.com/rui314/mold/releases/download/v2.34.1/mold-2.34.1-x86_64-linux.tar.gz
+        wget -nv --retry-connrefused $retry_on_host_error --output-document=mold.tar.gz https://github.com/rui314/mold/releases/download/v2.34.1/mold-2.34.1-x86_64-linux.tar.gz
+        tar xz --directory="$RISCV" --strip-components=1 -f mold.tar.gz
+        rm -f mold.tar.gz
+        echo -e "${SUCCESS_COLOR}Mold successfully installed/updated!${ENDC}"
+    else
+        echo -e "${SUCCESS_COLOR}Mold already installed.${ENDC}"
     fi
 fi
 

--- a/bin/wally-tool-chain-install.sh
+++ b/bin/wally-tool-chain-install.sh
@@ -264,7 +264,7 @@ if (( RHEL_VERSION == 8 )); then
 fi
 
 # Mold needed for Verilator
-if (( UBUNTU_VERSION == 20 )); then
+if (( UBUNTU_VERSION == 20  || DEBIAN_VERSION == 11 )); then
     STATUS="mold"
     if [ ! -e "$RISCV"/bin/mold ]; then
         section_header "Installing mold"

--- a/bin/wally-tool-chain-install.sh
+++ b/bin/wally-tool-chain-install.sh
@@ -263,6 +263,15 @@ if (( RHEL_VERSION == 8 )); then
     fi
 fi
 
+# Mold needed for Verilator
+if (( UBUNTU_VERSION == 20 )); then
+    STATUS="mold"
+    if [ ! -e "$RISCV"/bin/mold ]; then
+        section_header "Installing mold"
+        cd "$RISCV"
+        wget -nv --retry-connrefused $retry_on_host_error https://github.com/rui314/mold/releases/download/v2.34.1/mold-2.34.1-x86_64-linux.tar.gz
+    fi
+fi
 
 # RISC-V GNU Toolchain (https://github.com/riscv-collab/riscv-gnu-toolchain)
 # The RISC-V GNU Toolchain includes the GNU Compiler Collection (gcc), GNU Binutils, Newlib,


### PR DESCRIPTION
- Lots of cleanup of comments and print messages in installation files
- Enable support for Debian 11 and 12. They are nearly identical installation methods and this allows for the CVW tools to be installed on any Debian or Ubuntu distro/clone.