### PR TITLE
List compressed instructions in objdump (also disables pseudo instructions)

### DIFF
--- a/benchmarks/coremark/Makefile
+++ b/benchmarks/coremark/Makefile
@@ -23,7 +23,7 @@ PORT_CFLAGS = -g -mabi=$(ABI) -march=$(ARCH) -static -falign-functions=16 \
 	-fno-delete-null-pointer-checks -fno-rename-registers --param=loop-max-datarefs-for-datadeps=0 \
 	-funroll-all-loops --param=uninlined-function-insns=8 -fno-tree-vrp -fwrapv -fipa-pta \
 	-nostdlib -nostartfiles -ffreestanding -mstrict-align \
-	-DTOTAL_DATA_SIZE=2000 -DMAIN_HAS_NOARGC=1 -DPERFORMANCE_RUN=1 -DITERATIONS=10 -DXLEN=$(XLEN) 
+	-DTOTAL_DATA_SIZE=2000 -DMAIN_HAS_NOARGC=1 -DPERFORMANCE_RUN=1 -DITERATIONS=10 -DXLEN=$(XLEN)
 
 all: $(work_dir)/coremark.bare.riscv.elf.memfile
 
@@ -32,7 +32,7 @@ run: $(work_dir)/coremark.bare.riscv.elf.memfile
 	time wsim ${CONFIG} coremark 2>&1 | tee $(work_dir)/coremark.sim.log
 
 $(work_dir)/coremark.bare.riscv.elf.memfile: $(work_dir)/coremark.bare.riscv
-	riscv64-unknown-elf-objdump -D $< > $<.elf.objdump
+	riscv64-unknown-elf-objdump -Mno-aliases -D $< > $<.elf.objdump
 	riscv64-unknown-elf-elf2hex --bit-width $(XLEN) --input $< --output $@
 	extractFunctionRadix.sh $<.elf.objdump
 

--- a/benchmarks/embench/Makefile
+++ b/benchmarks/embench/Makefile
@@ -5,7 +5,7 @@
 embench_dir = ../../addins/embench-iot
 ARCH=rv32imac_zicsr
 
-all: build 
+all: build
 run: build size sim
 
 allClean: clean all
@@ -16,19 +16,19 @@ buildsize: build_speedopt_size build_sizeopt_size
 
 # uses the build_all.py python file to build the tests in addins/embench-iot/bd_speed/ optimized for speed and size
 build_speedopt_speed:
-	$(embench_dir)/build_all.py --builddir=bd_speedopt_speed --arch riscv32 --chip generic --board rv32wallyverilog --ldflags="-nostartfiles ../../../config/riscv32/boards/rv32wallyverilog/startup/crt0.S -march=$(ARCH)" --cflags="-O2 -nostartfiles -march=$(ARCH)" 
-	# remove files not used in embench1.0  When changing to 2.0, restore these files		
+	$(embench_dir)/build_all.py --builddir=bd_speedopt_speed --arch riscv32 --chip generic --board rv32wallyverilog --ldflags="-nostartfiles ../../../config/riscv32/boards/rv32wallyverilog/startup/crt0.S -march=$(ARCH)" --cflags="-O2 -nostartfiles -march=$(ARCH)"
+	# remove files not used in embench1.0  When changing to 2.0, restore these files
 	#rm -rf $(embench_dir)/bd_speedopt_speed/src/md5sum
 	#rm -rf $(embench_dir)/bd_speedopt_speed/src/tarfind
-	#rm -rf $(embench_dir)/bd_speedopt_speed/src/primecount	
+	#rm -rf $(embench_dir)/bd_speedopt_speed/src/primecount
 	find $(embench_dir)/bd_speedopt_speed/ -type f ! -name "*.*" | while read f; do cp "$$f" "$$f.elf"; done
 
 build_sizeopt_speed:
