### PR TITLE
Add Makefile in testbench to allow the memfile to generate the correc…

### DIFF
--- a/testbench/Makefile
+++ b/testbench/Makefile
@@ -1,9 +1,17 @@
 # Makefile for testbench to create .memfile, .objdump.addr, and .objdump.lab from an ELF
 # David_Harris@hmc.edu 3 July 2024
+# james.stine@okstate.edu 24 Jan 2025
 # SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
 
+# the width is set by the elf's type to allow for individual elf compilation
 %.memfile: %
-	riscv64-unknown-elf-elf2hex  --bit-width $(if $(findstring rv32,$*),32,64) --input $< --output $@
+	@if grep -q 'elf32' $*.objdump; then \
+		BIT_WIDTH=32; \
+	else \
+		BIT_WIDTH=64; \
+	fi; \
+	echo "Processing $< with --bit-width $$BIT_WIDTH"; \
+	riscv64-unknown-elf-elf2hex --bit-width $$BIT_WIDTH --input $< --output $@
 
 %.objdump.addr: %.objdump
 	extractFunctionRadix.sh $<


### PR DESCRIPTION
…t version based on the elf output in objdump.  Previously this was done via a findstring which works with riscv-arch-tests but doesn't allow individual programs/elf to be used unless the program is called xxx_rv32.

Tested with risv-arch-test as well as 32/64 bit programs in examples.  All generate correct response to allow simulation to work correctly.