### PR TITLE
Replace egrep with grep -E for better compatibility

### DIFF
--- a/bin/extractFunctionRadix.sh
+++ b/bin/extractFunctionRadix.sh
@@ -38,7 +38,7 @@ function processProgram {
 
     # when size = 16 => 64 bit
     # when size = 8 => 32 bit
-    local listOfAddr=`egrep -i "^[0-9a-f]{$size} <[0-9a-zA-Z_]+>" $objDumpFile`
+    local listOfAddr=$(grep -E -i "^[0-9a-f]{$size} <[0-9a-zA-Z_]+>" $objDumpFile)
 
     # skip if the wrong bit width.
     if [ -z "$listOfAddr" ]; then
@@ -46,16 +46,16 @@ function processProgram {
     fi
 
     # parse out the addresses and the labels
-    local addresses=`echo "$listOfAddr" | awk '{print $1}'`
-    local labels=`echo "$listOfAddr" | awk '{print  "\""$2"\"", "-color \"SpringGreen\","}' | tr -d '<>:'`
-    local labelsName=`echo "$listOfAddr" | awk '{print  ""$2""}' | tr -d '<>:'`
+    local addresses=$(echo "$listOfAddr" | awk '{print $1}')
+    local labels=$(echo "$listOfAddr" | awk '{print  "\""$2"\"", "-color \"SpringGreen\","}' | tr -d '<>:')
+    local labelsName=$(echo "$listOfAddr" | awk '{print  ""$2""}' | tr -d '<>:')
 
     # output per program function address list
     echo "$addresses" > $objDumpFile.addr
     echo "$labelsName" > $objDumpFile.lab    
 
     # need to add some formatting to each line
-    local numLines=`echo "$listOfAddr" | wc -l`
+    local numLines=$(echo "$listOfAddr" | wc -l)
 
     return 0
 }

--- a/sim/Makefile
+++ b/sim/Makefile
@@ -106,8 +106,8 @@ combine_functcov:
 	vcover report -details -html ${SIM}/questa/fcov_ucdb/fcov.ucdb
 	vcover report ${SIM}/questa/fcov_ucdb/fcov.ucdb -details -cvg > ${SIM}/questa/fcov/fcov.log
 	vcover report ${SIM}/questa/fcov_ucdb/fcov.ucdb -testdetails -cvg > ${SIM}/questa/fcov/fcov.testdetails.log
-#	vcover report ${SIM}/questa/fcov/fcov.ucdb -details -cvg -below 100 | egrep "Coverpoint|Covergroup|Cross" | grep -v Metric > ${SIM}/questa/fcov/fcov.ucdb.summary.log
-	vcover report ${SIM}/questa/fcov_ucdb/fcov.ucdb -details -cvg | egrep "Coverpoint|Covergroup|Cross|TYPE"  > ${SIM}/questa/fcov/fcov.summary.log
+#	vcover report ${SIM}/questa/fcov/fcov.ucdb -details -cvg -below 100 | grep -E "Coverpoint|Covergroup|Cross" | grep -v Metric > ${SIM}/questa/fcov/fcov.ucdb.summary.log
+	vcover report ${SIM}/questa/fcov_ucdb/fcov.ucdb -details -cvg | grep -E "Coverpoint|Covergroup|Cross|TYPE"  > ${SIM}/questa/fcov/fcov.summary.log
 	grep "Total Coverage By Instance" ${SIM}/questa/fcov/fcov.log
 
 remove_functcov_artifacts:


### PR DESCRIPTION
`egrep` has been deprecated since 2007, and newer versions of grep (used in the upcoming RHEL 10) now print a warning when using it. This switches to the equivalent posix compliant `grep -E`