### PR TITLE
Enable function coverage tests in nightly regression

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ SIM = ${WALLY}/sim
 
 .PHONY: all riscof testfloat combined_IF_vectors zsbl coverage cvw-arch-verif sim_bp clean
 
-all: riscof	testfloat combined_IF_vectors zsbl coverage sim_bp # cvw-arch-verif
+all: riscof	testfloat combined_IF_vectors zsbl coverage sim_bp cvw-arch-verif
 
 # riscof builds the riscv-arch-test and wally-riscv-arch-test suites
 riscof:

--- a/bin/regression-wally
+++ b/bin/regression-wally
@@ -455,7 +455,7 @@ def selectTests(args, sims, coverStr):
         addTestsByDir(f"{WALLY}/tests/riscof/work/wally-riscv-arch-test/rv64i_m/privilege", "rv64gc", coveragesim, coverStr, configs)
         # addTestsByDir(f"{WALLY}/tests/riscof/work/riscv-arch-test/rv64i_m/F", "rv64gc", coveragesim, coverStr, configs) # doesn't help fdivsqrt coverage 4/3/2025
     # run tests in lockstep in functional coverage mode
-    if args.fcov:
+    if args.fcov or args.nightly:
         addTestsByDir(f"{archVerifDir}/tests/rv32/", "rv32gc", coveragesim, coverStr, configs, lockstepMode=1)
         addTestsByDir(f"{archVerifDir}/tests/rv64/", "rv64gc", coveragesim, coverStr, configs, lockstepMode=1)
         addTestsByDir(f"{archVerifDir}/tests/priv/rv32/", "rv32gc", coveragesim, coverStr, configs, lockstepMode=1)


### PR DESCRIPTION
Especially now that they are taking longer (and we'll likely run them less often), run the functional coverage tests in nightly regression. This doesn't check the coverage (can be improved later), but will run all of the tests.