### PR TITLE
Fixed a bug related to Reserved Encoding in tlbcontrol.sv

### DIFF
--- a/src/mmu/tlb/tlbcontrol.sv
+++ b/src/mmu/tlb/tlbcontrol.sv
@@ -61,6 +61,7 @@ module tlbcontrol import cvw::*;  #(parameter cvw_t P, ITLB = 0) (
   logic                           TLBAccess;
   logic                           ImproperPrivilege;
   logic                           BadPBMT, BadNAPOT, BadReserved;
+  logic                           ReservedEncoding;
   logic                           InvalidAccess;
   logic                           PreUpdateDA, PrePageFault;
 
@@ -88,6 +89,7 @@ module tlbcontrol import cvw::*;  #(parameter cvw_t P, ITLB = 0) (
   assign BadPBMT = ((PTE_PBMT != 0) & ~(P.SVPBMT_SUPPORTED & ENVCFG_PBMTE)) | PTE_PBMT == 3; // PBMT must be zero if not supported; value of 3 is reserved
   assign BadNAPOT = PTE_N & (~P.SVNAPOT_SUPPORTED | ~NAPOT4);              // N must be be 0 if CVNAPOT is not supported or not 64 KiB contiguous region
   assign BadReserved = PTE_RESERVED;                                       // Reserved bits must be zero
+  assign ReservedEncoding = PTE_W & ~PTE_R;                                // fault on reserved encoding with R=0, W=1 to match ImperasDV behavior
  
   // Check whether the access is allowed, page faulting if not.
   if (ITLB == 1) begin:itlb // Instruction TLB fault checking
@@ -95,9 +97,9 @@ module tlbcontrol import cvw::*;  #(parameter cvw_t P, ITLB = 0) (
     // only execute non-user mode pages.
     assign ImproperPrivilege = ((PrivilegeModeW == P.U_MODE) & ~PTE_U) | ((PrivilegeModeW == P.S_MODE) & PTE_U);
     assign PreUpdateDA = ~PTE_A;
-    assign InvalidAccess = ~PTE_X;
+    assign InvalidAccess = ~PTE_X | ReservedEncoding;
  end else begin:dtlb // Data TLB fault checking
-    logic InvalidRead, InvalidWrite, ReservedEncoding;
+    logic InvalidRead, InvalidWrite;
     logic InvalidCBOM, InvalidCBOZ;
 
     // User mode may only load/store from user mode pages, and supervisor mode
@@ -112,7 +114,6 @@ module tlbcontrol import cvw::*;  #(parameter cvw_t P, ITLB = 0) (
     assign InvalidWrite = WriteAccess & ~PTE_W;
     assign InvalidCBOM = (|CMOpM[2:0]) & (~PTE_R & (~STATUS_MXR | ~PTE_X));
     assign InvalidCBOZ = CMOpM[3] & ~PTE_W;
-    assign ReservedEncoding = PTE_W & ~PTE_R; // fault on reserved encoding with R=0, W=1 to match ImperasDV behavior
     assign InvalidAccess = InvalidRead | InvalidWrite | InvalidCBOM | InvalidCBOZ | ReservedEncoding;
     assign PreUpdateDA = ~PTE_A | WriteAccess & ~PTE_D;
   end


### PR DESCRIPTION
Reserved Encoding was only being checked in the case of DTLB. Due to this, **VM SV32 reserved_pte tests** were showing a mismatch. 
I made changes in **tlbcontrol.sv** to check it for both ITLB & DTLB. This fixed the problem. Now reserved_pte tests are successfully running and showing zero mismatches.
This PR will fix the following issue https://github.com/openhwgroup/cvw/issues/1198
I checked for other possible bugs in tlbcontrol.sv, but according to my knowledge, I think this was the only bug.