### PR TITLE
RV32IMC bug fixes and general lockstep improvements

### DIFF
--- a/src/ifu/ifu.sv
+++ b/src/ifu/ifu.sv
@@ -379,7 +379,7 @@ module ifu import cvw::*;  #(parameter cvw_t P) (
     assign InstrD = InstrRawD;
     assign IllegalIEUInstrD = IllegalBaseInstrD;
   end
-  assign IllegalIEUFPUInstrD = IllegalIEUInstrD & IllegalFPUInstrD;
+  assign IllegalIEUFPUInstrD = IllegalIEUInstrD & (IllegalFPUInstrD | !P.F_SUPPORTED);
 
   // Misaligned PC logic
   // Instruction address misalignment only from br/jal(r) instructions.

--- a/src/privileged/csrsr.sv
+++ b/src/privileged/csrsr.sv
@@ -106,8 +106,8 @@ module csrsr import cvw::*;  #(parameter cvw_t P) (
   always_comb
     if      (CSRWriteValM[12:11] == P.U_MODE & P.U_SUPPORTED) STATUS_MPP_NEXT = P.U_MODE;
     else if (CSRWriteValM[12:11] == P.S_MODE & P.S_SUPPORTED) STATUS_MPP_NEXT = P.S_MODE;
-    else if (CSRWriteValM[12:11] == 2'b10)                    STATUS_MPP_NEXT = STATUS_MPP; // do not change MPP when trying to write reserved 10
-    else                                                      STATUS_MPP_NEXT = P.M_MODE;
+    else if (CSRWriteValM[12:11] == P.M_MODE)                 STATUS_MPP_NEXT = P.M_MODE;
+    else                                                      STATUS_MPP_NEXT = STATUS_MPP; // do not change MPP when trying to write reserved 10 or unsupported mode
 
   ///////////////////////////////////////////
   // Endianness logic Privileged Spec 3.1.6.4

--- a/testbench/common/wallyTracer.sv
+++ b/testbench/common/wallyTracer.sv
@@ -179,7 +179,7 @@ module wallyTracer import cvw::*; #(parameter cvw_t P) (rvviTrace rvvi);
     // S-mode trap CSRs
     if (P.S_SUPPORTED) begin
       `CONNECT_CSR(SSTATUS, 12'h100, testbench.dut.core.priv.priv.csr.csrs.csrs.SSTATUS_REGW);
-      `CONNECT_CSR(SIE, 12'h104, testbench.dut.core.priv.priv.csr.csrm.MIE_REGW & 12'h222);
+      `CONNECT_CSR(SIE, 12'h104, testbench.dut.core.priv.priv.csr.csrm.MIE_REGW & 12'h222 & testbench.dut.core.priv.priv.csr.csrm.MIDELEG_REGW);
       `CONNECT_CSR(STVEC, 12'h105, testbench.dut.core.priv.priv.csr.csrs.csrs.STVEC_REGW);
       `CONNECT_CSR(SSCRATCH, 12'h140, testbench.dut.core.priv.priv.csr.csrs.csrs.SSCRATCH_REGW);
       `CONNECT_CSR(SEPC, 12'h141, testbench.dut.core.priv.priv.csr.csrs.csrs.SEPC_REGW);


### PR DESCRIPTION
- Fix illegal instructions not being detected when the FPU was disabled
- Fix incorrect `mstatus.MPP` write logic when any privilege modes were disabled
- Gate more testbench volatile CSRs on appropriate extensions
- Don't mark `sie` CSR as volatile and fix the mask that was hooked up to ImperasDV for it.