### PR TITLE
Spyglass improvements

### DIFF
--- a/bin/lint-spyglass.sh
+++ b/bin/lint-spyglass.sh
@@ -20,6 +20,7 @@ fi
 GOAL="lint/lint_rtl"
 DEFAULT_CONFIGS=(rv32e rv64gc rv32gc rv32imc rv32i rv64i)
 CONFIGS=()
+BATCH_FLAG="-batch"
 
 # === Parse command-line options ===
 while [[ $# -gt 0 ]]; do
@@ -32,10 +33,15 @@ while [[ $# -gt 0 ]]; do
             IFS=',' read -r -a CONFIGS <<< "$2"
             shift 2
             ;;
+        --gui)
+            BATCH_FLAG=""
+            shift
+            ;;
         -h|--help)
-            echo "Usage: $0 [-g lint_goal] [-c config1,config2,...]"
+            echo "Usage: $0 [-g lint_goal] [-c config1,config2,...] [--gui]"
             echo "  -g, --goal      Linting goal (e.g., lint/lint_rtl or lint/lint_rtl_enhanced)"
             echo "  -c, --configs   Comma-separated list of configs to run (e.g., rv32e,rv64gc)"
+            echo "  --gui           Run SpyGlass with Verdi GUI"
             echo "Defaults: goal=$GOAL, configs=${DEFAULT_CONFIGS[*]}"
             exit 0
             ;;
@@ -51,6 +57,11 @@ if [ ${#CONFIGS[@]} -eq 0 ]; then
     CONFIGS=("${DEFAULT_CONFIGS[@]}")
 fi
 
+# For GUI mode, warn if multiple configs are specified
+if [ -z "$BATCH_FLAG" ] && [ ${#CONFIGS[@]} -gt 1 ]; then
+    echo "Warning: Multiple configurations selected. GUI will open for each configuration sequentially."
+fi
+
 # Spyglass work directories/files
 SPYGLASS_DIR="$WALLY/synthDC/spyglass"
 SPYGLASS_PRJ="$SPYGLASS_DIR/cvw.prj"
@@ -63,7 +74,7 @@ for config in "${CONFIGS[@]}"; do
 
     # Run SpyGlass
     echo "Running spyglass for: $config with goal: $GOAL"
-    WALLY_CONFIG=$config spyglass -project "$SPYGLASS_PRJ" -goal "$GOAL" -batch
+    WALLY_CONFIG=$config spyglass -project "$SPYGLASS_PRJ" -goal "$GOAL" $BATCH_FLAG
 
     if [ $? -ne 0 ]; then
         echo "Error running spyglass for configuration: $config"

--- a/bin/lint-spyglass.sh
+++ b/bin/lint-spyglass.sh
@@ -53,33 +53,24 @@ fi
 
 # Spyglass work directories/files
 SPYGLASS_DIR="$WALLY/synthDC/spyglass"
-TEMPLATE_PRJ="$SPYGLASS_DIR/cvw.prj"
-
-# Clean output directory
-echo "Cleaning lint-spyglass-reports directory..."
-rm -rf "$SPYGLASS_DIR/lint-spyglass-reports"
+SPYGLASS_PRJ="$SPYGLASS_DIR/cvw.prj"
 
 # Iterate configs
+errors=0
 for config in "${CONFIGS[@]}"; do
-    echo "Processing configuration: $config"
-    CONFIG_PRJ="$SPYGLASS_DIR/cvw_${config}.prj"
-
-    # Replace placeholders in template
-    sed -e "s|\$WALLY|$WALLY|g" \
-        -e "s|WALLYVER|$config|g" \
-        -e "s|read_file -type awl waivers.tcl|read_file -type awl $SPYGLASS_DIR/waivers.tcl|g" \
-        -e "s|set_option projectwdir lint-spyglass/|set_option projectwdir ${SPYGLASS_DIR}/lint-spyglass/|g" \
-        "$TEMPLATE_PRJ" > "$CONFIG_PRJ"
+    # Clean output directory
+    rm -rf "$SPYGLASS_DIR/lint-spyglass-reports/$config"
 
     # Run SpyGlass
     echo "Running spyglass for: $config with goal: $GOAL"
-    spyglass -project "$CONFIG_PRJ" -goal "$GOAL" -batch
+    WALLY_CONFIG=$config spyglass -project "$SPYGLASS_PRJ" -goal "$GOAL" -batch
 
     if [ $? -ne 0 ]; then
         echo "Error running spyglass for configuration: $config"
+        errors=$((errors + 1))
     else
         echo "Completed: $config"
     fi
-
-    rm "$CONFIG_PRJ"
 done
+
+exit $errors

--- a/site-setup.csh
+++ b/site-setup.csh
@@ -1,22 +1,29 @@
 #!/bin/csh
 
 # site-setup.csh
+# System Admin should install this into $RISCV/site-setup.csh
+# It is automatically placed in the $RISCV directory by wally-toolchain-install.sh
+# $RISCV is typically /opt/riscv or ~/riscv
+# System Admin must update the licenses and paths for localization.
+# SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
 
 # License servers and commercial CAD tool paths
 # Must edit these based on your local environment.  Ask your sysadmin.
 setenv MGLS_LICENSE_FILE 27002@zircon.eng.hmc.edu                         # Change this to your Siemens license server
 setenv SNPSLMD_LICENSE_FILE 27020@zircon.eng.hmc.edu                      # Change this to your Synopsys license server
-setenv QUESTAPATH /cad/mentor/questa_sim-2022.4_2/questasim/bin           # Change this for your path to Questa
-setenv SNPSPATH /cad/synopsys/SYN/bin                                     # Change this for your path to Design Compiler
-setenv VCSPATH /cad/synopsys/vcs/U-2023.03-SP2-4/bin                      # Change this for your path to Synopsys VCS
-setenv SPYGLASS_HOME /cad/synopsys/spyglass/W-2024.09-SP2-2/SPYGLASS_HOME # Change this for your path to Synopsys Spyglass
+setenv QUESTAPATH /cad/mentor/QUESTA/bin                                  # Change this for your path to Questa
+setenv DCPATH /cad/synopsys/SYN/bin                                       # Change this for your path to Design Compiler
+setenv VCSPATH /cad/synopsys/VCS/bin                                      # Change this for your path to Synopsys VCS
+setenv BREKER_HOME /cad/breker/TREK                                       # Change this for your path to Breker Trek
+setenv SPYGLASS_HOME /cad/synopsys/SPYGLASS_HOME                          # Change this for your path to Synopsys Spyglass
 
 
 # Tools
 # Questa and Synopsys
 extend PATH $QUESTAPATH
-extend PATH $SNPSPATH
+extend PATH $DCPATH
 extend PATH $VCSPATH
+extend PATH $SPYGLASS_HOME/bin
 # Synopsys Spyglass
 setenv SNPSLMD_QUEUE 1
 
@@ -62,6 +69,8 @@ if ($?IDV) then
 endif
 
 # Use newer gcc version for older distros
-if ( -e $RISCV/gcc-10 ) then
-    prepend PATH \$RISCV/gcc-10/bin # Ubuntu 20.04 LTS
+if ( -e $RISCV/gcc-13 ) then
+    prepend PATH $RISCV/gcc-13/bin # SUSE Family
+elseif ( -e $RISCV/gcc-10 ) then
+    prepend PATH $RISCV/gcc-10/bin # Ubuntu 20.04 LTS
 endif

--- a/site-setup.sh
+++ b/site-setup.sh
@@ -15,19 +15,19 @@ ENDC='\033[0m' # Reset to default color
 
 # license servers and commercial CAD tool paths
 # Must edit these based on your local environment.
-export MGLS_LICENSE_FILE=27002@zircon.eng.hmc.edu                         # Change this to your Siemens license server for Questa
-export SNPSLMD_LICENSE_FILE=27020@zircon.eng.hmc.edu                      # Change this to your Synopsys license server
-export IMPERASD_LICENSE_FILE=27020@zircon.eng.hmc.edu                     # Change this to your Imperas license server
-export BREKER_LICENSE_FILE=1819@zircon.eng.hmc.edu                        # Change this to your Breker license server
-export QUESTA_HOME=/cad/mentor/QUESTA                                     # Change this for your path to Questa, excluding bin
-export DC_HOME=/cad/synopsys/SYN                                          # Change this for your path to Synopsys DC, excluding bin
-export VCS_HOME=/cad/synopsys/VCS                                         # Change this for your path to Synopsys VCS, excluding bin
-export BREKER_HOME=/cad/breker/TREK                                       # Change this for your path to Breker Trek
-export SPYGLASS_HOME=/cad/synopsys/spyglass/W-2024.09-SP2-2/SPYGLASS_HOME # Change this for your path to Synopsys Spyglass
+export MGLS_LICENSE_FILE=27002@zircon.eng.hmc.edu                   # Change this to your Siemens license server for Questa
+export SNPSLMD_LICENSE_FILE=27020@zircon.eng.hmc.edu                # Change this to your Synopsys license server
+export IMPERASD_LICENSE_FILE=27020@zircon.eng.hmc.edu               # Change this to your Imperas license server
+export BREKER_LICENSE_FILE=1819@zircon.eng.hmc.edu                  # Change this to your Breker license server
+export QUESTA_HOME=/cad/mentor/QUESTA                               # Change this for your path to Questa, excluding bin
+export DC_HOME=/cad/synopsys/SYN                                    # Change this for your path to Synopsys DC, excluding bin
+export VCS_HOME=/cad/synopsys/VCS                                   # Change this for your path to Synopsys VCS, excluding bin
+export BREKER_HOME=/cad/breker/TREK                                 # Change this for your path to Breker Trek
+export SPYGLASS_HOME=/cad/synopsys/SPYGLASS_HOME                    # Change this for your path to Synopsys Spyglass
 
 # Tools
 # Questa and Synopsys
-export PATH=$QUESTA_HOME/bin:$DC_HOME/bin:$VCS_HOME/bin:$PATH
+export PATH=$QUESTA_HOME/bin:$DC_HOME/bin:$VCS_HOME/bin:$SPYGLASS_HOME/bin:$PATH
 # Synopsys Spyglass
 export SNPSLMD_QUEUE=1
 

--- a/synthDC/spyglass/cvw.prj
+++ b/synthDC/spyglass/cvw.prj
@@ -4,8 +4,11 @@
 # SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
 #
 
+set WALLY $::env(WALLY)
+set WALLY_CONFIG $::env(WALLY_CONFIG)
+
 # Sets directory for output reports
-set_option projectwdir $WALLY/synthDC/spyglass/lint-spyglass-reports/
+set_option projectwdir ${WALLY}/synthDC/spyglass/lint-spyglass-reports/${WALLY_CONFIG}
 set_option language_mode mixed
 set_option designread_enable_synthesis no
 set_option designread_disable_flatten no
@@ -16,18 +19,16 @@ set_option top wallywrapper
 set_parameter handle_large_bus yes
 
 # Include DIR
-set_option incdir $WALLY/config/WALLYVER
-set_option incdir $WALLY/config/shared
+set_option incdir ${WALLY}/config/${WALLY_CONFIG}
+set_option incdir ${WALLY}/config/shared
 
 # main CVW
-read_file -type verilog $WALLY/src/cvw.sv
-read_file -type verilog $WALLY/testbench/wallywrapper.sv
-read_file -type awl $WALLY/synthDC/spyglass/waivers.tcl
+read_file -type verilog ${WALLY}/src/cvw.sv
+read_file -type verilog ${WALLY}/testbench/wallywrapper.sv
+read_file -type awl ${WALLY}/synthDC/spyglass/waivers.tcl
 
 # generic read of Wally src files
-read_file -type verilog $WALLY/src/*/*
-read_file -type verilog $WALLY/src/*/*/*
+read_file -type verilog ${WALLY}/src/*/*
+read_file -type verilog ${WALLY}/src/*/*/*
 
 current_methodology $SPYGLASS_HOME/GuideWare/latest/block/rtl_handoff
-
-


### PR DESCRIPTION
- Update `site-setup.sh` to add `spyglass` to the path
- Update `cvw.prj` to use environment variables so temporary files created using sed are not needed
- Only delete reports for configurations that are being run
- Add `--gui` option to `lint-spyglass.sh` to launch interactive version of Spyglass in Verdi