### PR TITLE
Add --define to wsim

### DIFF
--- a/bin/wsim
+++ b/bin/wsim
@@ -30,6 +30,7 @@ def parseArgs():
     parser.add_argument("--fcov", "-f", help="Functional Coverage with cvw-arch-verif, implies lockstep", action="store_true")
     parser.add_argument("--args", "-a", help="Optional arguments passed to simulator via $value$plusargs", default="")
     parser.add_argument("--params", "-p", help="Optional top-level parameter overrides of the form param=value", default="")
+    parser.add_argument("--define", "-d", help="Optional define macros passed to simulator", default="")
     parser.add_argument("--vcd", "-v", help="Generate testbench.vcd", action="store_true")
     parser.add_argument("--lockstep", "-l", help="Run ImperasDV lock, step, and compare.", action="store_true")
     parser.add_argument("--lockstepverbose", "-lv", help="Run ImperasDV lock, step, and compare with tracing enabled", action="store_true")
@@ -136,6 +137,8 @@ def runQuesta(args, flags, prefix):
         args.args = fr'--args \"{args.args}\"'
     if args.params != "":
         args.params = fr'--params \"{args.params}\"'
+    if args.define != "":
+        args.define = fr'--define \"{args.define}\"'
     # Questa cannot accept more than 9 arguments.  fcov implies lockstep
     cmd = f"do wally.do {args.config} {args.testsuite} {args.tb} {args.args} {args.params} {flags}"
     cmd = f'cd $WALLY/sim/questa; {prefix} vsim {"-c" if not args.gui else ""} -do "{cmd}"'
@@ -144,7 +147,7 @@ def runQuesta(args, flags, prefix):
 
 def runVerilator(args):
     print(f"Running Verilator on {args.config} {args.testsuite}")
-    os.system(f'make -C {WALLY}/sim/verilator WALLYCONF={args.config} TEST={args.testsuite} TESTBENCH={args.tb} PLUS_ARGS="{args.args}" PARAM_ARGS="{args.params}"')
+    os.system(f'make -C {WALLY}/sim/verilator WALLYCONF={args.config} TEST={args.testsuite} TESTBENCH={args.tb} PLUS_ARGS="{args.args}" PARAM_ARGS="{args.params}" DEFINE_ARGS="{args.define}"')
 
 def runVCS(args, flags, prefix):
     print(f"Running VCS on {args.config} {args.testsuite}")
@@ -152,6 +155,8 @@ def runVCS(args, flags, prefix):
         args.args = f'--args "{args.args}"'
     if args.params != "":
         args.params = f'--params "{args.params}"'
+    if args.define != "":
+        args.define = f'--define "{args.define}"'
     cmd = f"cd $WALLY/sim/vcs; {prefix} ./run_vcs {args.config} {args.testsuite} --tb {args.tb} {args.args} {args.params} {flags}"
     print(cmd)
     os.system(cmd)

--- a/bin/wsim
+++ b/bin/wsim
@@ -55,7 +55,7 @@ def elfFileCheck(args):
     ElfFile = ""
     if os.path.isfile(args.elf):
         ElfFile = f"+ElfFile={os.path.abspath(args.elf)}"
-    elif args.elf != "":
+    elif args.elf:
         print(f"ELF file not found: {args.elf}")
         sys.exit(1)
     elif args.testsuite.endswith('.elf'): # No --elf argument; check if testsuite has a .elf extension and use that instead
@@ -138,11 +138,11 @@ def runSim(args, flags, prefix):
 def runQuesta(args, flags, prefix):
     # Force Questa to use 64-bit mode, sometimes it defaults to 32-bit even on 64-bit machines
     prefix = "MTI_VCO_MODE=64 " + prefix
-    if args.args != "":
+    if args.args:
         args.args = fr'--args \"{args.args}\"'
-    if args.params != "":
+    if args.params:
         args.params = fr'--params \"{args.params}\"'
-    if args.define != "":
+    if args.define:
         args.define = fr'--define \"{args.define}\"'
     # Questa cannot accept more than 9 arguments.  fcov implies lockstep
     cmd = f"do wally.do {args.config} {args.testsuite} {args.tb} {args.args} {args.params} {args.define} {flags}"
@@ -156,11 +156,11 @@ def runVerilator(args):
 
 def runVCS(args, flags, prefix):
     print(f"Running VCS on {args.config} {args.testsuite}")
-    if args.args != "":
+    if args.args:
         args.args = f'--args "{args.args}"'
-    if args.params != "":
+    if args.params:
         args.params = f'--params "{args.params}"'