-	$(embench_dir)/build_all.py --builddir=bd_sizeopt_speed --arch riscv32 --chip generic --board rv32wallyverilog --ldflags="-nostartfiles ../../../config/riscv32/boards/rv32wallyverilog/startup/crt0.S -march=$(ARCH)" --cflags="-Os -nostartfiles -march=$(ARCH)" 
-	# remove files not used in embench1.0  When changing to 2.0, restore these files		
+	$(embench_dir)/build_all.py --builddir=bd_sizeopt_speed --arch riscv32 --chip generic --board rv32wallyverilog --ldflags="-nostartfiles ../../../config/riscv32/boards/rv32wallyverilog/startup/crt0.S -march=$(ARCH)" --cflags="-Os -nostartfiles -march=$(ARCH)"
+	# remove files not used in embench1.0  When changing to 2.0, restore these files
 	#rm -rf $(embench_dir)/bd_sizeopt_speed/src/md5sum
 	#rm -rf $(embench_dir)/bd_sizeopt_speed/src/tarfind
-	#rm -rf $(embench_dir)/bd_sizeopt_speed/src/primecount	
+	#rm -rf $(embench_dir)/bd_sizeopt_speed/src/primecount
 	find $(embench_dir)/bd_sizeopt_speed/ -type f ! -name "*.*" | while read f; do cp "$$f" "$$f.elf"; done
 
 # uses the build_all.py python file to build the tests in addins/embench-iot/bd_speed/ optimized for speed and size
@@ -50,7 +50,7 @@ sim_run:
 
 # builds the objdump based on the compiled c elf files
 objdump:
-	find $(embench_dir)/bd_*_speed/ -type f -name "*.elf" | while read f; do riscv64-unknown-elf-objdump -S -D "$$f" > "$$f.objdump"; done
+	find $(embench_dir)/bd_*_speed/ -type f -name "*.elf" | while read f; do riscv64-unknown-elf-objdump -Mno-aliases -S -D "$$f" > "$$f.objdump"; done
 
 # build memfiles, objdump.lab and objdump.addr files
 sim_build_memfile: objdump
@@ -68,16 +68,16 @@ spike_run:
 
 # python wrapper to present results of embench size benchmark
 size: buildsize
-	$(embench_dir)/benchmark_size.py --builddir=bd_speedopt_size --json-output > wallySpeedOpt_size.json 
-	$(embench_dir)/benchmark_size.py --builddir=bd_sizeopt_size --json-output > wallySizeOpt_size.json 
+	$(embench_dir)/benchmark_size.py --builddir=bd_speedopt_size --json-output > wallySpeedOpt_size.json
+	$(embench_dir)/benchmark_size.py --builddir=bd_sizeopt_size --json-output > wallySizeOpt_size.json
 
 # python wrapper to present results of embench speed benchmark
 speed:
-	$(embench_dir)/benchmark_speed.py --builddir=bd_sizeopt_speed --target-module run_wally --cpu-mhz=1 --json-output > wallySizeOpt_speed.json 
-	$(embench_dir)/benchmark_speed.py --builddir=bd_speedopt_speed --target-module run_wally --cpu-mhz=1 --json-output > wallySpeedOpt_speed.json 
+	$(embench_dir)/benchmark_speed.py --builddir=bd_sizeopt_speed --target-module run_wally --cpu-mhz=1 --json-output > wallySizeOpt_speed.json
+	$(embench_dir)/benchmark_speed.py --builddir=bd_speedopt_speed --target-module run_wally --cpu-mhz=1 --json-output > wallySpeedOpt_speed.json
 
 # deletes all files
-clean: 
+clean:
 	rm -rf $(embench_dir)/bd_*_speed/
 	rm -rf $(embench_dir)/bd_*_size/
 

--- a/examples/C/fir/Makefile
+++ b/examples/C/fir/Makefile
@@ -1,9 +1,9 @@
 TARGET = fir
 
 $(TARGET).objdump: $(TARGET)
