### PR TITLE
Add support for SUSE family distros (tested on OpenSUSE) to installation script

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -73,6 +73,11 @@ jobs:
             os: ubuntu-latest
             image: almalinux:9
             imageFamily: redhat
+          # SUSE Installations
+          - name: opensuse-15.6
+            os: ubuntu-latest
+            image: opensuse/leap:15.6
+            imageFamily: suse
           # User level installation
           - name: user-install
             os: ubuntu-latest
@@ -107,6 +112,8 @@ jobs:
             elif [ ${{ matrix.imageFamily }} == "redhat" ]; then
               dnf install -y sudo git
               dnf install curl -y --allowerasing || true
+            elif [ ${{ matrix.imageFamily }} == "suse" ]; then
+              zypper install -y sudo git
             fi
       # Only clone submodules needed for standard tests/regression to save space
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Then fork and clone the repo, source setup, make the tests and run regression
 > This section describes the open source toolchain installation.
 
 ### Compatibility
-The current version of the toolchain has been tested on Ubuntu (versions 20.04 LTS, 22.04 LTS, and 24.04 LTS), Debian (versions 11 and 12), and Red Hat/Rocky/AlmaLinux (versions 8 and 9). Only the latest minor release of each major version is tested.
+The current version of the toolchain has been tested on Ubuntu (versions 20.04 LTS, 22.04 LTS, and 24.04 LTS), Debian (versions 11 and 12), Red Hat/Rocky/AlmaLinux (versions 8 and 9), and OpenSUSE (version 15.6). Only the latest minor release of each major version is tested.
 
 > [!WARNING]
 > - Ubuntu 22.04LTS is incompatible with Synopsys Design Compiler.

--- a/bin/wally-distro-check.sh
+++ b/bin/wally-distro-check.sh
@@ -95,6 +95,17 @@ elif [[ "$ID" == debian || "$ID_LIKE" == *debian* ]]; then
         printf "${FAIL_COLOR}%s\n${ENDC}" "The Wally installation script has only been tested with Debian versions 11 and 12. You have version $VERSION."
         exit 1
     fi
+elif [[ "$ID" == opensuse-leap || "$ID" == sles || "$ID_LIKE" == *suse* ]]; then
+    export FAMILY=suse
+    if [[ "$ID" != opensuse-leap && "$ID" != sles  ]]; then
+        printf "${WARNING_COLOR}%s%s\n${ENDC}" "For SUSE family distros, the Wally installation script has only been tested on OpenSUSE Leap and SLES. Your distro " \
+            "is $PRETTY_NAME. The regular SUSE install will be attempted, but there may be issues. If you are using OpenSUSE Tumbleweed, the version check will fail."
+    fi
+    export SUSE_VERSION="${VERSION_ID//.}"
+    if (( SUSE_VERSION < 156 )); then
+        printf "${FAIL_COLOR}%s\n${ENDC}" "The Wally installation script has only been tested with SUSE version 15.6. You have version $VERSION."
+        exit 1
+    fi
 else
     printf "${FAIL_COLOR}%s%s%s\n${ENDC}" "The Wally installation script is currently only compatible with Ubuntu, Debian, and Red Hat family " \
         "(RHEL, Rocky Linux, or AlmaLinux) distros. Your detected distro is $PRETTY_NAME. You may try manually running the " \

--- a/bin/wally-package-install.sh
+++ b/bin/wally-package-install.sh
@@ -107,7 +107,7 @@ case "$FAMILY" in
         SPIKE_PACKAGES+=(dtc libboost_regex1_75_0-devel libboost_system1_75_0-devel)
         VERILATOR_PACKAGES+=(gperftools perl-doc)
         BUILDROOT_PACKAGES+=(ncurses-utils ncurses-devel ncurses5-devel gcc-fortran) # gcc-fortran is only needed for compiling spec benchmarks on buildroot linux
-        OTHER_PACKAGES+=(gcc14 gcc14-c++ cpp14) # Newer version of gcc needed for many tools. Default is gcc7
+        OTHER_PACKAGES+=(gcc13 gcc13-c++ cpp13) # Newer version of gcc needed for many tools. Default is gcc7
         ;;
 esac
 

--- a/bin/wally-tool-chain-install.sh
+++ b/bin/wally-tool-chain-install.sh
@@ -192,11 +192,11 @@ fi
 if [ "$FAMILY" == rhel ]; then
     source /opt/rh/gcc-toolset-13/enable
 elif [ "$FAMILY" == suse ]; then
