### PR TITLE
SKY130 install script update

### DIFF
--- a/bin/installation/skywater-lib-install.sh
+++ b/bin/installation/skywater-lib-install.sh
@@ -29,16 +29,6 @@
 
 SKYWATER_LIB_VERSION=3e7dac7af98731b59982f99df6a71e979a44bff7 # Last commit as of Nov. 5, 2025
 
-# Ensure repo always comes from NEW GitHub
-if check_tool_version $SKYWATER_LIB_VERSION; then
-    rm -rf $RISCV/cad/lib/sky130_osu_sc_t12
-    git_checkout "sky130_osu_sc_t12" "https://github.com/stineje/sky130_osu_sc_t12" "$SKYWATER_LIB_VERSION"
-    echo "$SKYWATER_LIB_VERSION" > "$RISCV"/versions/$STATUS.version
-    echo -e "${SUCCESS_COLOR}OSU Skywater library successfully installed!${ENDC}"
-else
-  rm -rf "$RISCV/cad/lib/sky130_osu_sc_t12"
-fi
-
 set -e # break on error
 # If run standalone, check environment. Otherwise, use info from main install script
 if [ -z "$FAMILY" ]; then
@@ -55,7 +45,8 @@ STATUS="osu_skywater_130_cell_library"
 mkdir -p "$RISCV"/cad/lib
 cd "$RISCV"/cad/lib
 if check_tool_version $SKYWATER_LIB_VERSION; then
-    git_checkout "sky130_osu_sc_t12" "https://github.com/stineje/sky130_osu_sc_t12.git" "$SKYWATER_LIB_VERSION"
+    rm -rf $RISCV/cad/lib/sky130_osu_sc_t12
+    git_checkout "sky130_osu_sc_t12" "https://github.com/stineje/sky130_osu_sc_t12" "$SKYWATER_LIB_VERSION"
     echo "$SKYWATER_LIB_VERSION" > "$RISCV"/versions/$STATUS.version
     echo -e "${SUCCESS_COLOR}OSU Skywater library successfully installed!${ENDC}"
 else


### PR DESCRIPTION
update SKY130 location as Google has removed from their website.  The library is still open-source and just moved to a different location.