### PR TITLE
Fix riscv-config isa yaml for compatability with latest RISCOF for PMPs

### DIFF
--- a/bin/requirements.txt
+++ b/bin/requirements.txt
@@ -5,7 +5,7 @@ matplotlib>=3.9.0
 pre-commit>=4.0.0
 PyYAML>=5.2
 riscof @ git+https://github.com/riscv/riscof.git
-riscv-config>=3.18.3
+riscv-config @ git+https://github.com/riscv-software-src/riscv-config
 riscv-isac @ git+https://github.com/riscv-non-isa/riscv-arch-test/#subdirectory=riscv-isac
 scikit-learn>=1.5.0
 scipy>=1.13.0

--- a/tests/riscof/spike/spike_rv32e_isa.yaml
+++ b/tests/riscof/spike/spike_rv32e_isa.yaml
@@ -1,29 +1,33 @@
 hart_ids: [0]
 hart0:
-  ISA: RV32EMCZicsr_Zifencei_Zbkc
+  ISA: RV32EMCZicsr_Zifencei
   physical_addr_sz: 32
   User_Spec_Version: '2.3'
   supported_xlen: [32]
   misa:
-   reset-val: 0x40001014
-   rv32:
-     accessible: true
-     mxl:
-       implemented: true
-       type:
-           warl:
-              dependency_fields: []
-              legal:
-                - mxl[1:0] in [0x1]
-              wr_illegal:
-                - Unchanged
-     extensions:
-       implemented: true
-       type:
-           warl:
-              dependency_fields: []
-              legal:
-                - extensions[25:0] bitmask [0x0001034, 0x0000000]
-              wr_illegal:
-                - Unchanged
- 
+    reset-val: 0x40001014
+    rv32:
+      accessible: true
+      mxl:
+        implemented: true
+        type:
+          warl:
+            dependency_fields: []
+            legal:
+              - mxl[1:0] in [0x1]
+            wr_illegal:
+              - Unchanged
+      extensions:
+        implemented: true
+        type:
+          warl:
+            dependency_fields: []
+            legal:
+              - extensions[25:0] bitmask [0x0001034, 0x0000000]
+            wr_illegal:
+              - Unchanged
+  PMP:
+    implemented: False
+    pmp-grain: 0
+    pmp-count: 0
+    pmp-writable: 0

--- a/tests/riscof/spike/spike_rv32gc_isa.yaml
+++ b/tests/riscof/spike/spike_rv32gc_isa.yaml
@@ -1,29 +1,33 @@
 hart_ids: [0]
 hart0:
-#  ISA: RV32IMAFDCZicboz_Zicsr_Zicond_Zifencei_Zfa_Zfh_Zca_Zcb_Zba_Zbb_Zbc_Zbkb_Zbkc_Zbkx_Zbs_Zknd_Zkne_Zknh
   ISA: RV32IMAFDCSUZicsr_Zicond_Zifencei_Zfa_Zfh_Zca_Zcb_Zcd_Zcf_Zba_Zbb_Zbc_Zbkb_Zbkc_Zbkx_Zbs_Zknd_Zkne_Zknh
   physical_addr_sz: 32
   User_Spec_Version: '2.3'
   supported_xlen: [32]
   misa:
-   reset-val: 0x4014112D
-   rv32:
-     accessible: true
-     mxl:
-       implemented: true
-       type:
-           warl:
-              dependency_fields: []
-              legal:
-                - mxl[1:0] in [0x1]
-              wr_illegal:
-                - Unchanged
-     extensions:
-       implemented: true
-       type:
-           warl:
-              dependency_fields: []
-              legal:
-                - extensions[25:0] bitmask [0x014112D, 0x0000000]
-              wr_illegal:
-                - Unchanged
+    reset-val: 0x4014112D
+    rv32:
+      accessible: true
+      mxl:
+        implemented: true
+        type:
+          warl:
+            dependency_fields: []
+            legal:
+              - mxl[1:0] in [0x1]
+            wr_illegal:
+              - Unchanged
+      extensions:
+        implemented: true
+        type:
+          warl:
+            dependency_fields: []
+            legal:
+              - extensions[25:0] bitmask [0x014112D, 0x0000000]
+            wr_illegal:
+              - Unchanged
+  PMP:
+    implemented: True
+    pmp-grain: 0
+    pmp-count: 16
+    pmp-writable: 12

--- a/tests/riscof/spike/spike_rv64gc_isa.yaml
+++ b/tests/riscof/spike/spike_rv64gc_isa.yaml
@@ -1,34 +1,35 @@
 hart_ids: [0]
 hart0:
-#  ISA: RV64IMAFDQCSUZicboz_Zicsr_Zicond_Zifencei_Zfa_Zfh_Zca_Zcb_Zba_Zbb_Zbc_Zbkb_Zbkc_Zbkx_Zbs_Zknd_Zkne_Zknh
   ISA: RV64IMAFDCSUZicsr_Zicond_Zifencei_Zfa_Zfh_Zca_Zcb_Zcd_Zba_Zbb_Zbc_Zbkb_Zbkc_Zbkx_Zbs_Zknd_Zkne_Zknh
-#  ISA: RV64IMAFDQCSUZicsr_Zicond_Zifencei_Zfa_Zfh_Zca_Zcb_Zba_Zbb_Zbc_Zbkb_Zbkc_Zbkx_Zbs_Zknd_Zkne_Zknh  
   physical_addr_sz: 56
   User_Spec_Version: '2.3'
   supported_xlen: [64]
   misa:
-   reset-val: 0x800000000014112D
-#    reset-val: 0x800000000015112D
-   rv32:
+    reset-val: 0x800000000014112D
+    rv32:
       accessible: false
-   rv64:
-     accessible: true
-     mxl:
-       implemented: true
-       type:
-           warl:
+    rv64:
+      accessible: true
+      mxl:
+        implemented: true
+        type:
+            warl:
               dependency_fields: []
               legal:
                 - mxl[1:0] in [0x2]
               wr_illegal:
                 - Unchanged
-     extensions:
-       implemented: true
-       type:
-           warl:
-              dependency_fields: []
-              legal:
-                - extensions[25:0] bitmask [0x015112D, 0x0000000]
-              wr_illegal:
-                - Unchanged
- 
+      extensions:
+        implemented: true
+        type:
+          warl:
+            dependency_fields: []
+            legal:
+              - extensions[25:0] bitmask [0x015112D, 0x0000000]
+            wr_illegal:
+              - Unchanged
+  PMP:
+    implemented: True
+    pmp-grain: 0
+    pmp-count: 16
+    pmp-writable: 12


### PR DESCRIPTION
The latest version of RISCOF expects a PMP field to be present in the riscv-config isa yaml files for configuring the PMP tests. This adds it to our copies of the riscv-config files. Also remove Zbkc from our rv32e riscv-config file.