### PR TITLE
Enable pre-commit hooks

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   lint:
-    name: Python ${{matrix.version}} lint
+    name: Lint (Python ${{matrix.version}})
     strategy:
       matrix:
         version: [39, 312] # Test on oldest and newest verions used in wally-package-install.sh

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,8 +25,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - name: Checkout code
+      uses: actions/checkout@v4
+
     - name: Set Python version
       run: sed -i '/^target-version/c\target-version = "py${{matrix.version}}"' .ruff.toml
-    - name: Run ruff
-      uses: astral-sh/ruff-action@v3
+
+    - name: Ensure pre-commit checks pass
+      run: python3 -m pip install pre-commit && pre-commit run --all-files --show-diff-on-failure --color=always

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,31 @@
+# .pre-commit-config.yaml
+# jcarlin@hmc.edu 8 April 2025
+# Pre-commit hook configuration file for CVW
+
+# SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+minimum_pre_commit_version: "4.0.0"
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: check-added-large-files
+      - id: check-case-conflict
+      - id: check-docstring-first
+      # - id: check-executables-have-shebangs
+      # - id: check-shebang-scripts-are-executable
+      - id: check-symlinks
+        exclude: bin/sim_bp # symlink to compiled executable
+      - id: requirements-txt-fixer
+        files: requirements.txt
+      # - id: end-of-file-fixer
+      # - id: trailing-whitespace
+      #   args: [--markdown-linebreak-ext=md]
+      - id: check-merge-conflict
+        args: ["--assume-in-merge"]
+        exclude: \.adoc$ # sections titles Level 6 "=======" get flagged otherwise
+      - id: check-json
+      - id: check-toml
+      - id: check-yaml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 minimum_pre_commit_version: "4.0.0"
 repos:
+  # Standard pre-commit hooks
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
     hooks:
@@ -29,3 +30,11 @@ repos:
       - id: check-json
       - id: check-toml
       - id: check-yaml
