### PR TITLE
Remove FreeRTOS submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,9 +8,6 @@
 [submodule "addins/coremark"]
 	path = addins/coremark
 	url = https://github.com/eembc/coremark
-[submodule "addins/FreeRTOS-Kernel"]
-	path = addins/FreeRTOS-Kernel
-	url = https://github.com/FreeRTOS/FreeRTOS-Kernel.git
 [submodule "addins/vivado-boards"]
 	path = addins/vivado-boards
 	url = https://github.com/Digilent/vivado-boards/


### PR DESCRIPTION
We don't currently use it and if/when we do start working on getting it running, we probably want to start with a newer version.