-    mkdir -p "$RISCV"/gcc-14/bin
+    mkdir -p "$RISCV"/gcc-13/bin
     for f in gcc cpp g++ gcc-ar gcc-nm gcc-ranlib gcov gcov-dump gcov-tool lto-dump; do
-        ln -vsf /usr/bin/$f-14 "$RISCV"/gcc-14/bin/$f
+        ln -vsf /usr/bin/$f-13 "$RISCV"/gcc-13/bin/$f
     done
-    export PATH="$RISCV"/gcc-14/bin:$PATH
+    export PATH="$RISCV"/gcc-13/bin:$PATH
 elif (( UBUNTU_VERSION == 20 )); then
     mkdir -p "$RISCV"/gcc-10/bin
     for f in gcc cpp g++ gcc-ar gcc-nm gcc-ranlib gcov gcov-dump gcov-tool lto-dump; do

--- a/bin/wally-tool-chain-install.sh
+++ b/bin/wally-tool-chain-install.sh
@@ -191,6 +191,12 @@ fi
 # Enable newer version of gcc for older distros (required for QEMU/Verilator)
 if [ "$FAMILY" == rhel ]; then
     source /opt/rh/gcc-toolset-13/enable
+elif [ "$FAMILY" == suse ]; then
+    mkdir -p "$RISCV"/gcc-14/bin
+    for f in gcc cpp g++ gcc-ar gcc-nm gcc-ranlib gcov gcov-dump gcov-tool lto-dump; do
+        ln -vsf /usr/bin/$f-14 "$RISCV"/gcc-14/bin/$f
+    done
+    export PATH="$RISCV"/gcc-14/bin:$PATH
 elif (( UBUNTU_VERSION == 20 )); then
     mkdir -p "$RISCV"/gcc-10/bin
     for f in gcc cpp g++ gcc-ar gcc-nm gcc-ranlib gcov gcov-dump gcov-tool lto-dump; do
@@ -264,7 +270,7 @@ if (( RHEL_VERSION == 8 )); then
 fi
 
 # Mold needed for Verilator
-if (( UBUNTU_VERSION == 20  || DEBIAN_VERSION == 11 )); then
+if (( UBUNTU_VERSION == 20  || DEBIAN_VERSION == 11 )) || [ "$FAMILY" == suse ]; then
     STATUS="mold"
     if [ ! -e "$RISCV"/bin/mold ]; then
         section_header "Installing mold"

--- a/site-setup.sh
+++ b/site-setup.sh
@@ -77,6 +77,8 @@ fi
 # Use newer gcc version for older distros
 if [ -e /opt/rh/gcc-toolset-13/enable ]; then
     source /opt/rh/gcc-toolset-13/enable # Red Hat Family
+elif [ -e $RISCV/gcc-14 ]; then
+    export PATH=$RISCV/gcc-14/bin:$PATH  # SUSE Family
 elif [ -e $RISCV/gcc-10 ]; then
     export PATH=$RISCV/gcc-10/bin:$PATH  # Ubuntu 20.04 LTS
 fi

--- a/site-setup.sh
+++ b/site-setup.sh
@@ -77,8 +77,8 @@ fi
 # Use newer gcc version for older distros
 if [ -e /opt/rh/gcc-toolset-13/enable ]; then
     source /opt/rh/gcc-toolset-13/enable # Red Hat Family
-elif [ -e $RISCV/gcc-14 ]; then
-    export PATH=$RISCV/gcc-14/bin:$PATH  # SUSE Family
+elif [ -e $RISCV/gcc-13 ]; then
+    export PATH=$RISCV/gcc-13/bin:$PATH  # SUSE Family
 elif [ -e $RISCV/gcc-10 ]; then
     export PATH=$RISCV/gcc-10/bin:$PATH  # Ubuntu 20.04 LTS
 fi


### PR DESCRIPTION
The one major family of Linux distros that still wasn't supported was SUSE. This adds support for the latest version of OpenSUSE Leap (and should be compatible with SLES as well). Besides RHEL, this is the other major distro supported by EDA tool vendors, so it seemed worthwhile to include. Especially because it was very little effort to add after the recent refactoring of the scripts.

I also took the chance to do additional refactoring of the installation script for improved maintenance and readability.