-	riscv64-unknown-elf-objdump -S -D $(TARGET) > $(TARGET).objdump
+	riscv64-unknown-elf-objdump -Mno-aliases -S -D $(TARGET) > $(TARGET).objdump
 	spike $(TARGET)
-    
+
 $(TARGET): $(TARGET).c Makefile
 	riscv64-unknown-elf-gcc -o $(TARGET) -g\
 	  -march=rv64gc -mabi=lp64d -mcmodel=medany \
@@ -17,12 +17,12 @@ $(TARGET): $(TARGET).c Makefile
 #  -march=rv64gc -mabi=lp64d =mcmodel=medany generates code for RV64GC with doubles and long/ptrs = 64 bits
 #  -static forces static linking (no dynamic shared libraries on bare metal)
 #  -lm links the math library if necessary (when #include math.h)
-#  -nostdlib avoids inserting standard startup files and default libraries 
+#  -nostdlib avoids inserting standard startup files and default libraries
 #     because we are using crt.s on bare metal
-#  -fno-tree-loop-distribute-patterns turns replacing loops with memcpy/memset in the std library 
+#  -fno-tree-loop-distribute-patterns turns replacing loops with memcpy/memset in the std library
 #  -T specifies the linker file
 #  -I specifies the include path (e.g. for util.h)
-#  The last line defines the C files to compile.  
+#  The last line defines the C files to compile.
 #    crt.S is needed as our startup file to initialize the processor
 #    syscalls.c implements printf through the HTIF for Spike
 # other flags from riscv-tests makefiles that don't seem to be important

--- a/examples/C/inline/Makefile
+++ b/examples/C/inline/Makefile
@@ -1,8 +1,8 @@
 TARGET = inline
 
 $(TARGET).objdump: $(TARGET)
-	riscv64-unknown-elf-objdump -S -D $(TARGET) > $(TARGET).objdump
-    
+	riscv64-unknown-elf-objdump -Mno-aliases -S -D $(TARGET) > $(TARGET).objdump
+
 $(TARGET): $(TARGET).c Makefile
 	riscv64-unknown-elf-gcc -o $(TARGET) -g -O\
 	  -march=rv64gc -mabi=lp64d -mcmodel=medany \
@@ -16,12 +16,12 @@ $(TARGET): $(TARGET).c Makefile
 #  -march=rv64gc -mabi=lp64d =mcmodel=medany generates code for RV64GC with doubles and long/ptrs = 64 bits
 #  -static forces static linking (no dynamic shared libraries on bare metal)
 #  -lm links the math library if necessary (when #include math.h)
-#  -nostdlib avoids inserting standard startup files and default libraries 
+#  -nostdlib avoids inserting standard startup files and default libraries
 #     because we are using crt.s on bare metal
-#  -fno-tree-loop-distribute-patterns turns replacing loops with memcpy/memset in the std library 
+#  -fno-tree-loop-distribute-patterns turns replacing loops with memcpy/memset in the std library
 #  -T specifies the linker file
 #  -I specifies the include path (e.g. for util.h)
-#  The last line defines the C files to compile.  
+#  The last line defines the C files to compile.
 #    crt.S is needed as our startup file to initialize the processor
 #    syscalls.c implements printf through the HTIF for Spike
 # other flags from riscv-tests makefiles that don't seem to be important

--- a/examples/C/mcmodel/Makefile
+++ b/examples/C/mcmodel/Makefile
@@ -1,8 +1,8 @@
 all:
 	riscv64-unknown-elf-gcc -O3 -march=rv64gc -mcmodel=medlow mcmodel.c -o mcmodel_medlow
-	riscv64-unknown-elf-objdump -d mcmodel_medlow > mcmodel_medlow.objdump
+	riscv64-unknown-elf-objdump -Mno-aliases -d mcmodel_medlow > mcmodel_medlow.objdump
 	riscv64-unknown-elf-gcc -O3 -march=rv64gc -mcmodel=medany mcmodel.c -o mcmodel_medany
