### PR TITLE
wally-riscv-arch-test now passing regression

### DIFF
--- a/tests/riscof/sail_cSim/env/link.ld
+++ b/tests/riscof/sail_cSim/env/link.ld
@@ -1,18 +1,52 @@
 OUTPUT_ARCH( "riscv" )
 ENTRY(rvtest_entry_point)
 
-SECTIONS
+/* Program headers: put code in a RX PT_LOAD and writable objects in an RW PT_LOAD */
+PHDRS
 {
-  . = 0x80000000;
-  .text.init : { *(.text.init) }
-  . = ALIGN(0x1000);
-  .tohost : { *(.tohost) }
-  . = ALIGN(0x1000);
-  .text : { *(.text) }
-  . = ALIGN(0x1000);
-  .data : { *(.data) }
-  .data.string : { *(.data.string)}
-  .bss : { *(.bss) }
-  _end = .;
+  /* PF_R | PF_X = 5, PF_R | PF_W = 6 */
+  text PT_LOAD FLAGS(5);
+  data PT_LOAD FLAGS(6);
 }
 
+SECTIONS
+{
+  /* Place the program at the machine start address */
+  . = 0x80000000;
+
+  /* Align to page and place executable/code+rodata in the text PT_LOAD (RX) */
+  . = ALIGN(0x1000);
+  .text :
+  {
+    *(.text.init)
+    *(.text)
+    *(.rodata)
+  } :text
+
+  /* I/O/host communications - keep small alignment but put into data PT_LOAD */
+  . = ALIGN(0x1000);
+  .tohost :
+  {
+    *(.tohost)
+  } :data
+
+  /* Writable data segment */
+  . = ALIGN(0x1000);
+  .data :
+  {
+    *(.data)
+    *(.data.*)
+    . = ALIGN(8);
+    *(.data.string)
+  } :data
+
+  /* BSS should not occupy file space (NOLOAD) but must be in the RW segment */
+  . = ALIGN(0x1000);
+  .bss (NOLOAD) :
+  {
+    *(.bss)
+    *(COMMON)
+  } :data
+
+  _end = .;
+}

--- a/tests/riscof/sail_cSim/rv32gc.json
+++ b/tests/riscof/sail_cSim/rv32gc.json
@@ -15,7 +15,7 @@
       "grain": 4,
       "count": 16,
       "tor_supported": true,
-      "na4_supported": true,
+      "na4_supported": false,
       "napot_supported": true
     },
     "misaligned": {

--- a/tests/riscof/sail_cSim/rv64gc.json
+++ b/tests/riscof/sail_cSim/rv64gc.json
@@ -15,7 +15,7 @@
       "grain": 4,
       "count": 16,
       "tor_supported": true,
-      "na4_supported": true,
+      "na4_supported": false,
       "napot_supported": true
     },
     "misaligned": {


### PR DESCRIPTION
Disabled NA4 because it is incompatible with PMP grain > 0, fixed link.ld with chatGPT to eliminate warnings about rwx in LOAD segment

All PMP mismatches now fixed.

Hopefully this fixes nightly regression.