### PR TITLE
Full csru code coverage

### DIFF
--- a/sim/questa/coverage-exclusions-rv64gc.do
+++ b/sim/questa/coverage-exclusions-rv64gc.do
@@ -439,6 +439,12 @@ coverage exclude -scope /dut/core/hzu -linerange [GetLineNum ${SRC}/hazard/hazar
 # Instruction Misaligned never asserted because compresssed instructions are accepted
 coverage exclude -scope /dut/core/priv/priv/trap -linerange [GetLineNum ${SRC}/privileged/trap.sv "assign ExceptionM"] -item e 1 -fecexprrow 2
 
+# Attempting to access fflags, frm, fcsr with mstatus.FS = 0 traps, so checking for (STATUS_FS != 2'b00)
+# before enabling writes to these CSRs is redundant and uncoverable
+coverage exclude -scope /dut/core/priv/priv/csr/csru/csru -linerange [GetLineNum ${SRC}/privileged/csru.sv "assign WriteFRMM"] -item e 1 -fecexprrow 3
+coverage exclude -scope /dut/core/priv/priv/csr/csru/csru -linerange [GetLineNum ${SRC}/privileged/csru.sv "assign WriteFFLAGSM"] -item e 1 -fecexprrow 3
+
+
 ####################
 # EBU
 ####################

--- a/src/privileged/csru.sv
+++ b/src/privileged/csru.sv
@@ -51,6 +51,8 @@ module csru import cvw::*;  #(parameter cvw_t P) (
   logic                     WriteFFLAGSM;
   
   // Write enables
+  // Explicitly checking STATUS_FS != 0 is redundant since the instruction traps otherwise, 
+  // causing CSRWriteM to go low, but it is left here for safety
   assign WriteFRMM    = CSRUWriteM & (STATUS_FS != 2'b00) & (CSRAdrM == FRM | CSRAdrM == FCSR);
   assign WriteFFLAGSM = CSRUWriteM & (STATUS_FS != 2'b00) & (CSRAdrM == FFLAGS | CSRAdrM == FCSR);
 


### PR DESCRIPTION
Functional coverage suite attempts writes to fcsr, frm, fflags with mstatus.FS = 0 but this was not covered. Further inspection reveals that this attempt traps and flushes the M stage and therefore cannot be covered. 
(FS != 0) -> IllegalCSRUAccessM -> IllegalCSRAccessM -> IllegalInstrFaultM -> ExceptionM -> trapM -> FlushM 