### PR TITLE
Fix RHEL family installation in CI

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -136,7 +136,7 @@ jobs:
         run: |
               if [ ! -z ${{ matrix.image }} ]; then
                 ./bin/wally-tool-chain-install.sh --clean ${{ matrix.riscv_path }}
-              else if [ -z ${{ matrix.user }} ]; then
+              elif [ -z ${{ matrix.user }} ]; then
                 sudo ./bin/wally-tool-chain-install.sh --clean ${{ matrix.riscv_path }}
               else
                 sudo ./bin/wally-package-install.sh

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -108,12 +108,12 @@ jobs:
         run: |
             if [ ${{ matrix.imageFamily }} == "debian" ]; then
               apt-get update
-              apt-get install -y sudo git
+              apt-get install -y git
             elif [ ${{ matrix.imageFamily }} == "redhat" ]; then
-              dnf install -y sudo git
+              dnf install -y git
               dnf install curl -y --allowerasing || true
             elif [ ${{ matrix.imageFamily }} == "suse" ]; then
-              zypper install -y sudo git
+              zypper install -y git
             fi
       # Only clone submodules needed for standard tests/regression to save space
       - uses: actions/checkout@v4
@@ -134,7 +134,9 @@ jobs:
       # Run main tool chain installation script, either as a user or system wide
       - name: Install
         run: |
-              if [ -z ${{ matrix.user }} ]; then
+              if [ ! -z ${{ matrix.image }} ]; then
+                ./bin/wally-tool-chain-install.sh --clean ${{ matrix.riscv_path }}
+              else if [ -z ${{ matrix.user }} ]; then
                 sudo ./bin/wally-tool-chain-install.sh --clean ${{ matrix.riscv_path }}
               else
                 sudo ./bin/wally-package-install.sh

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -19,6 +19,7 @@ on:
       - 'bin/wally-tool-chain-install.sh'
       - 'bin/wally-distro-check.sh'
       - 'bin/wally-package-install.sh'
+      - '.github/workflows/install.yml'
   schedule:
     - cron: "0 7 * * 3" # Run at 12:00 AM Pacific Time on Wednesdays
 

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -166,7 +166,7 @@ jobs:
       # Only the linux-testvectors are needed, so remove the rest of the buildroot to save space
       - name: Remove Buildroot to Save Space
         run: |
-              sudo rm -rf $RISCV/buildroot/output/build
+              rm -rf $RISCV/buildroot/output/build || sudo rm -rf $RISCV/buildroot/output/build
               df -h
       # Run standard regression, skipping distros that are known to be broken with Verilator
       - name: Regression

--- a/bin/wally-package-install.sh
+++ b/bin/wally-package-install.sh
@@ -55,7 +55,7 @@ case "$FAMILY" in
     rhel)
         PYTHON_VERSION=python3.12
         PACKAGE_MANAGER="dnf -y"
-        UPDATE_COMMAND="sudo $PACKAGE_MANAGER update"
+        UPDATE_COMMAND="$PACKAGE_MANAGER update"
         GENERAL_PACKAGES+=(which "$PYTHON_VERSION" "$PYTHON_VERSION"-pip pkgconf-pkg-config gcc-c++ ssmtp)
         GNU_PACKAGES+=(libmpc-devel mpfr-devel gmp-devel zlib-devel expat-devel libslirp-devel ninja-build)
         QEMU_PACKAGES+=(glib2-devel libfdt-devel pixman-devel)
@@ -87,7 +87,7 @@ case "$FAMILY" in
             VERILATOR_PACKAGES+=(mold)
         fi
         PACKAGE_MANAGER="DEBIAN_FRONTEND=noninteractive apt-get -y"
-        UPDATE_COMMAND="sudo $PACKAGE_MANAGER update && sudo $PACKAGE_MANAGER upgrade --with-new-pkgs"
+        UPDATE_COMMAND="$PACKAGE_MANAGER update && $PACKAGE_MANAGER upgrade --with-new-pkgs"
         GENERAL_PACKAGES+=("$PYTHON_VERSION" python3-pip "$PYTHON_VERSION"-venv pkg-config g++ ssmtp)
         GNU_PACKAGES+=(autotools-dev libmpc-dev libmpfr-dev libgmp-dev build-essential ninja-build zlib1g-dev libexpat1-dev libglib2.0-dev libslirp-dev)
         QEMU_PACKAGES+=(libfdt-dev libpixman-1-dev)
@@ -100,7 +100,7 @@ case "$FAMILY" in
         PYTHON_VERSION=python3.12
         PYTHON_VERSION_PACKAGE=python312
         PACKAGE_MANAGER="zypper -n"
-        UPDATE_COMMAND="sudo $PACKAGE_MANAGER update"
+        UPDATE_COMMAND="$PACKAGE_MANAGER update"
         GENERAL_PACKAGES+=("$PYTHON_VERSION_PACKAGE" "$PYTHON_VERSION_PACKAGE"-pip pkg-config)
         GNU_PACKAGES+=(mpc-devel mpfr-devel gmp-devel zlib-devel libexpat-devel libslirp-devel ninja)
         QEMU_PACKAGES+=(glib2-devel libpixman-1-0-devel) # maybe also need qemu itself?
