### PR TITLE
Fix fulladder example and install gtkwave

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,6 +115,9 @@ sim/questa/riscv.ucdb
 transcript
 vsim.wlf
 wlft*
+qrun*
+simv
+*.ucdb
 
 # VCS
 sim/vcs/logs
@@ -144,6 +147,7 @@ examples/verilog/fulladder/simprofile_dir/
 examples/verilog/fulladder/simv.daidir/
 examples/verilog/fulladder/ucli.key
 examples/verilog/fulladder/verdi_config_file
+examples/verilog/fulladder/fulladder_coverage_details.rpt
 examples/fp/softfloat_demo/softfloat_demo
 examples/fp/softfloat_demo/softfloat_demoDP
 examples/fp/softfloat_demo/softfloat_demoQP

--- a/bin/wally-package-install.sh
+++ b/bin/wally-package-install.sh
@@ -45,7 +45,7 @@ fi
 GENERAL_PACKAGES+=(rsync git curl wget tar unzip gzip bzip2 gcc make dialog mutt) # TODO: check what needs dialog
 GNU_PACKAGES+=(autoconf automake gawk bison flex texinfo gperf libtool patchutils bc)
 SAIL_PACKAGES+=(cmake)
-VERILATOR_PACKAGES+=(autoconf flex bison help2man perl ccache numactl)
+VERILATOR_PACKAGES+=(autoconf flex bison help2man perl ccache numactl gtkwave) # gtkwave is not needed for verilator, but useful for viewing waveforms
 BUILDROOT_PACKAGES+=(patchutils perl cpio bc)
 
 # Distro specific packages and package manager

--- a/examples/verilog/fulladder/fulladder.sv
+++ b/examples/verilog/fulladder/fulladder.sv
@@ -46,7 +46,11 @@ module testbench();
       if (vectornum === 10) begin 
         $display("%d tests completed with %d errors", 
 	           vectornum, errors);
+`ifdef QUESTA
+        $stop;  // if this is changed to $finish for Questa, coverage is not collected
+`else
         $finish;
+`endif
       end
     end
 


### PR DESCRIPTION
Fixes for examples in Ch 5 of the textbook:
- Install `gtkwave` for viewing Verilator vcd files.
- Update `fulladder.sv` testbench to use `$stop`/`$finish` depending on the simulator so the code coverage example works (was unconditionally using `$finish` before and coverage was not actually generated).
- Update `.gitignore` to ignore more files generated by running the examples.

NOTE: The installation CI will fail because of the ongoing issue with the riscv-arch-test pmp tests. This can be merged anyway.