### PR TITLE
Remove deprecated --fp option from regression-wally

### DIFF
--- a/bin/regression-wally
+++ b/bin/regression-wally
@@ -392,7 +392,6 @@ def parse_args():
     parser.add_argument("--buildroot", help="Include Buildroot Linux boot test (takes many hours, done along with --nightly)", action="store_true")
     parser.add_argument("--testfloat", help="Include Testfloat floating-point unit tests", action="store_true")
     parser.add_argument("--branch", help="Run branch predictor accuracy tests", action="store_true")
-    parser.add_argument("--fp", help="Include floating-point tests in coverage (slower runtime)", action="store_true") # Currently not used
     parser.add_argument("--breker", help="Run Breker tests", action="store_true") # Requires a license for the breker tool. See tests/breker/README.md for details
     parser.add_argument("--dryrun", help="Print commands invoked to console without running regression", action="store_true")
     return parser.parse_args()


### PR DESCRIPTION
This option hasn't done anything since we switched to using cvw-arch-verif for code coverage. Code coverage of the fpu is at 100%, so it doesn't seem like it will be needed.