### PR TITLE
Added flush instructions to exercise CacheWays ClearValid

### DIFF
--- a/tests/coverage/dcache1.S
+++ b/tests/coverage/dcache1.S
@@ -80,4 +80,15 @@ main:
       sd zero, 0(t0)
       .word 0x00000013
       .word 0x00000013
+
+# test flushing
+      li t0, 0x80100000
+      cbo.flush (t0)
+      li t0, 0x80101000
+      cbo.flush (t0)
+      li t0, 0x80102000
+      cbo.flush (t0)
+      li t0, 0x80103000
+      cbo.flush (t0)
+
       j done


### PR DESCRIPTION
CacheWays is now covered except ChacheWays[2] never hits FlushStage = 1 while SetDirtyWay or ClearDirtyWay is asserted.

----------------Focused Condition View-------------------
Line       171 Item    1  ((SetDirtyWay | ClearDirtyWay) & ~FlushStage)
Condition totals: 2 of 3 input terms covered = 66.66%

     Input Term   Covered  Reason for no coverage   Hint
    -----------  --------  -----------------------  --------------
    SetDirtyWay         Y
  ClearDirtyWay         Y
     FlushStage         N  '_1' not hit             Hit '_1'
