### PR TITLE
Cleaned up spurious uninitialized RAM warning #1297

### DIFF
--- a/testbench/common/ramxdetector.sv
+++ b/testbench/common/ramxdetector.sv
@@ -32,12 +32,13 @@ module ramxdetector #(parameter XLEN, LLEN) (
   input  logic [XLEN-1:0] PCM,
   input  logic [31:0]     InstrM,
   input  logic [XLEN-1:0] IEUAdrM,
+  input  logic            StallW,
   input  string           InstrMName
 );
 
   always_ff @(posedge clk)
     /* verilator lint_off WIDTHXZEXPAND */
-    if (MemReadM & ~LSULoadAccessFaultM & (ReadDataM === 'bx)) begin
+    if (MemReadM & ~LSULoadAccessFaultM & ~StallW & (ReadDataM === 'bx)) begin
       /* verilator lint_on WIDTHXZEXPAND */
       $display("WARNING: Attempting to read from uninitialized RAM.  Processor may go haywire if it uses x value. But this is normal in WALLY-mmu and ExceptionInstr tests.");
       $display("  PCM = %x InstrM = %x (%s), IEUAdrM = %x", PCM, InstrM, InstrMName, IEUAdrM);

--- a/testbench/testbench.sv
+++ b/testbench/testbench.sv
@@ -693,7 +693,7 @@ module testbench;
   // watch for problems such as lockup, reading uninitialized memory, bad configs
   watchdog #(P.XLEN, 1000000) watchdog(.clk, .reset, .TEST);  // check if PCW is stuck
   ramxdetector #(P.XLEN, P.LLEN) ramxdetector(clk, dut.core.lsu.MemRWM[1], dut.core.lsu.LSULoadAccessFaultM, dut.core.lsu.ReadDataM,
-                                      dut.core.ifu.PCM, InstrM, dut.core.lsu.IEUAdrM, InstrMName);
+                                      dut.core.ifu.PCM, InstrM, dut.core.lsu.IEUAdrM, dut.core.lsu.StallW, InstrMName);
   riscvassertions       #(P) riscvassertions();     // check assertions for a legal architectural configuration
   riscvassertions_wally #(P) riscvassertions_wally();  // check assertions for a legal microarchitectural configuration
   loggers #(P, PrintHPMCounters, I_CACHE_ADDR_LOGGER, D_CACHE_ADDR_LOGGER, BPRED_LOGGER)


### PR DESCRIPTION
Only check uninitialized RAM when memory system is not stalled.
This fixes #1297.

Note that I am not seeing an x value warning in WALLY-mmu anymore,
even without this fix.