-	riscv64-unknown-elf-objdump -d mcmodel_medany > mcmodel_medany.objdump
+	riscv64-unknown-elf-objdump -Mno-aliases -d mcmodel_medany > mcmodel_medany.objdump
 
 clean:
 	rm mcmodel_*

--- a/examples/C/sum/Makefile
+++ b/examples/C/sum/Makefile
@@ -1,8 +1,8 @@
 TARGET = sum
 
 $(TARGET).objdump: $(TARGET)
-	riscv64-unknown-elf-objdump -S -D $(TARGET) > $(TARGET).objdump
-    
+	riscv64-unknown-elf-objdump -Mno-aliases -S -D $(TARGET) > $(TARGET).objdump
+
 $(TARGET): $(TARGET).c Makefile
 	riscv64-unknown-elf-gcc -o $(TARGET) -gdwarf-2 -O\
 	  -march=rv64gc -mabi=lp64d -mcmodel=medany \
@@ -16,12 +16,12 @@ $(TARGET): $(TARGET).c Makefile
 #  -march=rv64gc -mabi=lp64d =mcmodel=medany generates code for RV64GC with doubles and long/ptrs = 64 bits
 #  -static forces static linking (no dynamic shared libraries on bare metal)
 #  -lm links the math library if necessary (when #include math.h)
-#  -nostdlib avoids inserting standard startup files and default libraries 
+#  -nostdlib avoids inserting standard startup files and default libraries
 #     because we are using crt.s on bare metal
-#  -fno-tree-loop-distribute-patterns turns replacing loops with memcpy/memset in the std library 
+#  -fno-tree-loop-distribute-patterns turns replacing loops with memcpy/memset in the std library
 #  -T specifies the linker file
 #  -I specifies the include path (e.g. for util.h)
-#  The last line defines the C files to compile.  
+#  The last line defines the C files to compile.
 #    crt.S is needed as our startup file to initialize the processor
 #    syscalls.c implements printf through the HTIF for Spike
 # other flags from riscv-tests makefiles that don't seem to be important

--- a/examples/C/sum_mixed/Makefile
+++ b/examples/C/sum_mixed/Makefile
@@ -1,8 +1,8 @@
 TARGET = sum_mixed
 
 $(TARGET).objdump: $(TARGET)
-	riscv64-unknown-elf-objdump -S -D $(TARGET) > $(TARGET).objdump
-    
+	riscv64-unknown-elf-objdump -Mno-aliases -S -D $(TARGET) > $(TARGET).objdump
+
 $(TARGET): $(TARGET).c Makefile
 	riscv64-unknown-elf-gcc -o $(TARGET) -g -O\
 	  -march=rv64gc -mabi=lp64d -mcmodel=medany \
@@ -16,12 +16,12 @@ $(TARGET): $(TARGET).c Makefile
 #  -march=rv64gc -mabi=lp64d =mcmodel=medany generates code for RV64GC with doubles and long/ptrs = 64 bits
 #  -static forces static linking (no dynamic shared libraries on bare metal)
 #  -lm links the math library if necessary (when #include math.h)
-#  -nostdlib avoids inserting standard startup files and default libraries 
+#  -nostdlib avoids inserting standard startup files and default libraries
 #     because we are using crt.s on bare metal
-#  -fno-tree-loop-distribute-patterns turns replacing loops with memcpy/memset in the std library 
+#  -fno-tree-loop-distribute-patterns turns replacing loops with memcpy/memset in the std library
 #  -T specifies the linker file
 #  -I specifies the include path (e.g. for util.h)
-#  The last line defines the C files to compile.  
+#  The last line defines the C files to compile.
 #    crt.S is needed as our startup file to initialize the processor
 #    syscalls.c implements printf through the HTIF for Spike
 # other flags from riscv-tests makefiles that don't seem to be important