-    if args.define != "":
+    if args.define:
         args.define = f'--define "{args.define}"'
     cmd = f"cd $WALLY/sim/vcs; {prefix} ./run_vcs {args.config} {args.testsuite} --tb {args.tb} {args.args} {args.params} {args.define} {flags}"
     print(cmd)

--- a/bin/wsim
+++ b/bin/wsim
@@ -96,8 +96,8 @@ def prepSim(args, ElfFile):
         flagsList.append("--ccov")
     if args.fcov:
         flagsList.append("--fcov")
-        defineList.append("+define+INCLUDE_TRACE2COV", "+define+IDV_INCLUDE_TRACE2COV", "+define+COVER_BASE_RV32I") # COVER_BASE_RV32I is just needed to keep riscvISACOV happy, but does not affect tests
-        argsList.append("+TRACE2COV_ENABLE=1", "+IDV_TRACE2COV=1")
+        defineList.extend(["+define+INCLUDE_TRACE2COV", "+define+IDV_INCLUDE_TRACE2COV", "+define+COVER_BASE_RV32I"]) # COVER_BASE_RV32I is just needed to keep riscvISACOV happy, but does not affect tests
+        argsList.extend(["+TRACE2COV_ENABLE=1", "+IDV_TRACE2COV=1"])
     if args.gui:
         flagsList.append("--gui")
     if args.lockstep or args.lockstepverbose:

--- a/bin/wsim
+++ b/bin/wsim
@@ -81,6 +81,7 @@ def prepSim(args, ElfFile):
     paramsList = []
     argsList = []
     flagsList = []
+    defineList = []
     if args.vcd:
         paramsList.append("MAKE_VCD=1")
     if args.rvvi:
@@ -95,15 +96,19 @@ def prepSim(args, ElfFile):
         flagsList.append("--ccov")
     if args.fcov:
         flagsList.append("--fcov")
+        defineList.append("+define+INCLUDE_TRACE2COV", "+define+IDV_INCLUDE_TRACE2COV", "+define+COVER_BASE_RV32I") # COVER_BASE_RV32I is just needed to keep riscvISACOV happy, but does not affect tests
+        argsList.append("+TRACE2COV_ENABLE=1", "+IDV_TRACE2COV=1")
     if args.gui:
         flagsList.append("--gui")
     if args.lockstep or args.lockstepverbose:
         flagsList.append("--lockstep")
     if args.lockstep or args.lockstepverbose or args.fcov:
         prefix = lockstepSetup(args)
+        defineList.append("+define+USE_IMPERAS_DV")
     # Combine into a single string
     args.args += " ".join(argsList)
     args.params += " ".join(paramsList)
+    args.define += " ".join(defineList)
     flags = " ".join(flagsList)
     return flags, prefix
 
@@ -140,7 +145,7 @@ def runQuesta(args, flags, prefix):
     if args.define != "":
         args.define = fr'--define \"{args.define}\"'
     # Questa cannot accept more than 9 arguments.  fcov implies lockstep
-    cmd = f"do wally.do {args.config} {args.testsuite} {args.tb} {args.args} {args.params} {flags}"
+    cmd = f"do wally.do {args.config} {args.testsuite} {args.tb} {args.args} {args.params} {args.define} {flags}"
     cmd = f'cd $WALLY/sim/questa; {prefix} vsim {"-c" if not args.gui else ""} -do "{cmd}"'
     print(f"Running Questa with command: {cmd}")
     os.system(cmd)
@@ -157,13 +162,13 @@ def runVCS(args, flags, prefix):
         args.params = f'--params "{args.params}"'
     if args.define != "":
         args.define = f'--define "{args.define}"'
-    cmd = f"cd $WALLY/sim/vcs; {prefix} ./run_vcs {args.config} {args.testsuite} --tb {args.tb} {args.args} {args.params} {flags}"
+    cmd = f"cd $WALLY/sim/vcs; {prefix} ./run_vcs {args.config} {args.testsuite} --tb {args.tb} {args.args} {args.params} {args.define} {flags}"
     print(cmd)
     os.system(cmd)
 
 def main(args):
     validateArgs(args)
-    print(f"Config={args.config} tests={args.testsuite} sim={args.sim} gui={args.gui} args='{args.args}' params='{args.params}'")
+    print(f"Config={args.config} tests={args.testsuite} sim={args.sim} gui={args.gui} args='{args.args}' params='{args.params}' define='{args.define}'")
     ElfFile = elfFileCheck(args)
     flags, prefix = prepSim(args, ElfFile)
     createDirs(args.sim)

