### PR TITLE
Use Python for `lint-wally` script

### DIFF
--- a/bin/lint-wally
+++ b/bin/lint-wally
@@ -1,55 +1,135 @@
-#!/bin/bash
-# check for warnings in Verilog code
-# The verilator lint tool is faster and better than Questa so it is best to run this first.
+#!/usr/bin/env python3
+##################################
+#
+# lint-wally
+# jcarlin@hmc.edu October 25, 2025
 # SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+#
+# Check for warnings in Verilog code using Verilator lint tool.
+# The verilator lint tool is faster and better than Questa so it is best to run this first.
+#
+##################################
 
-verilator=$(which verilator)
 
-basepath=$(dirname "$0")/..
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-NC='\033[0m' # No Color
-fails=0
+import argparse
+import multiprocessing
+import os
+import signal
+import subprocess
+import sys
+from pathlib import Path
 
-if [ "$1" == "--nightly" ]; then
-    configs=(rv32e rv64gc rv32gc rv32imc rv32i rv64i) 
-    derivconfigs=$(ls "$WALLY"/config/deriv)
-    for entry in $derivconfigs
-    do
-        if [[ $entry != *"syn_sram"* ]]; then  # ignore syn_sram* configs that contain undefined module
-            configs[${#configs[@]}]=$entry
-        fi
-    done
-else
-    configs=(rv32e rv64gc rv32gc rv32imc rv32i rv64i fdqh_rv64gc)
-fi
+# ANSI color codes
+RED = "\033[0;31m"
+GREEN = "\033[0;32m"
+NC = "\033[0m"  # No Color
 
-for config in ${configs[@]}; do
-#    echo "$config linting..."
-    if ! ($verilator --lint-only --quiet --top-module wallywrapper \
-         "-I$basepath/config/shared" "-I$basepath/config/$config" "-I$basepath/config/deriv/$config" \
-         $basepath/src/cvw.sv $basepath/testbench/wallywrapper.sv $basepath/src/*/*.sv $basepath/src/*/*/*.sv \
-         -Wall -Wno-UNUSEDSIGNAL -Wno-VARHIDDEN -Wno-GENUNNAMED -Wno-PINCONNECTEMPTY); then
-        if [ "$1" == "-nightly" ]; then
-            echo -e "${RED}$config failed lint${NC}"
-            fails=$((fails+1))
-        else
-            echo -e "${RED}$config fails with lint errors or warnings"
-            exit 1
-        fi
-    else
-        echo -e "${GREEN}$config passed lint${NC}"
-    fi
-done
-if [ $fails -gt 0 ]; then
-    echo -e "${RED}Linting failed for $fails of ${#configs[@]} configurations${NC}"
-    exit 1
-fi
-echo -e "${GREEN}All ${#configs[@]} lints run with no errors or warnings${NC}"
 
-# --lint-only just runs lint rather than trying to compile and simulate
-# -I points to the include directory where files such as `include config.vh  are found
+def get_configs(nightly: bool, WALLY: Path) -> list[str]:
+    """Get list of configurations to lint."""
+    # Start with base configs
+    configs = ["rv32e", "rv64gc", "rv32gc", "rv32imc", "rv32i", "rv64i"]
 
-# For more exhaustive (and sometimes spurious) warnings, add --Wall to the Verilator command
-# verilator --lint-only -Wall --quiet --top-module wallywrapper -Iconfig/shared -Iconfig/rv64gc src/cvw.sv testbench/wallywrapper.sv src/*/*.sv src/*/*/*.sv -Wno-UNUSEDPARAM -Wno-VARHIDDEN -Wno-GENUNNAMED -Wno-PINCONNECTEMPTY
-# Unfortunately, this produces a bunch of UNUSED and UNDRIVEN signal warnings in blocks that are configured to not exist.
+    if not nightly:
+        return configs + ["fdqh_rv64gc"]
+
+    # Add derivative configs, excluding syn_sram* configs that contain undefined module
+    deriv_dir = WALLY / "config" / "deriv"
+    if deriv_dir.exists():
+        for entry in deriv_dir.iterdir():
+            if entry.is_dir() and "syn_sram" not in entry.name:
+                configs.append(entry.name)
+
+    return configs
+
+
+def lint_config(WALLY: Path, config: str) -> bool:
+    """Run verilator lint on a single configuration."""
+    # Build the verilator command
+    cmd = [
+        "verilator",
+        "--lint-only",
+        "--quiet",
+        "--top-module",
+        "wallywrapper",
+        f"-I{WALLY}/config/shared",
+        f"-I{WALLY}/config/{config}",
+        f"-I{WALLY}/config/deriv/{config}",
+        f"{WALLY}/src/cvw.sv",
+        f"{WALLY}/testbench/wallywrapper.sv",
+    ]
+
+    # Add all SystemVerilog files
+    src_dir = WALLY / "src"
+    cmd.extend(str(sv_file) for sv_file in src_dir.rglob("*.sv"))
+
+    # Add warning flags
+    cmd.extend(
+        [
+            "-Wall",
+            "-Wno-UNUSEDSIGNAL",
+            "-Wno-VARHIDDEN",
+            "-Wno-GENUNNAMED",
+            "-Wno-PINCONNECTEMPTY",
+        ]
+    )
+
+    try:
+        subprocess.run(cmd, check=True)
+        return True
+    except subprocess.CalledProcessError:
+        return False
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Lint Verilog code using Verilator")
+    parser.add_argument("--nightly", action="store_true", help="Run lint on all configurations including derivatives")
+    args = parser.parse_args()
+
+    # Get WALLY environment variable
+    WALLY = os.getenv("WALLY")
+    if WALLY is None:
+        sys.exit(f"{RED}Error: WALLY environment variable is not set.{NC}")
+    WALLY = Path(WALLY)
+
+    # Get configurations to test
+    configs = get_configs(args.nightly, WALLY)
+    fails = 0
+
+    # Override signal handling for clean Ctrl+C
+    original_sigint_handler = signal.signal(signal.SIGINT, signal.SIG_IGN)
+
+    try:
+        with multiprocessing.Pool() as pool:
+            # Restore original signal handler in child processes
+            signal.signal(signal.SIGINT, original_sigint_handler)
+
+            # Run lint on each configuration in parallel
+            results = [(config, pool.apply_async(lint_config, (WALLY, config))) for config in configs]
+
+            # Process results as they complete
+            for config, result in results:
+                passed = result.get()
+                if passed:
+                    print(f"{GREEN}{config} passed lint{NC}")
+                else:
+                    print(f"{RED}{config} failed lint{NC}")
+                    if not args.nightly:
+                        pool.terminate()
+                        sys.exit(1)
+                    fails += 1
+
+    # Terminate the entire linting job on Ctrl+C
+    except KeyboardInterrupt:
+        sys.exit(1)
+
+    # Report results
+    if fails > 0:
+        print(f"{RED}Linting failed for {fails} of {len(configs)} configurations{NC}")
+        sys.exit(1)
+
+    print(f"{GREEN}All {len(configs)} lints passed{NC}")
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/nightly_build.py
+++ b/bin/nightly_build.py
@@ -704,7 +704,7 @@ def main():
     elif (args.tests == "regression"):
         test_list = [["python", "./regression-wally", []]]
     elif (args.tests == "lint"):
-        test_list = [["bash", "./lint-wally", ["--nightly"]]]
+        test_list = [["python", "./lint-wally", ["--nightly"]]]
     else:
         print(f"Error: Invalid test {args.tests} specified")
         raise SystemExit

--- a/bin/regression-wally
+++ b/bin/regression-wally
@@ -490,7 +490,7 @@ def selectTests(args, sims, coverStr):
         addTestsByDir(f"{WALLY}/tests/riscof/work/riscv-arch-test/rv64i_m/pmp", "rv64gc", coveragesim, coverStr, configs, lockstepMode=1)
         addTestsByDir(f"{WALLY}/tests/riscof/work/wally-riscv-arch-test/rv64i_m/privilege", "rv64gc", coveragesim, coverStr, configs, lockstepMode=1)
         addTestsByDir(f"{archVerifDir}/work/cvw-rv64gc/elfs", "rv64gc", coveragesim, coverStr, configs, lockstepMode=1)
-        addTestsByDir(WALLY+"/tests/coverage/", "rv64gc", coveragesim, coverStr, configs, lockstepMode=1)
+        addTestsByDir(f"{WALLY}/tests/coverage/", "rv64gc", coveragesim, coverStr, configs, lockstepMode=1)
     # run tests in lockstep in functional coverage mode
     if args.fcov or args.nightly:
         addTestsByDir(f"{archVerifDir}/work/cvw-rv32gc/elfs/rv32/I", "rv32gc", coveragesim, coverStr, configs, lockstepMode=1)
@@ -508,7 +508,7 @@ def selectTests(args, sims, coverStr):
         addTests(bpredtests, defaultsim, coverStr, configs)
     # run Breker tests (requires a license for the breker tool)
     if args.breker:
-        addTestsByDir(WALLY+"/tests/breker/work", "rv64breker", "questa", coverStr, configs, brekerMode=1)
+        addTestsByDir(f"{WALLY}/tests/breker/work", "rv64breker", "questa", coverStr, configs, brekerMode=1)
     # standard tests
     if not(args.testfloat or args.ccov or args.fcov or args.cache or args.branch or args.benchmark or args.breker):
         for sim in sims:
@@ -517,9 +517,9 @@ def selectTests(args, sims, coverStr):
             addTests(standard_tests, sim, coverStr, configs)
     # run derivative configurations and lockstep tests in nightly regression
     if args.nightly:
-        addTestsByDir(WALLY+"/tests/coverage", "rv64gc", lockstepsim, coverStr, configs, lockstepMode=1)
-        addTestsByDir(WALLY+"/tests/riscof/work/wally-riscv-arch-test/rv64i_m", "rv64gc", lockstepsim, coverStr, configs, lockstepMode=1)
-        addTestsByDir(WALLY+"/tests/riscof/work/wally-riscv-arch-test/rv32i_m", "rv32gc", lockstepsim, coverStr, configs, lockstepMode=1)
+        addTestsByDir(f"{WALLY}/tests/coverage", "rv64gc", lockstepsim, coverStr, configs, lockstepMode=1)
+        addTestsByDir(f"{WALLY}/tests/riscof/work/wally-riscv-arch-test/rv64i_m", "rv64gc", lockstepsim, coverStr, configs, lockstepMode=1)
+        addTestsByDir(f"{WALLY}/tests/riscof/work/wally-riscv-arch-test/rv32i_m", "rv32gc", lockstepsim, coverStr, configs, lockstepMode=1)
         addTests(derivconfigtests, defaultsim, coverStr, configs)
         # addTests(bpredtests, defaultsim) # This is currently broken in regression due to something related to the new wsim script.
     # testfloat tests


### PR DESCRIPTION
I had this lying around from a while ago but apparently never pushed it.

Benefits of switching to Python:
- Lint jobs are now run in parallel. `lint-wally --nightly` goes from ~6 minutes to ~1 minute.
- Control-C stops the entire linting job instead of just one config.
- The nightly flag was handled inconsistently in the previous version, sometimes looking for `--nightly` and sometimes for `-nightly`.