--- a/examples/asm/etc/Makefile
+++ b/examples/asm/etc/Makefile
@@ -1,8 +1,8 @@
 TARGET = pause
 
 $(TARGET).objdump: $(TARGET)
-	riscv64-unknown-elf-objdump -D $(TARGET) > $(TARGET).objdump
-    
+	riscv64-unknown-elf-objdump -Mno-aliases -D $(TARGET) > $(TARGET).objdump
+
 pause: pause.S Makefile
 	riscv64-unknown-elf-gcc -o pause -march=rv32ia_zihintpause -mabi=ilp32 -mcmodel=medany \
 	    -nostartfiles -T../../link/link.ld  pause.S

--- a/examples/asm/example/Makefile
+++ b/examples/asm/example/Makefile
@@ -1,6 +1,6 @@
 example.objdump: example
-	riscv64-unknown-elf-objdump -D example > example.objdump
-    
+	riscv64-unknown-elf-objdump -Mno-aliases -D example > example.objdump
+
 example: example.S Makefile
 	riscv64-unknown-elf-gcc -o example -march=rv32i -mabi=ilp32 -mcmodel=medany \
 	    -nostartfiles -T../../link/link.ld  example.S

--- a/examples/asm/sumtest/Makefile
+++ b/examples/asm/sumtest/Makefile
@@ -1,8 +1,8 @@
 TARGET = sumtest
 
 $(TARGET).objdump: $(TARGET)
-	riscv64-unknown-elf-objdump -D $(TARGET) > $(TARGET).objdump
-    
+	riscv64-unknown-elf-objdump -Mno-aliases -D $(TARGET) > $(TARGET).objdump
+
 $(TARGET): $(TARGET).S sum.S Makefile
 	riscv64-unknown-elf-gcc -g -o $(TARGET) -march=rv64gc -mabi=lp64 -mcmodel=medany \
 	    -nostartfiles -T../../link/link.ld $(TARGET).S sum.S

--- a/examples/asm/trap/Makefile
+++ b/examples/asm/trap/Makefile
@@ -1,8 +1,8 @@
 TARGET = trap
 
 $(TARGET).objdump: $(TARGET)
-	riscv64-unknown-elf-objdump -D $(TARGET) > $(TARGET).objdump
-    
+	riscv64-unknown-elf-objdump -Mno-aliases -D $(TARGET) > $(TARGET).objdump
+
 $(TARGET): $(TARGET).S Makefile
 	riscv64-unknown-elf-gcc -g -o $(TARGET) -march=rv64gc -mabi=lp64 -mcmodel=medany \
 	    -nostartfiles -T../../link/link.ld $(TARGET).S