--- a/sim/questa/wally.do
+++ b/sim/questa/wally.do
@@ -104,7 +104,10 @@ if {[lcheck lst "--ccov"]} {
 # if --fcov found set flag and remove from list
 if {[lcheck lst "--fcov"]} {
     set FunctCoverage 1
-    set FCvlog "+incdir+$env(WALLY)/addins/cvw-arch-verif/riscvISACOV/source"
+    set FCvlog "+incdir+$env(WALLY)/addins/cvw-arch-verif/riscvISACOV/source \
+                +incdir+${FCRVVI}/rv32 +incdir+${FCRVVI}/rv64 \
+                +incdir+${FCRVVI}/priv +incdir+${FCRVVI}/rv64_priv +incdir+${FCRVVI}/rv32_priv \
+                +incdir+${FCRVVI}/common +incdir+${FCRVVI}"
 }
 
 # if --lockstep or --fcov found set flag and remove from list
@@ -159,7 +162,7 @@ if {$DEBUG > 0} {
 # suppress spurious warnngs about
 # "Extra checking for conflicts with always_comb done at vopt time"
 # because vsim will run vopt
-set INC_DIRS "+incdir+${CONFIG}/${CFG} +incdir+${CONFIG}/deriv/${CFG} +incdir+${CONFIG}/shared +incdir+${FCRVVI} +incdir+${FCRVVI}/rv32 +incdir+${FCRVVI}/rv64 +incdir+${FCRVVI}/rv64_priv +incdir+${FCRVVI}/priv +incdir+${FCRVVI}/rv32_priv +incdir+${FCRVVI}/common +incdir+${FCRVVI}"
+set INC_DIRS "+incdir+${CONFIG}/${CFG} +incdir+${CONFIG}/deriv/${CFG} +incdir+${CONFIG}/shared"
 set SOURCES "${SRC}/cvw.sv ${TB}/${TESTBENCH}.sv ${TB}/common/*.sv ${SRC}/*/*.sv ${SRC}/*/*/*.sv ${WALLY}/addins/verilog-ethernet/*/*.sv ${WALLY}/addins/verilog-ethernet/*/*/*/*.sv"
 vlog -permissive -lint -work ${WKDIR} {*}${INC_DIRS} {*}${DefineArgs} {*}${FCvlog} {*}${lockstepvlog} {*}${SOURCES} -suppress 2282,2583,7053,7063,2596,13286
 

--- a/sim/questa/wally.do
+++ b/sim/questa/wally.do
@@ -161,7 +161,7 @@ if {$DEBUG > 0} {
 # because vsim will run vopt
 set INC_DIRS "+incdir+${CONFIG}/${CFG} +incdir+${CONFIG}/deriv/${CFG} +incdir+${CONFIG}/shared +incdir+${FCRVVI} +incdir+${FCRVVI}/rv32 +incdir+${FCRVVI}/rv64 +incdir+${FCRVVI}/rv64_priv +incdir+${FCRVVI}/priv +incdir+${FCRVVI}/rv32_priv +incdir+${FCRVVI}/common +incdir+${FCRVVI}"
 set SOURCES "${SRC}/cvw.sv ${TB}/${TESTBENCH}.sv ${TB}/common/*.sv ${SRC}/*/*.sv ${SRC}/*/*/*.sv ${WALLY}/addins/verilog-ethernet/*/*.sv ${WALLY}/addins/verilog-ethernet/*/*/*/*.sv"
-vlog -permissive -lint -work ${WKDIR} {*}${INC_DIRS} {*}{$DefineArgs} {*}${FCvlog} {*}${lockstepvlog} {*}${SOURCES} -suppress 2282,2583,7053,7063,2596,13286
+vlog -permissive -lint -work ${WKDIR} {*}${INC_DIRS} {*}${DefineArgs} {*}${FCvlog} {*}${lockstepvlog} {*}${SOURCES} -suppress 2282,2583,7053,7063,2596,13286
 
 # start and run simulation
 # remove +acc flag for faster sim during regressions if there is no need to access internal signals

--- a/sim/questa/wally.do
+++ b/sim/questa/wally.do
@@ -62,7 +62,6 @@ set CoverageVsimArg ""
 
 set FunctCoverage 0
 set FCvlog ""
-set FCvopt ""
 
 set lockstep 0
 set lockstepvlog ""
@@ -105,20 +104,14 @@ if {[lcheck lst "--ccov"]} {
 # if --fcov found set flag and remove from list
 if {[lcheck lst "--fcov"]} {
     set FunctCoverage 1
-    # COVER_BASE_RV32I is just needed to keep riscvISACOV happy, but no longer affects tests
-    set FCvlog "+define+INCLUDE_TRACE2COV \
-                +define+IDV_INCLUDE_TRACE2COV \
-                +define+COVER_BASE_RV32I \
-                +incdir+$env(WALLY)/addins/cvw-arch-verif/riscvISACOV/source"
-    set FCvopt "+TRACE2COV_ENABLE=1 +IDV_TRACE2COV=1"
+    set FCvlog "+incdir+$env(WALLY)/addins/cvw-arch-verif/riscvISACOV/source"
 }
 
 # if --lockstep or --fcov found set flag and remove from list
 if {[lcheck lst "--lockstep"] || $FunctCoverage == 1} {
     set IMPERAS_HOME $::env(IMPERAS_HOME)
     set lockstep 1
-    set lockstepvlog "+define+USE_IMPERAS_DV \
-                      +incdir+${IMPERAS_HOME}/ImpPublic/include/host \
+    set lockstepvlog "+incdir+${IMPERAS_HOME}/ImpPublic/include/host \
                       +incdir+${IMPERAS_HOME}/ImpProprietary/include/host \
                       ${IMPERAS_HOME}/ImpPublic/source/host/rvvi/*.sv \
                       ${IMPERAS_HOME}/ImpProprietary/source/host/idv/*.sv"
@@ -174,7 +167,7 @@ vlog -permissive -lint -work ${WKDIR} {*}${INC_DIRS} {*}{$DefineArgs} {*}${FCvlo
 # remove +acc flag for faster sim during regressions if there is no need to access internal signals
 vopt $accFlag wkdir/${CFG}_${TESTSUITE}.${TESTBENCH} -work ${WKDIR} {*}${ExpandedParamArgs} -o testbenchopt ${CoverageVoptArg}
 
-vsim -lib ${WKDIR} testbenchopt +TEST=${TESTSUITE} {*}${PlusArgs} -fatal 7 {*}${SVLib} {*}${FCvopt} -suppress 3829 ${CoverageVsimArg}
+vsim -lib ${WKDIR} testbenchopt +TEST=${TESTSUITE} {*}${PlusArgs} -fatal 7 {*}${SVLib} -suppress 3829 ${CoverageVsimArg}
 
 # power add generates the logging necessary for saif generation.
 # power add -r /dut/core/*

--- a/sim/vcs/run_vcs
+++ b/sim/vcs/run_vcs
@@ -28,11 +28,12 @@ parser.add_argument("--ccov", "-c", help="Code Coverage", action="store_true")
 parser.add_argument("--fcov", "-f", help="Functional Coverage", action="store_true")
 parser.add_argument("--args", "-a", help="Optional arguments passed to simulator via $value$plusargs", default="")
 parser.add_argument("--params", "-p", help="Optional top-level parameter overrides of the form param=value", default="")
+parser.add_argument("--define", "-d", help="Optional define macros passed to simulator", default="")
 parser.add_argument("--lockstep", "-l", help="Run ImperasDV lock, step, and compare.", action="store_true")
 # GUI not yet implemented
 #parser.add_argument("--gui", "-g", help="Simulate with GUI", action="store_true")
 args = parser.parse_args()
-print("run_vcs Config=" + args.config + " tests=" + args.testsuite + " lockstep=" + str(args.lockstep) + " args='" + args.args + "' params='" + args.params + "'")
+print("run_vcs Config=" + args.config + " tests=" + args.testsuite + " lockstep=" + str(args.lockstep) + " args='" + args.args + "' params='" + args.params + "'" + " define='" + args.define + "'")
 
 cfgdir = "$WALLY/config"
 srcdir = "$WALLY/src"
@@ -85,7 +86,7 @@ PARAM_OVERRIDES=" -parameters " + wkdir + "/param_overrides.txt "
 
 # Simulation commands
 OUTPUT="sim_out"
-VCS_CMD="vcs +lint=all,noGCWM,noUI,noSVA-UA,noIDTS,noNS,noULCO,noCAWM-L,noWMIA-L,noSV-PIU,noSTASKW_CO,noSTASKW_CO1,noSTASKW_RMCOF -suppress +warn -sverilog +vc -Mupdate -line -full64 -lca -ntb_opts sensitive_dyn " + "-top " + args.tb + PARAM_OVERRIDES + INCLUDE_PATH # Disabled Debug flags; add them back for a GUI mode -debug_access+all+reverse  -kdb +vcs+vcdpluson
+VCS_CMD="vcs +lint=all,noGCWM,noUI,noSVA-UA,noIDTS,noNS,noULCO,noCAWM-L,noWMIA-L,noSV-PIU,noSTASKW_CO,noSTASKW_CO1,noSTASKW_RMCOF -suppress +warn -sverilog +vc -Mupdate -line -full64 -lca -ntb_opts sensitive_dyn " + "-top " + args.tb + " " + args.define + " " + PARAM_OVERRIDES + INCLUDE_PATH # Disabled Debug flags; add them back for a GUI mode -debug_access+all+reverse  -kdb +vcs+vcdpluson
 VCS = VCS_CMD + " -Mdir=" + wkdir + " " + srcdir + "/cvw.sv " + LOCKSTEP_OPTIONS + " " + COV_OPTIONS + " " + RTL_FILES + " -o " + wkdir + "/" + OUTPUT + " -work " + wkdir + " -Mlib=" + wkdir + " -l " + logdir + "/" + args.config + "_" + args.testsuite + ".log"
 SIMV_CMD= wkdir + "/" + OUTPUT + " +TEST=" + args.testsuite + " " + args.args + " -no_save " + LOCKSTEP_SIMV
 

--- a/sim/vcs/run_vcs
+++ b/sim/vcs/run_vcs
@@ -59,7 +59,7 @@ INCLUDE_PATH="+incdir+" + cfgdir + "/" + args.config + " +incdir+" + cfgdir + "/
 
 # lockstep mode
 if (args.lockstep):
-    LOCKSTEP_OPTIONS = " +define+USE_IMPERAS_DV +incdir+$IMPERAS_HOME/ImpPublic/include/host  +incdir+$IMPERAS_HOME/ImpProprietary/include/host  $IMPERAS_HOME/ImpPublic/source/host/rvvi/*.sv $IMPERAS_HOME/ImpProprietary/source/host/idv/*.sv " + tbdir + "/common/wallyTracer.sv"
+    LOCKSTEP_OPTIONS = " +incdir+$IMPERAS_HOME/ImpPublic/include/host  +incdir+$IMPERAS_HOME/ImpProprietary/include/host  $IMPERAS_HOME/ImpPublic/source/host/rvvi/*.sv $IMPERAS_HOME/ImpProprietary/source/host/idv/*.sv " + tbdir + "/common/wallyTracer.sv"
     LOCKSTEP_SIMV = "-sv_lib $IMPERAS_HOME/lib/Linux64/ImperasLib/imperas.com/verification/riscv/1.0/model"
 else:
     LOCKSTEP_OPTIONS = ""

--- a/sim/verilator/Makefile
+++ b/sim/verilator/Makefile
@@ -13,6 +13,7 @@ VERILATOR_DIR=${WALLY}/sim/verilator
 SOURCE=${WALLY}/config/shared/*.vh ${WALLY}/config/${WALLYCONF} ${WALLY}/config/deriv/${WALLYCONF} ${WALLY}/src/cvw.sv ${WALLY}/testbench/*.sv ${WALLY}/testbench/common/*.sv ${WALLY}/src/*/*.sv ${WALLY}/src/*/*/*.sv
 PLUS_ARGS=
 PARAM_ARGS=
+DEFINE_ARGS=
 EXPANDED_PARAM_ARGS:=$(patsubst %,-G%,$(PARAM_ARGS))
 
 WALLYCONF?=rv64gc
@@ -63,6 +64,7 @@ $(WORKDIR)/V${TESTBENCH}: $(DEPENDENCIES)
 	--top-module ${TESTBENCH}  --relative-includes \
 	$(INCLUDE_PATH) \
 	${WRAPPER} \
+	${DEFINE_ARGS} \
 	${EXPANDED_PARAM_ARGS} \
 	$(SOURCES)
 
@@ -75,6 +77,7 @@ obj_dir_profiling/V${TESTBENCH}_$(WALLYCONF): $(DEPENDENCIES)
 	--top-module ${TESTBENCH}  --relative-includes \
 	$(INCLUDE_PATH) \
 	${WRAPPER} \
+	${DEFINE_ARGS} \
 	${EXPANDED_PARAM_ARGS} \
 	$(SOURCES)
 


### PR DESCRIPTION
- Add `--define` flag to `wsim` that takes arguments of the standard form `"+define+USE_IMPERAS_DV"` to pass as macro definition overrides to simulators. Support added to all 3 individual simulator scripts.
- Refactor lots of the lockstep and fcov logic to be in the wsim level for easier maintainability across simulators.