### PR TITLE
Workaround binutils 2.44 objdump 6-byte instruction bug in fpu.S coverage test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,13 +6,13 @@ MAKEFLAGS += --output-sync --no-print-directory
 
 SIM = ${WALLY}/sim
 
-.PHONY: all riscof testfloat combined_IF_vectors zsbl coverage cvw-arch-verif sim_bp clean
+.PHONY: all riscof testfloat combined_IF_vectors zsbl coverage cvw-arch-verif sim_bp deriv clean
 
-all: riscof	testfloat combined_IF_vectors zsbl coverage sim_bp cvw-arch-verif
+all: riscof	testfloat combined_IF_vectors zsbl coverage sim_bp cvw-arch-verif deriv
 
 # riscof builds the riscv-arch-test and wally-riscv-arch-test suites
 riscof:
-	$(MAKE) -C sim
+	$(MAKE) -C tests/riscof
 
 testfloat:
 	$(MAKE) -C ${WALLY}/tests/fp vectors
@@ -25,6 +25,9 @@ zsbl:
 
 coverage:
 	$(MAKE) -C tests/coverage
+
+deriv:
+	derivgen.pl
 
 cvw-arch-verif:
 	$(MAKE) -C ${WALLY}/addins/cvw-arch-verif
@@ -40,7 +43,8 @@ breker:
 	$(MAKE) -C ${WALLY}/tests/breker
 
 clean:
-	$(MAKE) clean -C sim
+	$(MAKE) clean -C ${WALLY}/tests/riscof
 	$(MAKE) clean -C ${WALLY}/tests/fp
+	$(MAKE) clean -C ${WALLY}/fpga/zsbl
 	$(MAKE) clean -C ${WALLY}/tests/coverage
 	$(MAKE) clean -C ${WALLY}/addins/cvw-arch-verif

--- a/tests/coverage/fpu.S
+++ b/tests/coverage/fpu.S
@@ -214,6 +214,9 @@ TestData2:
 .int 0xbf800000 #FP -1.0
 .int 0x7fa00000 #SNaN
 .int 0x3fffffff #OverFlow Test
+# workaround for binutils 2.44 bug with displaying 6 byte instructions (https://sourceware.org/pipermail/binutils/2025-February/139413.html)
+.word 0x0000
+.align 3
 TestData3:
 .dword 0xABCD543212345678 # NaN box test
 DivTestData:


### PR DESCRIPTION
Fixes #1419