@@ -132,32 +132,32 @@ else
     section_header "Installing/Updating Dependencies from Package Manager"
     # Enable extra repos necessary for rhel
     if [ "$FAMILY" == rhel ]; then
-        sudo dnf install -y dnf-plugins-core
-        sudo dnf group install -y "Development Tools"
+        dnf install -y dnf-plugins-core
+        dnf group install -y "Development Tools"
         if [ "$ID" == rhel ]; then
-            sudo subscription-manager repos --enable "codeready-builder-for-rhel-$RHEL_VERSION-$(arch)-rpms"
-            sudo dnf install -y "https://dl.fedoraproject.org/pub/epel/epel-release-latest-$RHEL_VERSION.noarch.rpm"
+            subscription-manager repos --enable "codeready-builder-for-rhel-$RHEL_VERSION-$(arch)-rpms"
+            dnf install -y "https://dl.fedoraproject.org/pub/epel/epel-release-latest-$RHEL_VERSION.noarch.rpm"
         else # RHEL clone
             if (( RHEL_VERSION == 8 )); then
-                sudo dnf config-manager -y --set-enabled powertools
+                dnf config-manager -y --set-enabled powertools
             else # Version 9
-                sudo dnf config-manager -y --set-enabled crb
+                dnf config-manager -y --set-enabled crb
             fi
-            sudo dnf install -y epel-release
+            dnf install -y epel-release
         fi
     fi
 
     # Update and Upgrade tools
     eval "$UPDATE_COMMAND"
     # Install packages listed above using appropriate package manager
-    sudo $PACKAGE_MANAGER install "${GENERAL_PACKAGES[@]}" "${GNU_PACKAGES[@]}" "${QEMU_PACKAGES[@]}" "${SPIKE_PACKAGES[@]}" "${VERILATOR_PACKAGES[@]}" "${BUILDROOT_PACKAGES[@]}" "${OTHER_PACKAGES[@]}" "${VIVADO_PACKAGES[@]}"
+    $PACKAGE_MANAGER install "${GENERAL_PACKAGES[@]}" "${GNU_PACKAGES[@]}" "${QEMU_PACKAGES[@]}" "${SPIKE_PACKAGES[@]}" "${VERILATOR_PACKAGES[@]}" "${BUILDROOT_PACKAGES[@]}" "${OTHER_PACKAGES[@]}" "${VIVADO_PACKAGES[@]}"
 
     # Post install steps
     # Vivado looks for ncurses5 libraries, but Ubuntu 24.04 only has ncurses6
     # Create symbolic links to the ncurses6 libraries to fool Vivado
     if (( UBUNTU_VERSION >= 24 )); then
-        sudo ln -vsf /lib/x86_64-linux-gnu/libncurses.so.6 /lib/x86_64-linux-gnu/libncurses.so.5
-        sudo ln -vsf /lib/x86_64-linux-gnu/libtinfo.so.6 /lib/x86_64-linux-gnu/libntinfo.so.5
+        ln -vsf /lib/x86_64-linux-gnu/libncurses.so.6 /lib/x86_64-linux-gnu/libncurses.so.5
+        ln -vsf /lib/x86_64-linux-gnu/libtinfo.so.6 /lib/x86_64-linux-gnu/libntinfo.so.5
     fi
 
     echo -e "${SUCCESS_COLOR}Packages successfully installed.${ENDC}"

--- a/bin/wally-package-install.sh
+++ b/bin/wally-package-install.sh
@@ -150,7 +150,7 @@ else
     # Update and Upgrade tools
     eval "$UPDATE_COMMAND"
     # Install packages listed above using appropriate package manager
-    $PACKAGE_MANAGER install "${GENERAL_PACKAGES[@]}" "${GNU_PACKAGES[@]}" "${QEMU_PACKAGES[@]}" "${SPIKE_PACKAGES[@]}" "${VERILATOR_PACKAGES[@]}" "${BUILDROOT_PACKAGES[@]}" "${OTHER_PACKAGES[@]}" "${VIVADO_PACKAGES[@]}"
+    eval $PACKAGE_MANAGER install "${GENERAL_PACKAGES[@]}" "${GNU_PACKAGES[@]}" "${QEMU_PACKAGES[@]}" "${SPIKE_PACKAGES[@]}" "${VERILATOR_PACKAGES[@]}" "${BUILDROOT_PACKAGES[@]}" "${OTHER_PACKAGES[@]}" "${VIVADO_PACKAGES[@]}"
 
     # Post install steps
     # Vivado looks for ncurses5 libraries, but Ubuntu 24.04 only has ncurses6


### PR DESCRIPTION
Finally got around to fixing this. RHEL broke passwordless sudo in docker images, but we really shouldn't ever need sudo in the image since it is run as root anyway.

This refactors the installation CI script to avoid calling sudo in a docker image and also updates the `wally-package-install.sh` script to remove the explicit calls to sudo since the entire script needs to be run with sudo or as root.

Also update the Installation CI to run if the CI action itself is modified.