--- a/fpga/zsbl/Makefile
+++ b/fpga/zsbl/Makefile
@@ -19,7 +19,7 @@ TARGETDIR	:= bin
 TARGET		:= $(TARGETDIR)/boot
 MEMFILES    := $(TARGETDIR/boot.mem $(TARGETDIR)/data.mem
 ROOT		:= ..
-LIBRARY_DIRS	:= 
+LIBRARY_DIRS	:=
 LIBRARY_FILES	:=
 
 MARCH           :=-march=rv64imfdc_zifencei
@@ -63,7 +63,7 @@ ifdef LIBRARY_DIRS
 LIBS+=${LIBRARY_DIRS:%=-L%}  ${LIBRARY_FILES:%=-l%}
 INC+=${LIBRARY_DIRS:%=-I%}
 
-${LIBRARY_DIRS}: 
+${LIBRARY_DIRS}:
 	$(MAKE) -C $@ -j 1
 
 .PHONY: $(LIBRARY_DIRS) $(TARGET)
@@ -113,7 +113,7 @@ $(BUILDDIR)/%.$(OBJEXT): $(SRCDIR)/%.$(CPPEXT)
 # convert to hex
 $(TARGET).memfile: $(TARGET)
 	@echo 'Making object dump file.'
-	riscv64-unknown-elf-objdump -DS $< > $<.objdump
+	riscv64-unknown-elf-objdump -Mno-aliases -DS $< > $<.objdump
 	@echo 'Making memory file'
 	riscv64-unknown-elf-elf2hex --bit-width 64 --input $^ --output $@
 	extractFunctionRadix.sh $<.objdump

--- a/linux/Makefile
+++ b/linux/Makefile
@@ -89,11 +89,11 @@ disassemble: check_environment
 	@echo "Disassembly successfully completed."
 
 $(DIS)/%.objdump: $(IMAGES)/%.elf
-	riscv64-unknown-elf-objdump -DS $< >> $@
+	riscv64-unknown-elf-objdump -Mno-aliases -DS $< >> $@
 	$(WALLY)/bin/extractFunctionRadix.sh $@
 
 $(DIS)/%.objdump: $(IMAGES)/%
-	riscv64-unknown-elf-objdump -S $< >> $@
+	riscv64-unknown-elf-objdump -Mno-aliases -S $< >> $@
 	$(WALLY)/bin/extractFunctionRadix.sh $@
 
 $(IMAGES)/vmlinux:

--- a/testbench/Makefile
+++ b/testbench/Makefile
@@ -9,4 +9,4 @@
 	extractFunctionRadix.sh $<
 
 %.elf.objdump: %.elf
-	riscv64-unknown-elf-objdump -S -D $< > $@
+	riscv64-unknown-elf-objdump -Mno-aliases -S -D $< > $@

--- a/tests/coverage/Makefile
+++ b/tests/coverage/Makefile
@@ -14,7 +14,7 @@ all: $(OBJDUMPS) $(MEMFILES)
 
 # Create dissassembly
 %.elf.objdump: %.elf
-	riscv64-unknown-elf-objdump -S -D $< > $@
+	riscv64-unknown-elf-objdump -Mno-aliases -S -D $< > $@
 	extractFunctionRadix.sh $@
 
 # Create memfile

--- a/tests/custom/lpddrtest/Makefile
+++ b/tests/custom/lpddrtest/Makefile
@@ -11,7 +11,7 @@ LINK_FLAGS      :=$(MARCH) $(MABI) -nostartfiles -Wl,-Map=$(TARGET).map -L $(RIS
 
 CFLAGS =$(MARCH) $(MABI) -Wa,-alhs -Wa,-L -mcmodel=medany  -mstrict-align -O2
 CC=riscv64-unknown-elf-gcc
-DA=riscv64-unknown-elf-objdump -d
+DA=riscv64-unknown-elf-objdump -Mno-aliases -d
 
 
 include $(ROOT)/makefile.inc

--- a/tests/custom/makefile.inc
+++ b/tests/custom/makefile.inc
@@ -27,7 +27,7 @@ directories:
 	@mkdir -p $(BUILDDIR)
 
 clean:
-	rm -rf $(BUILDDIR) $(TARGETDIR) *.memfile *.objdump 
+	rm -rf $(BUILDDIR) $(TARGETDIR) *.memfile *.objdump
 
 
 #Needed for building additional library projects
@@ -35,7 +35,7 @@ ifdef LIBRARY_DIRS
 LIBS+=${LIBRARY_DIRS:%=-L%}  ${LIBRARY_FILES:%=-l%}
 INC+=${LIBRARY_DIRS:%=-I%}
 
-${LIBRARY_DIRS}: 
+${LIBRARY_DIRS}:
 	make -C $@ -j 1
 
 .PHONY: $(LIBRARY_DIRS) $(TARGET)
@@ -85,7 +85,7 @@ $(BUILDDIR)/%.$(OBJEXT): $(SRCDIR)/%.$(CPPEXT)
 # convert to hex
 $(TARGET).memfile: $(TARGET)
 	@echo 'Making object dump file.'
-	@riscv64-unknown-elf-objdump -D $< > $<.objdump
+	@riscv64-unknown-elf-objdump -Mno-aliases -D $< > $<.objdump
 	@echo 'Making memory file'
 	riscv64-unknown-elf-elf2hex --bit-width $(WIDTH) --input $< --output $@
 	extractFunctionRadix.sh $<.objdump

--- a/tests/custom/spitest/Makefile
+++ b/tests/custom/spitest/Makefile
@@ -18,7 +18,7 @@ OBJECTS		:= $(patsubst $(SRCDIR)/%,$(BUILDDIR)/%,$(OBJECTS))
 TARGETDIR	:= bin
 TARGET		:= $(TARGETDIR)/spitest.elf
 ROOT		:= ..
-LIBRARY_DIRS	:= 
+LIBRARY_DIRS	:=
 LIBRARY_FILES	:=
 
 MARCH           :=-march=rv64imfdc
@@ -46,7 +46,7 @@ directories:
 	@mkdir -p $(BUILDDIR)
 
 clean:
-	rm -rf $(BUILDDIR) $(TARGETDIR) *.memfile *.objdump 
+	rm -rf $(BUILDDIR) $(TARGETDIR) *.memfile *.objdump
 
 
 #Needed for building additional library projects
@@ -54,7 +54,7 @@ ifdef LIBRARY_DIRS
 LIBS+=${LIBRARY_DIRS:%=-L%}  ${LIBRARY_FILES:%=-l%}
 INC+=${LIBRARY_DIRS:%=-I%}
 
-${LIBRARY_DIRS}: 
+${LIBRARY_DIRS}:
 	$(MAKE) -C $@ -j 1
 
 .PHONY: $(LIBRARY_DIRS) $(TARGET)
@@ -104,7 +104,7 @@ $(BUILDDIR)/%.$(OBJEXT): $(SRCDIR)/%.$(CPPEXT)
 # convert to hex
 $(TARGET).memfile: $(TARGET)
 	@echo 'Making object dump file.'
-	@riscv64-unknown-elf-objdump -D $< > $<.objdump
+	@riscv64-unknown-elf-objdump -Mno-aliases -D $< > $<.objdump
 	@echo 'Making memory file'
 	riscv64-unknown-elf-elf2hex --bit-width 64 --input $^ --output $@
 	extractFunctionRadix.sh $<.objdump

--- a/tests/riscof/sail_cSim/riscof_sail_cSim.py
+++ b/tests/riscof/sail_cSim/riscof_sail_cSim.py
@@ -41,7 +41,7 @@ class sail_cSim(pluginTemplate):
     def initialise(self, suite, work_dir, archtest_env):
         self.suite = suite
         self.work_dir = work_dir
-        self.objdump_cmd = 'riscv64-unknown-elf-objdump -D {0} > {2};'
+        self.objdump_cmd = 'riscv64-unknown-elf-objdump -Mno-aliases -D {0} > {2};'
         self.compile_cmd = 'riscv64-unknown-elf-gcc -march={0} \
          -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles\
          -T '+self.pluginpath+'/env/link.ld\
@@ -109,7 +109,7 @@ class sail_cSim(pluginTemplate):
 
             execute += self.objdump_cmd.format(elf, self.xlen, 'ref.elf.objdump')
             sig_file = os.path.join(test_dir, self.name[:-1] + ".signature")
-            
+
             # Check if the tests can be run on SAIL
             if ('NO_SAIL=True' in testentry['macros']):
                 # if the tests can't run on SAIL we copy the reference output to the src directory


### PR DESCRIPTION
Add `-Mno-aliases` to all objdump commands. This makes compressed instructions come through correctly in the objdump files (`c.lw` instead of `lw`, `c.addi16sp` instead of jus `addi`, etc.). It does have the downside of also not using any pseudoinstructions, so `csrr` now comes through as `csrrw zero`. I think it's still worth it, but could go either way.