+
+  # Ruff python linter
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.11.4
+    hooks:
+      # Run the linter.
+      - id: ruff
+        args: [ --fix ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,7 @@
 
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
+exclude: addins/
 minimum_pre_commit_version: "4.0.0"
 repos:
   # Standard pre-commit hooks

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,6 +1,5 @@
 # Lint all .py files and extra python scripts without extensions
-include = ["*.py", "bin/wsim", "bin/regression-wally", "bin/iterelf", "sim/vcs/run_vcs"]
-exclude = ["addins/*", "tests/fp/quad/fpdatasetgen.py"]
+exclude = ["addins/*"]
 
 # Target oldest version of Python used (Python 3.9 for Ubuntu 20.04 LTS)
 target-version = "py39"

--- a/bin/requirements.txt
+++ b/bin/requirements.txt
@@ -2,6 +2,7 @@ adjustText>=1.2
 lief>=0.14.1
 Markdown>=3.6
 matplotlib>=3.9.0
+pre-commit>=4.0.0
 PyYAML>=5.2
 riscof @ git+https://github.com/riscv/riscof.git
 riscv-config>=3.18.3

--- a/fpga/generator/probe
+++ b/fpga/generator/probe
@@ -26,11 +26,12 @@
 
 import sys
 
+
 def usage():
-	print("Usage: ./probes name width probenum")
+  print("Usage: ./probes name width probenum")
 
 def header():
-	return """create_debug_core u_ila_0 ila
+  return """create_debug_core u_ila_0 ila
 
 set_property C_DATA_DEPTH 16384 [get_debug_cores u_ila_0]
 set_property C_TRIGIN_EN false [get_debug_cores u_ila_0]
@@ -49,49 +50,47 @@ endgroup
 connect_debug_port u_ila_0/clk [get_nets [list xlnx_ddr4_c0/inst/u_ddr4_infrastructure/addn_ui_clkout1 ]]"""
 
 def convertLine(x):
-	temp = x.split()
-	temp[1] = int(temp[1])
-	return tuple(temp)
+  temp = x.split()
+  temp[1] = int(temp[1])
+  return tuple(temp)
 
 def probeBits( probe ):
-	str = ''
+  string = ''
 
-	if (probe[1] > 1):
-		for i in range(probe[1]):
-			if i != (probe[1]-1):
-				str = str + f"{{{probe[0]}[{i}]}} "
-			else:
-				str = str + f"{{{probe[0]}[{i}]}} "
+  if (probe[1] > 1):
+    for i in range(probe[1]):
+      if i != (probe[1]-1):
+        string = string + f"{{{probe[0]}[{i}]}} "
+      else:
+        string = string + f"{{{probe[0]}[{i}]}} "
 
-	else:
-		str = f'{{{probe[0]}}}'
+  else:
+    string = f'{{{probe[0]}}}'
 
-	return str
+  return string
 
 def printProbe( probe, i ):
-	bits = probeBits(probe)
+  bits = probeBits(probe)
 
-	return (
-	    f'create_debug_port u_ila_0 probe\n'
-	    f'set_property port_width {probe[1]} [get_debug_ports u_ila_0/probe{i}]\n'
-	    f'set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe{i}]\n'
-	    f'connect_debug_port u_ila_0/probe{i} [get_nets [list {bits}]]\n\n'
-	)
+  return (
+      f'create_debug_port u_ila_0 probe\n'
+      f'set_property port_width {probe[1]} [get_debug_ports u_ila_0/probe{i}]\n'
+      f'set_property PROBE_TYPE DATA_AND_TRIGGER [get_debug_ports u_ila_0/probe{i}]\n'
+      f'connect_debug_port u_ila_0/probe{i} [get_nets [list {bits}]]\n\n'
+  )
 
 def main(args):
-	if (len(args) != 3):
-		usage()
+  if (len(args) != 3):
+    usage()
 
-	name = args[0]
-	width = int(args[1])
-	probeNum = int(args[2])
+  name = args[0]
+  width = int(args[1])
+  probeNum = int(args[2])
 
 
-	probe = (name, width)
+  probe = (name, width)
 
-	print(printProbe(probe, probeNum))
+  print(printProbe(probe, probeNum))
 
 if __name__ == '__main__':
-	main(sys.argv[1:])
-
-	
+  main(sys.argv[1:])

--- a/fpga/probe
+++ b/fpga/probe
@@ -27,6 +27,7 @@
 
 import sys
 
+
 def usage():
     print("Usage: ./probes name width probenum")
     exit(1)
@@ -37,19 +38,19 @@ def convertLine(x):
     return tuple(temp)
 
 def probeBits( probe ):
-    str = ''
+    string = ''
 
     if (probe[1] > 1):
         for i in range(probe[1]):
             if i != (probe[1]-1):
-                str = str + f"{{{probe[0]}[{i}]}} "
+                string = string + f"{{{probe[0]}[{i}]}} "
             else:
-                str = str + f"{{{probe[0]}[{i}]}} "
+                string = string + f"{{{probe[0]}[{i}]}} "
 
     else:
-        str = f'{{{probe[0]}}}'
+        string = f'{{{probe[0]}}}'
 
-    return str
+    return string
 
 def printProbe( probe, i ):
     bits = probeBits(probe)

--- a/fpga/proberange
+++ b/fpga/proberange
@@ -27,6 +27,7 @@
 
 import sys
 
+
 def usage():
   print("Usage: ./probes list_of_probes outfile")
 
@@ -56,19 +57,19 @@ def convertLine(x):
   return tuple(temp)
 
 def probeBits( probe ):
-  str = ''
+  string = ''
 
   if (probe[1] > 1):
     for i in range(probe[1]):
       if i != (probe[1]-1):
-        str = str + f"{{{probe[0]}[{i}]}} "
+        string = string + f"{{{probe[0]}[{i}]}} "
       else:
-        str = str + f"{{{probe[0]}[{i}]}} "
+        string = string + f"{{{probe[0]}[{i}]}} "
 
   else:
-    str = f'{{{probe[0]}}}'
+    string = f'{{{probe[0]}}}'
 
-  return str
+  return string
 
 def printProbe( probe,):
   bits = probeBits(probe)

--- a/fpga/probes
+++ b/fpga/probes
@@ -27,6 +27,7 @@
 
 import sys
 
+
 def usage():
   print("Usage: ./probes list_of_probes outfile")
 
@@ -55,19 +56,19 @@ def convertLine(x):
   return tuple(temp)
 
 def probeBits( probe ):
-  str = ''
+  string = ''
 
   if (probe[1] > 1):
     for i in range(probe[1]):
       if i != (probe[1]-1):
-        str = str + f"{{{probe[0]}[{i}]}} "
+        string = string + f"{{{probe[0]}[{i}]}} "
       else:
-        str = str + f"{{{probe[0]}[{i}]}} "
+        string = string + f"{{{probe[0]}[{i}]}} "
 
   else:
-    str = f'{{{probe[0]}}}'
+    string = f'{{{probe[0]}}}'
 
-  return str
+  return string
 
 def printProbe( probe, i ):
   bits = probeBits(probe)

--- a/setup.sh
+++ b/setup.sh
@@ -51,4 +51,9 @@ else
     exit 1
 fi
 
+if [ ! -e "${WALLY}/.git/hooks/pre-commit" ]; then
+    echo "Installing pre-commit hooks"
+    pre-commit install
+fi
+
 echo "setup done"


### PR DESCRIPTION
Add pre-commit hooks to ensure all lint rules pass before committing. This avoids repeatedly pushing to GitHub to try resolving a lint error.

The setup script is updated to automatically enable the pre-commit hooks whenever someone clones the repo and the installation files are updated to install `pre-commit` when running the main toolchain install.

Migrates the existing ruff lint to run in pre-commit hooks and adds several other basic checks (no large files, no merge conflict indicator marks, parseable yaml/json files, etc.).

There are several other pre-commit hooks that we should enable, but they touch a decent number of files so I'll do them as separate PRs to make it easier to review.