### PR TITLE
Fixed regression failures

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -36,9 +36,3 @@
 [submodule "addins/cvw-riscv-arch-test"]
 	path = addins/cvw-riscv-arch-test
 	url = https://github.com/jordancarlin/riscv-arch-test
-[submodule "addins/riscv-unified-db"]
-	path = addins/riscv-unified-db
-	url = https://github.com/riscv-software-src/riscv-unified-db
-[submodule "addins/riscv-isa-manual"]
-	path = addins/riscv-isa-manual
-	url = https://github.com/davidharrishmc/riscv-isa-manual


### PR DESCRIPTION
WALLY-status-tw-01.elf and tests/coverage/priv.elf were broken for rv64gc when the imperas.ic added
--override cpu/TW_time_limit=65536

This is now commented out.  It was used for interrupt coverage tests, but we will need to find a different solution there.
