### PR TITLE
Reworked wallyTracer and regression-wally to disable boottrace.log blowups 

### DIFF
--- a/bin/regression-wally
+++ b/bin/regression-wally
@@ -50,7 +50,7 @@ tests_buildrootboot = [
     ]
 
 tests_buildrootbootlockstep = [
-                    ["buildroot", ["buildroot"], [f"+INSTR_LIMIT=600000000 --lockstep"], # boot entire buildroot Linux to login prompt
+                    ["buildroot", ["buildroot"], {'args': [f"+INSTR_LIMIT=600000000 --lockstep"], 'params': ["STD_LOG=0"]}, # boot entire buildroot Linux to login prompt
                         "WallyHostname login: ", "buildroot_uart.out"]
     ]
 

--- a/testbench/common/wallyTracer.sv
+++ b/testbench/common/wallyTracer.sv
@@ -23,14 +23,13 @@
 `define NUM_REGS 32
 `define NUM_CSRS 4096
 
-`define STD_LOG 1
 `define PRINT_PC_INSTR 0
 `define PRINT_MOST 0
 `define PRINT_ALL 0
 `define PRINT_CSRS 0
 
 
-module wallyTracer import cvw::*; #(parameter cvw_t P) (rvviTrace rvvi);
+module wallyTracer import cvw::*; #(parameter cvw_t P, parameter STD_LOG=1) (rvviTrace rvvi);
 
   localparam NUMREGS = P.E_SUPPORTED ? 16 : 32;
   
@@ -715,7 +714,7 @@ module wallyTracer import cvw::*; #(parameter cvw_t P) (rvviTrace rvvi);
   string  instrWName;
   int     file;
   string  LogFile;
-  if(`STD_LOG) begin
+  if(STD_LOG) begin
     instrNameDecTB NameDecoder(rvvi.insn[0][0], instrWName);
     initial begin
       LogFile = "logs/boottrace.log";
@@ -725,7 +724,7 @@ module wallyTracer import cvw::*; #(parameter cvw_t P) (rvviTrace rvvi);
   
   always_ff @(posedge clk) begin
 	if(valid) begin
-      if(`STD_LOG) begin
+      if(STD_LOG) begin
         $fwrite(file, "%016x, %08x, %s\t\t", rvvi.pc_rdata[0][0], rvvi.insn[0][0], instrWName);
         for(index2 = 0; index2 < `NUM_REGS; index2 += 1) begin
           if(rvvi.x_wb[0][0][index2]) begin

--- a/testbench/testbench.sv
+++ b/testbench/testbench.sv
@@ -40,6 +40,7 @@ module testbench;
   /* verilator lint_off WIDTHEXPAND */
   parameter DEBUG=0;
   parameter PrintHPMCounters=0;
+  parameter STD_LOG=1;
   parameter BPRED_LOGGER=0;
   parameter I_CACHE_ADDR_LOGGER=0;
   parameter D_CACHE_ADDR_LOGGER=0;
@@ -710,7 +711,7 @@ end
 `ifdef USE_IMPERAS_DV
 
   rvviTrace #(.XLEN(P.XLEN), .FLEN(P.FLEN)) rvvi();
-  wallyTracer #(P) wallyTracer(rvvi);
+  wallyTracer #(P, STD_LOG) wallyTracer(rvvi);
 
   trace2log idv_trace2log(rvvi);
   trace2cov idv_trace2cov(rvvi);


### PR DESCRIPTION
Fixed issue where boottrace.log was exploding nightly regression runs in regression-wally.