### PR TITLE
Disable VCS coverage

### DIFF
--- a/bin/wsim
+++ b/bin/wsim
@@ -44,8 +44,14 @@ def validateArgs(args):
     if (args.lockstep or args.lockstepverbose) and not ((args.testsuite and args.testsuite.endswith(".elf")) or args.elf) and args.testsuite != "buildroot":
         print(f"Invalid Options. Cannot run a testsuite, {args.testsuite} with lockstep. Must run a single elf or buildroot.")
         sys.exit(1)
-    elif any([args.gui, args.ccov, args.fcov, args.lockstep, args.lockstepverbose]) and args.sim not in ["questa", "vcs"]:
-        print("Option only supported for Questa and VCS")
+    elif args.gui and args.sim != "questa":
+        print("GUI only supported by Questa")
+        sys.exit(1)
+    elif any([args.gui, args.ccov, args.fcov]) and args.sim != "questa":
+        print("Coverage only supported by Questa")
+        sys.exit(1)
+    elif any([args.lockstep, args.lockstepverbose]) and args.sim not in ["questa", "vcs"]:
+        print("Lockstep only supported by Questa and VCS")
         sys.exit(1)
     elif args.tb == "testbench_fp" and args.sim != "questa":
         print("Error: testbench_fp presently only supported by Questa, not VCS or Verilator, because of a touchy testbench")

--- a/sim/vcs/run_vcs
+++ b/sim/vcs/run_vcs
@@ -33,8 +33,8 @@ def parseArgs():
     parser.add_argument("config", help="Configuration file")
     parser.add_argument("testsuite", help="Test suite (or none, when running a single ELF file) ")
     parser.add_argument("--tb", "-t", help="Testbench", choices=["testbench", "testbench_fp"], default="testbench")
-    parser.add_argument("--ccov", "-c", help="Code Coverage", action="store_true")
-    parser.add_argument("--fcov", "-f", help="Functional Coverage", action="store_true")
+    # parser.add_argument("--ccov", "-c", help="Code Coverage", action="store_true") # Not yet implemented
+    # parser.add_argument("--fcov", "-f", help="Functional Coverage", action="store_true") # Not yet implemented
     parser.add_argument("--args", "-a", help="Optional arguments passed to simulator via $value$plusargs", default="")
     parser.add_argument("--params", "-p", help="Optional top-level parameter overrides of the form param=value", default="")
     parser.add_argument("--define", "-d", help="Optional define macros passed to simulator", default="")
@@ -67,8 +67,8 @@ def processArgs(wkdir, args):
                                 "$IMPERAS_HOME/ImpPublic/source/host/rvvi/*.sv",
                                 "$IMPERAS_HOME/ImpProprietary/source/host/idv/*.sv"])
         simvOptions.append("-sv_lib $IMPERAS_HOME/lib/Linux64/ImperasLib/imperas.com/verification/riscv/1.0/model")
-    if args.ccov:
-        compileOptions.extend(["-cm line+cond+branch+fsm+tgl", f"-cm_log {wkdir}/coverage.log", f"-cm_dir {wkdir}/coverage"])
+    # if args.ccov:
+    #     compileOptions.extend(["-cm line+cond+branch+fsm+tgl", f"-cm_log {wkdir}/coverage.log", f"-cm_dir {wkdir}/coverage"])
     if args.params:
         compileOptions.append(setupParamOverrides(wkdir, args))
     if args.define:
@@ -111,8 +111,8 @@ def main(args):
     compileOptions, simvOptions = processArgs(wkdir, args)
     vcsCMD, simvCMD = setupCommands(wkdir, rtlFiles, compileOptions, simvOptions, args)
     runVCS(vcsCMD, simvCMD)
-    if args.ccov:
-        runCoverage(wkdir, args.config, args.testsuite)
+    # if args.ccov:
+    #     runCoverage(wkdir, args.config, args.testsuite)
 
 if __name__ == "__main__":
     args = parseArgs()


### PR DESCRIPTION
Print an unsupported error from wsim when attempting to use `ccov` or `fcov` with VCS.