### PR TITLE
Add H Interrupts

### DIFF
--- a/config/shared/config-shared.vh
+++ b/config/shared/config-shared.vh
@@ -19,6 +19,7 @@ localparam PA_BITS     = (XLEN==32 ? 32'd34 : 32'd56);
 localparam SVMODE_BITS = (XLEN==32 ? 32'd1  : 32'd4);
 localparam ASID_BASE   = (XLEN==32 ? 32'd22 : 32'd44);
 localparam ASID_BITS   = (XLEN==32 ? 32'd9  : 32'd16);
+localparam GEILEN      = H_SUPPORTED ? 32'd1 : 32'd0;
 
 // constants to check SATP_MODE against
 // defined in Table 4.3 of the privileged spec

--- a/config/shared/parameter-defs.vh
+++ b/config/shared/parameter-defs.vh
@@ -99,6 +99,7 @@ localparam cvw_t P = '{
   PLIC_UART_ID :        PLIC_UART_ID,
   PLIC_SPI_ID :        PLIC_SPI_ID,
   PLIC_SDC_ID :        PLIC_SDC_ID,
+  GEILEN :              GEILEN,
   BPRED_SUPPORTED :        BPRED_SUPPORTED,
   BPRED_TYPE :        BPRED_TYPE,
   BPRED_SIZE :        BPRED_SIZE,

--- a/src/cvw.sv
+++ b/src/cvw.sv
@@ -162,6 +162,7 @@ typedef struct packed {
   int           PLIC_UART_ID;
   int           PLIC_SPI_ID;
   int           PLIC_SDC_ID;
+  int           GEILEN;
 
   logic                BPRED_SUPPORTED;
   logic [31:0]         BPRED_TYPE;

--- a/src/privileged/csr.sv
+++ b/src/privileged/csr.sv
@@ -48,6 +48,7 @@ module csr import cvw::*;  #(parameter cvw_t P) (
   input  logic                     MExtInt, SExtInt,          // external interrupt (from PLIC)
   input  logic                     MSwInt,                    // software interrupt
   input  logic [63:0]              MTIME_CLINT,               // TIME value from CLINT
+  input  logic [P.XLEN-1:0]        HGEIPIn,                   // guest external interrupt sources
   input  logic                     InstrValidM,               // current instruction is valid
   input  logic                     FRegWriteM,                // writes to floating point registers change STATUS.FS
   input  logic [4:0]               SetFflagsM,                // Set floating point flag bits in FCSR
@@ -366,7 +367,7 @@ module csr import cvw::*;  #(parameter cvw_t P) (
     csrh #(P) csrh(.clk, .reset,
       .CSRMWriteM, .CSRSWriteM, .CSRWriteM, .CSRAdrM, .CSRWriteValM,
       .PrivilegeModeW, .VirtModeW, .FRegWriteM, .WriteFRMM, .SetOrWriteFFLAGSM,
-      .TrapGVAM, .MTIME_CLINT,
+      .TrapGVAM, .MTIME_CLINT, .HGEIPIn,
       .STATUS_TVM, .MCOUNTEREN_TM(MCOUNTEREN_REGW[1]),
       .MENVCFG_STCE(MENVCFG_REGW[63]), .MENVCFG_PBMTE(MENVCFG_REGW[62]), .MENVCFG_ADUE(MENVCFG_REGW[61]),
       .TrapToM, .TrapToHSM, .TrapToVSM, .sretM, .InstrM, .InstrOrigM,

--- a/src/privileged/csrh.sv
+++ b/src/privileged/csrh.sv
@@ -40,6 +40,7 @@ module csrh import cvw::*;  #(parameter cvw_t P) (
   input  logic              SetOrWriteFFLAGSM,// VS CSR write to FFLAGS updates vsstatus.FS
   input  logic              TrapGVAM,         // Trap writes guest virtual address to tval
   input  logic [63:0]       MTIME_CLINT,      // time source for VSTIP (vstimecmp)
+  input  logic [P.XLEN-1:0] HGEIPIn,          // guest external interrupt sources
   input  logic              STATUS_TVM,       // mstatus.TVM gate for HGATP access in HS-mode
   input  logic              MCOUNTEREN_TM,    // mcounteren.TM gate for VS timer CSR access
   input  logic              MENVCFG_STCE,     // menvcfg.STCE constrains henvcfg.STCE
@@ -144,8 +145,7 @@ module csrh import cvw::*;  #(parameter cvw_t P) (
   // HIDELEG: only VS-level interrupts (VSSIP/VSTIP/VSEIP) are writable.
   localparam [15:0] HIDELEG_MASK = 16'h0444;
   localparam [11:0] HVIP_MASK    = 12'h444; // Only VSSIP[2], VSTIP[6], VSEIP[10] are writable (spec 7.4.4)
-  // No guest-external interrupt source is wired in yet, so GEILEN is architecturally zero.
-  localparam int unsigned GEILEN = 0;
+  localparam int unsigned GEILEN = (P.GEILEN > (P.XLEN-1)) ? (P.XLEN-1) : P.GEILEN;
   // Write Enables for CSR instructions
   logic WriteMTINSTM;
   logic WriteMTVAL2M;
@@ -162,7 +162,6 @@ module csrh import cvw::*;  #(parameter cvw_t P) (
   logic WriteHIPM;
   logic WriteHTINSTM;
   logic WriteHGATPM;
-  logic WriteHGEIPM;
   logic WriteVSTVECM;
   logic WriteVSSCRATCHM;
   logic WriteVSEPCM;
@@ -191,11 +190,18 @@ module csrh import cvw::*;  #(parameter cvw_t P) (
   logic              LegalVSatpModeM;
   logic [P.XLEN-1:0] LegalizedVSatpWriteValM;
   logic [P.XLEN-1:0] HGATPReadVal;
-  logic [P.XLEN-1:0] HGEIEWriteMaskM;
+  logic [P.XLEN-1:0] HGEIMaskM;
   logic [P.XLEN-1:0] NextHGEIEM;
+  logic [5:0]        HSTATUSVGEINWriteValM;
+  logic [5:0]        LegalizedHSTATUSVGEINWriteValM;
+  localparam logic [5:0] GEILEN_LIMIT = GEILEN[5:0];
 
   // CBIE has WARL encoding; 2'b10 is reserved and is legalized to 2'b00.
   assign LegalizedHENVCFG_CBIE = (CSRWriteValM[5:4] == 2'b10) ? 2'b00 : CSRWriteValM[5:4];
+  // Hypervisor spec norm:hstatus-vgein_op: VGEIN is WLRL with legal values 0..GEILEN,
+  // and VGEIN=0 selects no guest external source. Legalize unsupported values to 0.
+  assign HSTATUSVGEINWriteValM = (P.XLEN == 32) ? {1'b0, CSRWriteValM[16:12]} : CSRWriteValM[17:12];
+  assign LegalizedHSTATUSVGEINWriteValM = (HSTATUSVGEINWriteValM <= GEILEN_LIMIT) ? HSTATUSVGEINWriteValM : 6'b0;
 
   // CSR Write Validation Intermediates
   logic LegalHAccessM;
@@ -260,9 +266,6 @@ module csrh import cvw::*;  #(parameter cvw_t P) (
   assign WriteHTINSTM     = ValidHWriteM & (CSRAdrM == HTINST);
   assign WriteHGATPM      = P.VIRTMEM_SUPPORTED & ValidHWriteM & (CSRAdrM == HGATP) &
                             ((PrivilegeModeW == P.M_MODE) | ~STATUS_TVM);
-  // HGEIP is pending-interrupt state from external interrupt fabric.
-  // Until that source is integrated, keep it read-only.
-  assign WriteHGEIPM      = 1'b0;
   assign WriteVSTVECM     = ValidVSWriteM & (CSRAdrM == VSTVEC);
   assign WriteVSSCRATCHM  = ValidVSWriteM & (CSRAdrM == VSSCRATCH);
   assign WriteVSEPCM      = ValidVSWriteM & (CSRAdrM == VSEPC);
@@ -328,13 +331,7 @@ module csrh import cvw::*;  #(parameter cvw_t P) (
       HSTATUS_SPV   <= CSRWriteValM[7];
       HSTATUS_SPVP  <= CSRWriteValM[8];
       HSTATUS_HU    <= P.U_SUPPORTED & CSRWriteValM[9];
-      // VGEIN is WARL and depends on GEILEN. With GEILEN=0 it is read-only zero.
-      if (GEILEN == 0)
-        HSTATUS_VGEIN <= 6'b0;
-      else if (P.XLEN == 32)
-        HSTATUS_VGEIN <= {1'b0, CSRWriteValM[16:12]};
-      else
-        HSTATUS_VGEIN <= CSRWriteValM[17:12];
+      HSTATUS_VGEIN <= LegalizedHSTATUSVGEINWriteValM;
       HSTATUS_VTVM  <= CSRWriteValM[20];
       HSTATUS_VTW   <= CSRWriteValM[21];
       HSTATUS_VTSR  <= CSRWriteValM[22];
@@ -475,8 +472,9 @@ module csrh import cvw::*;  #(parameter cvw_t P) (
   assign VSIP_REGW = (HIP_PENDING[11:0] & HIDELEG_REGW[11:0]) >> 1;
 
   // hgeie bits GEILEN:1 are writable; all others are read-only zero.
-  assign HGEIEWriteMaskM = {{(P.XLEN-GEILEN-1){1'b0}}, {GEILEN{1'b1}}, 1'b0};
-  assign NextHGEIEM = CSRWriteValM & HGEIEWriteMaskM;
+  assign HGEIMaskM = {{(P.XLEN-GEILEN-1){1'b0}}, {GEILEN{1'b1}}, 1'b0};
+  assign HGEIP_REGW = HGEIPIn & HGEIMaskM;
+  assign NextHGEIEM = CSRWriteValM & HGEIMaskM;
   flopenr #(P.XLEN) HGEIEreg(clk, reset, WriteHGEIEM, NextHGEIEM, HGEIE_REGW);
 
   // HTVAL: Written by CSR instructions and by hardware on traps
@@ -631,10 +629,6 @@ module csrh import cvw::*;  #(parameter cvw_t P) (
     flopenr #(P.XLEN) HTIMEDELTAreg(clk, reset, WriteHTIMEDELTAM, CSRWriteValM, HTIMEDELTA_REGW[31:0]);
     flopenr #(P.XLEN) HTIMEDELTAHreg(clk, reset, WriteHTIMEDELTAHM, CSRWriteValM, HTIMEDELTA_REGW[63:32]);
   end
-  // HGEIP is sourced by platform interrupt logic; keep zero until that path is integrated.
-  flopenr #(P.XLEN) HGEIPreg(clk, reset, WriteHGEIPM, '0, HGEIP_REGW);
-
-
   // CSR Read and Illegal Access Logic
   always_comb begin : csrrh
     CSRHReadValM = '0;

--- a/src/privileged/csri.sv
+++ b/src/privileged/csri.sv
@@ -87,7 +87,7 @@ module csri import cvw::*;  #(parameter cvw_t P) (
   // mie owns all implemented enable state.  hie and vsie are aliases that
   // update/view the H-added bits in mie, matching the existing sie aliasing.
   if (P.H_SUPPORTED) begin : mie_h
-    assign HIE_WRITE_MASK = 16'h0444;
+    assign HIE_WRITE_MASK = 16'h0444 | ((P.GEILEN > 0) ? 16'h1000 : 16'h0000);
     assign WriteMIEMasked = WriteMIEM | WriteSIEM | WriteHIEM | WriteVSIEM;
     always_comb begin
       NextMIE_REGW = MIE_REGW;
@@ -120,8 +120,8 @@ module csri import cvw::*;  #(parameter cvw_t P) (
 
   assign HIE_REGW = MIE_REGW & HIE_WRITE_MASK;
 
-  // Bits 13:12 are present for future LCOFI/SGEI support; they remain zero
-  // until the corresponding interrupt sources are implemented.
+  // Bit 12 aliases SGEIP when guest external interrupts are implemented.
+  // Bit 13 is present for future LCOFI support and remains zero.
   if (P.H_SUPPORTED) begin : mip_h
     assign MIP_REGW = {3'b0,      HIP_MIP_REGW[12],
                        MExtInt,   HIP_MIP_REGW[10], SExtInt|MIP_REGW_writeable[9],  1'b0,

--- a/src/privileged/csrm.sv
+++ b/src/privileged/csrm.sv
@@ -110,7 +110,7 @@ module csrm  import cvw::*;  #(parameter cvw_t P) (
   localparam [63:0] MEDELEG_MASK = (P.ZCA_SUPPORTED ? 64'h0000_0000_0000_B3FE : 64'h0000_0000_0000_B3FF) |
                                    (P.H_SUPPORTED ? 64'h0000_0000_0040_0400 : 64'h0000_0000_0000_0000);
   localparam [15:0] MIDELEG_MASK = 16'h0222; // only standard S-level interrupt delegation bits are writable
-  localparam [15:0] MIDELEG_RO1  = P.H_SUPPORTED ? 16'h0444 : 16'h0000; // VS-level interrupts are always delegated past M
+  localparam [15:0] MIDELEG_RO1  = P.H_SUPPORTED ? (16'h0444 | ((P.GEILEN > 0) ? 16'h1000 : 16'h0000)) : 16'h0000; // VS-level and guest external interrupts are always delegated past M
   localparam Gm1 = P.PMP_G > 0 ? P.PMP_G - 1 : 0; // max(G-1, 0)
 
  // There are PMP_ENTRIES = 0, 16, or 64 PMPADDR registers, each of which has its own flop

--- a/src/privileged/privileged.sv
+++ b/src/privileged/privileged.sv
@@ -75,6 +75,7 @@ module privileged import cvw::*;  #(parameter cvw_t P) (
   input  logic              IllegalIEUFPUInstrD,                            // illegal instruction from IEU or FPU
   input  logic              MTimerInt, MExtInt, SExtInt, MSwInt,            // interrupt sources
   input  logic [63:0]       MTIME_CLINT,                                    // timer value from CLINT
+  input  logic [P.XLEN-1:0] HGEIPIn,                                        // guest external interrupt sources
   input  logic [4:0]        SetFflagsM,                                     // set FCSR flags from FPU
   input  logic              SelHPTW,                                        // HPTW in use.  Causes system to use S-mode endianness for accesses
   // CSR outputs
@@ -155,7 +156,7 @@ module privileged import cvw::*;  #(parameter cvw_t P) (
     .InstrM, .InstrOrigM, .PCM, .PCSpillM, .SrcAM, .IEUAdrxTvalM,
     .CSRReadM, .CSRWriteM, .TrapM, .TrapToM, .TrapToHSM, .TrapToVSM, .mretM, .sretM, .InterruptM,
     .MTimerInt, .MExtInt, .SExtInt, .MSwInt,
-    .MTIME_CLINT, .InstrValidM, .FRegWriteM, .LoadStallD, .StoreStallD,
+    .MTIME_CLINT, .HGEIPIn, .InstrValidM, .FRegWriteM, .LoadStallD, .StoreStallD,
     .BPDirWrongM, .BTAWrongM, .RASPredPCWrongM, .BPWrongM,
     .sfencevmaM, .ExceptionM, .InvalidateICacheM, .ICacheStallF, .DCacheStallM, .DivBusyE, .FDivBusyE,
     .IClassWrongM, .IClassM, .DCacheMiss, .DCacheAccess, .ICacheMiss, .ICacheAccess,

--- a/src/privileged/trap.sv
+++ b/src/privileged/trap.sv
@@ -57,7 +57,7 @@ module trap import cvw::*;  #(parameter cvw_t P) (
   logic                        BothInstrAccessFaultM, BothInstrPageFaultM;      // instruction or HPTW ITLB fill caused an Instruction Access Fault
   logic [15:0]                 PendingIntsM, ValidIntsM, EnabledIntsM;          // interrupts are pending, valid, or enabled
   logic [15:0]                 MEnabledIntsM, HSEnabledIntsM, VSEnabledIntsM;   // interrupt sets by target mode
-  // TODO: Add cause priority for SGEI/LCOFI when those interrupt sources are implemented.
+  // TODO: Add cause priority for LCOFI when that interrupt source is implemented.
   logic                        DelegateToVSM;                                  // trap delegated from HS to VS
   logic [5:0]                  CauseIdxM;                                      // cause index for 64-bit delegation CSRs
   logic                        HidelegHitM, HedelegHitM;
@@ -165,6 +165,7 @@ module trap import cvw::*;  #(parameter cvw_t P) (
     else if (ValidIntsM[9])                                   CauseM = 5'd9;  // Supervisor External Int
     else if (ValidIntsM[1])                                   CauseM = 5'd1;  // Supervisor Sw Int
     else if (ValidIntsM[5])                                   CauseM = 5'd5;  // Supervisor Timer Int
+    else if (P.H_SUPPORTED & ValidIntsM[12])                  CauseM = 5'd12; // Supervisor Guest External Int
     else if (P.H_SUPPORTED & ValidIntsM[10])                  CauseM = 5'd10; // Virtual Supervisor External Int
     else if (P.H_SUPPORTED & ValidIntsM[2])                   CauseM = 5'd2;  // Virtual Supervisor Software Int
     else if (P.H_SUPPORTED & ValidIntsM[6])                   CauseM = 5'd6;  // Virtual Supervisor Timer Int

--- a/src/uncore/trickbox_apb.sv
+++ b/src/uncore/trickbox_apb.sv
@@ -59,32 +59,40 @@ module trickbox_apb import cvw::*;  #(parameter XLEN = 64, NUM_HARTS = 1) (
   logic [XLEN-1:0]            TOHOST;
   logic [XLEN-1:0]            HGEIP[NUM_HARTS-1:0];
   logic [15:0]                entry;
-  logic [9:0]                 hart;                   // which hart is being accessed
+  logic [9:0]                 hartaddr;               // which hart is being accessed
+  logic                       HartValid;
   logic                       memwrite;
   logic [63:0]                RD;
+  logic [63:0]                PWDATA64;
   genvar                      i;
+  localparam HartIndexBits = NUM_HARTS > 1 ? $clog2(NUM_HARTS) : 1;
+  logic [HartIndexBits-1:0]   hart;
 
   assign memwrite = PWRITE & PENABLE & PSEL;  // only write in access phase
   assign PREADY   = 1'b1;                     // CLINT never takes >1 cycle to respond
-  assign hart = PADDR[12:3];                  // middle bits of address allow control of up to 1024 harts
+  assign hartaddr = PADDR[12:3];              // middle bits of address allow control of up to 1024 harts
+  assign hart = hartaddr[HartIndexBits-1:0];
+  assign HartValid = hartaddr < NUM_HARTS;
+  assign PWDATA64 = {{(64-XLEN){1'b0}}, PWDATA};
 
   // read circuitry
   // 64-bit accesses, then reduce to 32-bit for RV32
   always_ff @(posedge PCLK) begin
+    RD <= '0;
     case (PADDR[15:13])
-      3'b000: RD <= {63'b0, MSIP[hart]};     // *** memory map
-      3'b001: RD <= {63'b0, SSIP[hart]};
-      3'b010: RD <= MTIMECMP[hart];
-      3'b011: RD <= {63'b0, MEIP[hart]};
-      3'b100: RD <= {63'b0, SEIP[hart]};
-      3'b101: case (hart)
-        10'b0000000000: RD <= TOHOST;
+      3'b000: if (HartValid) RD <= {63'b0, MSIP[hart]};     // *** memory map
+      3'b001: if (HartValid) RD <= {63'b0, SSIP[hart]};
+      3'b010: if (HartValid) RD <= MTIMECMP[hart];
+      3'b011: if (HartValid) RD <= {63'b0, MEIP[hart]};
+      3'b100: if (HartValid) RD <= {63'b0, SEIP[hart]};
+      3'b101: case (hartaddr)
+        10'b0000000000: RD <= {{(64-XLEN){1'b0}}, TOHOST};
         10'b0000000001: RD <= '0; // Reading COM1 has no effect; busy bit not yet implemented.  Later add busy bit
         10'b0000000010: RD <= {56'b0, TRICKEN};
         10'b1111111111: RD <= MTIME;
         default: RD <= '0;
       endcase
-      3'b110: RD <= HGEIP[hart];
+      3'b110: if (HartValid) RD <= {{(64-XLEN){1'b0}}, HGEIP[hart]};
       default: RD <= '0;
     endcase
   end
@@ -104,15 +112,17 @@ module trickbox_apb import cvw::*;  #(parameter XLEN = 64, NUM_HARTS = 1) (
       TRICKEN <= '0;
     end else if (memwrite) begin
       case (PADDR[15:13])
-        3'b000: MSIP[hart] <= PWDATA[0];
-        3'b001: SSIP[hart] <= PWDATA[0];
-        3'b011: MEIP[hart] <= PWDATA[0];
-        3'b100: SEIP[hart] <= PWDATA[0];
-        3'b101: case (hart)
+        3'b000: if (HartValid) MSIP[hart] <= PWDATA[0];
+        3'b001: if (HartValid) SSIP[hart] <= PWDATA[0];
+        3'b011: if (HartValid) MEIP[hart] <= PWDATA[0];
+        3'b100: if (HartValid) SEIP[hart] <= PWDATA[0];
+        3'b101: case (hartaddr)
           10'b0000000000: TOHOST <= PWDATA;
           10'b0000000001: $display("%c", PWDATA[7:0]); // COM1 prints to simulation console.  Eventually allow it to be redirected to a UART, and provide a busy bit.
           10'b0000000010: TRICKEN <= PWDATA[7:0];
+          default: ;
         endcase
+        default: ;
       endcase
     end
     // generate loop write circuits for MTIMECMP and HGEIP
@@ -121,12 +131,12 @@ module trickbox_apb import cvw::*;  #(parameter XLEN = 64, NUM_HARTS = 1) (
         if (~PRESETn) begin
           MTIMECMP[i] <= 64'hFFFFFFFFFFFFFFFF; // Spec says MTIMECMP is not reset, but we reset to maximum value to prevent spurious timer interrupts
           HGEIP[i] <= 0;
-        end else if (memwrite & (hart == i)) begin
+        end else if (memwrite & (hartaddr == i)) begin
           if (PADDR[15:13] == 3'b010) begin
-            if (XLEN == 64) MTIMECMP[hart] <= PWDATA; // 64-bit write
-            else            MTIMECMP[hart][PADDR[2]*32 +: 32] <= PWDATA; // 32-bit write
+            if (XLEN == 64) MTIMECMP[i] <= PWDATA64; // 64-bit write
+            else            MTIMECMP[i][PADDR[2]*32 +: 32] <= PWDATA[31:0]; // 32-bit write
           end else if (PADDR[15:13] == 3'b110) begin
-            HGEIP[hart] <= PWDATA;
+            HGEIP[i] <= PWDATA;
           end
         end
 
@@ -134,9 +144,9 @@ module trickbox_apb import cvw::*;  #(parameter XLEN = 64, NUM_HARTS = 1) (
   always_ff @(posedge PCLK)
     if (~PRESETn) begin
       MTIME <= '0;
-    end else if (memwrite & (PADDR[15:13] == 3'b101 && hart == 10'b1111111111)) begin
-      if (XLEN == 64) MTIME <= PWDATA; // 64-bit write
-      else            MTIME <= MTIME[PADDR[2]*32 +: 32]; // 32-bit write
+    end else if (memwrite & (PADDR[15:13] == 3'b101 && hartaddr == 10'b1111111111)) begin
+      if (XLEN == 64) MTIME <= PWDATA64; // 64-bit write
+      else            MTIME[PADDR[2]*32 +: 32] <= PWDATA[31:0]; // 32-bit write
     end else          MTIME <= MTIME + 1;
 
   // timer interrupt when MTIME >= MTIMECMP (unsigned)

--- a/src/uncore/uncore.sv
+++ b/src/uncore/uncore.sv
@@ -49,6 +49,7 @@ module uncore import cvw::*;  #(parameter cvw_t P)(
   // peripheral pins
   output logic                 MTimerInt, MSwInt,         // Timer and software interrupts from CLINT
   output logic                 MExtInt, SExtInt,          // External interrupts from PLIC
+  output logic [P.XLEN-1:0]    HGEIPIn,                   // Guest external interrupts
   output logic [63:0]          MTIME_CLINT,               // MTIME, from CLINT
   input  logic [31:0]          GPIOIN,                    // GPIO pin input value
   output logic [31:0]          GPIOOUT, GPIOEN,           // GPIO pin output value and enable
@@ -135,6 +136,24 @@ module uncore import cvw::*;  #(parameter cvw_t P)(
   end else begin : plic
     assign MExtInt = 1'b0;
     assign SExtInt = 1'b0;
+  end
+
+  if (P.H_SUPPORTED) begin : trickbox
+    logic [P.XLEN-1:0] HGEIPInTB[0:0], HGEIPOutTB[0:0];
+
+    assign HGEIPInTB[0] = '0;
+
+    // The TrickBox provides a local guest-external interrupt source for tests
+    // and future interrupt-controller integration.  Architectural hgeip/hgeie
+    // masking is handled in CSRs.
+    trickbox_apb #(.XLEN(P.XLEN), .NUM_HARTS(1)) trickbox(
+      .PCLK, .PRESETn, .PSEL(PSEL[1]), .PADDR(PADDR[15:0]), .PWDATA, .PSTRB, .PWRITE, .PENABLE,
+      .PRDATA(), .PREADY(), .MTIME_IN(MTIME_CLINT), .MTIP_IN(MTimerInt), .MSIP_IN(MSwInt), .SSIP_IN(1'b0),
+      .MEIP_IN(MExtInt), .SEIP_IN(SExtInt), .HGEIP_IN(HGEIPInTB), .MTIME_OUT(), .MTIP_OUT(), .MSIP_OUT(),
+      .SSIP_OUT(), .MEIP_OUT(), .SEIP_OUT(), .HGEIP_OUT(HGEIPOutTB), .TOHOST_OUT());
+    assign HGEIPIn = HGEIPOutTB[0];
+  end else begin : trickbox
+    assign HGEIPIn = '0;
   end
 
   if (P.GPIO_SUPPORTED == 1) begin : gpio

--- a/src/wally/wallypipelinedcore.sv
+++ b/src/wally/wallypipelinedcore.sv
@@ -32,6 +32,7 @@ module wallypipelinedcore import cvw::*; #(parameter cvw_t P) (
    // Privileged
    input  logic                  MTimerInt, MExtInt, SExtInt, MSwInt,
    input  logic [63:0]           MTIME_CLINT,
+   input  logic [P.XLEN-1:0]     HGEIPIn,
    // Bus Interface
    input  logic [P.AHBW-1:0]     HRDATA,
    input  logic                  HREADY, HRESP,
@@ -302,7 +303,7 @@ module wallypipelinedcore import cvw::*; #(parameter cvw_t P) (
       .InstrMisalignedFaultM, .IllegalIEUFPUInstrD,
       .LoadMisalignedFaultM, .StoreAmoMisalignedFaultM,
       .MTimerInt, .MExtInt, .SExtInt, .MSwInt,
-      .MTIME_CLINT, .IEUAdrxTvalM, .SetFflagsM,
+      .MTIME_CLINT, .HGEIPIn, .IEUAdrxTvalM, .SetFflagsM,
       .InstrAccessFaultF, .HPTWInstrAccessFaultF, .HPTWInstrPageFaultF, .LoadAccessFaultM, .StoreAmoAccessFaultM, .SelHPTW,
       .PrivilegeModeW, .SATP_REGW,
       .STATUS_MXR, .STATUS_SUM, .STATUS_MPRV, .STATUS_MPP, .STATUS_FS,

--- a/src/wally/wallypipelinedsoc.sv
+++ b/src/wally/wallypipelinedsoc.sv
@@ -72,13 +72,14 @@ module wallypipelinedsoc import cvw::*; #(parameter cvw_t P)  (
   logic                       MTimerInt, MSwInt;// timer and software interrupts from CLINT
   logic [63:0]                MTIME_CLINT;      // from CLINT to CSRs
   logic                       MExtInt,SExtInt;  // from PLIC
+  logic [P.XLEN-1:0]          HGEIPIn;          // guest external interrupts
 
   // synchronize reset to SOC clock domain
   synchronizer resetsync(.clk, .d(reset_ext), .q(reset));
 
   // instantiate processor and internal memories
   wallypipelinedcore #(P) core(.clk, .reset,
-    .MTimerInt, .MExtInt, .SExtInt, .MSwInt, .MTIME_CLINT,
+    .MTimerInt, .MExtInt, .SExtInt, .MSwInt, .MTIME_CLINT, .HGEIPIn,
     .HRDATA, .HREADY, .HRESP, .HCLK, .HRESETn, .HADDR, .HWDATA, .HWSTRB,
     .HWRITE, .HSIZE, .HBURST, .HPROT, .HTRANS, .HMASTLOCK, .ExternalStall
    );
@@ -88,11 +89,11 @@ module wallypipelinedsoc import cvw::*; #(parameter cvw_t P)  (
     uncore #(P) uncore(.HCLK, .HRESETn, .TIMECLK,
       .HADDR, .HWDATA, .HWSTRB, .HWRITE, .HSIZE, .HBURST, .HPROT, .HTRANS, .HMASTLOCK, .HRDATAEXT,
       .HREADYEXT, .HRESPEXT, .HRDATA, .HREADY, .HRESP, .HSELEXT,
-      .MTimerInt, .MSwInt, .MExtInt, .SExtInt, .GPIOIN, .GPIOOUT, .GPIOEN, .UARTSin,
+      .MTimerInt, .MSwInt, .MExtInt, .SExtInt, .HGEIPIn, .GPIOIN, .GPIOOUT, .GPIOEN, .UARTSin,
       .UARTSout, .MTIME_CLINT, .SPIIn, .SPIOut, .SPICS, .SPICLK, .SDCIn, .SDCCmd, .SDCCS, .SDCCLK);
   end else begin
     assign {HRDATA, HREADY, HRESP, HSELEXT, MTimerInt, MSwInt, MExtInt, SExtInt,
-            MTIME_CLINT, GPIOOUT, GPIOEN, UARTSout, SPIOut, SPICS, SPICLK, SDCCmd, SDCCS, SDCCLK} = '0;
+            MTIME_CLINT, HGEIPIn, GPIOOUT, GPIOEN, UARTSout, SPIOut, SPICS, SPICLK, SDCCmd, SDCCS, SDCCLK} = '0;
   end
 
 

--- a/testbench/testbench.sv
+++ b/testbench/testbench.sv
@@ -912,6 +912,11 @@ end
     if (P.S_SUPPORTED) begin
       void'(rvviRefCsrSetVolatile(0, 32'h144));   // SIP
     end
+    if (P.H_SUPPORTED) begin
+      void'(rvviRefCsrSetVolatile(0, 32'h244));   // VSIP
+      void'(rvviRefCsrSetVolatile(0, 32'h644));   // HIP
+      void'(rvviRefCsrSetVolatile(0, 32'hE12));   // HGEIP
+    end
 
     // Privileges for PMA are set in the imperas.ic
     // volatile (IO) regions are defined here
@@ -947,6 +952,10 @@ end
       // See Fixed https://github.com/openhwgroup/cvw-arch-verif/issues/670
       //always @(dut.core.priv.priv.csr.csri.MIP_REGW[1])   void'(rvvi.net_push("SSWInterrupt",       dut.core.priv.priv.csr.csri.MIP_REGW[1]));
       always @(dut.core.priv.priv.trap.ValidIntsM[1])   void'(rvvi.net_push("SSWInterrupt",       dut.core.priv.priv.trap.ValidIntsM[1])); // dh 6/29/25 temporarily use ValidInts until Synopsys fixes level sensitive  https://github.com/openhwgroup/cvw-arch-verif/issues/670
+    end
+    if (P.H_SUPPORTED & (P.GEILEN > 0)) begin
+      always @(dut.HGEIPIn[1])
+        void'(rvvi.net_push("GuestExternalInterrupt1", dut.HGEIPIn[1]));
     end
   end
 

--- a/tests/coverage/README.md
+++ b/tests/coverage/README.md
@@ -10,11 +10,12 @@ This is not a full H-extension architectural compliance test. In particular, it 
 
 - Hypervisor CSR read/write and WARL behavior from M-mode:
   - `mtinst`, `mtval2`
-  - `hstatus`, `hedeleg`, `hideleg`, `hcounteren`, `hgeie`
+  - `hstatus`, `hedeleg`, `mideleg`, `hideleg`, `hcounteren`, `hgeie`
   - `htval`, `htinst`, `hgatp`
   - `vsstatus`, `vstvec`, `vsscratch`, `vsepc`, `vscause`, `vstval`, `vsatp`
 
 - Hypervisor interrupt CSR aliasing:
+  - GEILEN=1 behavior for `hstatus.VGEIN`, `hgeie`, and `mideleg`.SGEI
   - `hie` writes reflected in `mie`
   - `vsie` writes reflected through delegated `hie`/`mie` bits
   - `hip`, `hvip`, and `vsip` delegated virtual interrupt aliases
@@ -25,11 +26,12 @@ This is not a full H-extension architectural compliance test. In particular, it 
   - `htimedelta`
 
 - Read-only / illegal CSR behavior:
-  - `hgeip` write attempts trap as illegal and read back as zero
+  - `hgeip` write attempts trap as illegal; pending state is driven by the test MMIO source
 
 - HS-mode execution test:
   - enters HS using the shared `WALLY-init-lib.h` ecall privilege-change helper
   - executes `hfence.gvma x0, x0` in HS
+  - drives guest external interrupt 1 through the local TrickBox HGEIP source and checks HS-level SGEI delivery
   - returns to M-mode and verifies a marker register to confirm the HS block ran
 
 - Hypervisor privileged instruction decode:
@@ -76,7 +78,8 @@ make deriv
 Then create the local Imperas config if needed. Copy and paste the contents of `config/rv64gc/imperas.ic` into `config/deriv/rv64gch/imperas.ic`, then make these edits:
 
 1. Change the variant line from `--variant RV64GCK` to `--variant RV64GCH`.
-2. Remove the crypto override block, because this target is `GCH`, not `GCK`:
+2. Add `--override cpu/GEILEN=1`.
+3. Remove the crypto override block, because this target is `GCH`, not `GCK`:
 
 ```text
 # Crypto extensions
@@ -93,7 +96,7 @@ mkdir -p config/deriv/rv64gch
 touch config/deriv/rv64gch/imperas.ic
 ```
 
-Then paste in the contents from `config/rv64gc/imperas.ic` and make the two edits above.
+Then paste in the contents from `config/rv64gc/imperas.ic` and make the edits above.
 
 From the repository root:
 
@@ -111,6 +114,10 @@ Mismatches            : 0
 
 The test should write `tohost = 1`, then stop at the normal coverage-test self loop / testbench stop point.
 
+If a self-check fails, the test writes `tohost = 3` with a store word so the testbench terminates instead of repeatedly writing `tohost`.
+
+The guest-external interrupt check uses the CLINT-range TrickBox sidecar: `TRICKEN[6]` is written at `0x0200A010`, then HGEIP bit 1 is driven through the slot at `0x0200C000`.
+
 In `--lockstepverbose` output, the HS-mode test can be identified by the instruction trace around `hs_mode_entry`, where Imperas prints the privilege label as `Supervisor`:
 
 ```text
@@ -119,6 +126,33 @@ In `--lockstepverbose` output, the HS-mode test can be identified by the instruc
 ```
 
 In this test context, `Supervisor` with virtualization mode `V=0` corresponds to HS-mode.
+
+## Hypervisor Interrupt Tests
+
+`hypervisorInterrupts.S` is a focused companion test for implemented H-extension interrupt behavior. It currently covers:
+
+- `GEILEN=1` interrupt-visible CSR behavior for `hstatus.VGEIN`, `hgeie`, and read-only-one `mideleg`.SGEI
+- `hie` / `mie` aliasing for SGEIE and VS interrupt-enable bits
+- `vsie` delegated interrupt-enable aliasing
+- `hip`, `hvip`, and `vsip` delegated virtual interrupt-pending aliases
+- read-only `hgeip` CSR behavior
+- HS-mode delivery of software-injected VSSI, VSTI, and VSEI through `hvip`
+- HS-mode supervisor guest external interrupt delivery through the local TrickBox HGEIP source
+
+Build it from the repository root with:
+
+```sh
+source ./setup.sh
+make -C tests/coverage hypervisorInterrupts.elf hypervisorInterrupts.elf.objdump
+```
+
+Run it with ImperasDV lockstep using the same `rv64gch` setup described above:
+
+```sh
+wsim rv64gch --elf tests/coverage/hypervisorInterrupts.elf --lockstepverbose > hypervisorInterrupts.log 2>&1
+```
+
+The same local ImperasDV `GEILEN=1` override and HGEIP TrickBox addresses described for `hypervisorUnitTests.S` apply to this test.
 
 ## Hypervisor Exception Tests
 

--- a/tests/coverage/hypervisorExceptions.S
+++ b/tests/coverage/hypervisorExceptions.S
@@ -215,7 +215,7 @@ vs_exception_entry:
 fail:
     la t1, tohost
     li t0, 3
-    sd t0, 0(t1)
+    sw t0, 0(t1)
 fail_loop:
     j fail_loop
 

--- a/tests/coverage/hypervisorInterrupts.S
+++ b/tests/coverage/hypervisorInterrupts.S
@@ -1,0 +1,223 @@
+///////////////////////////////////////////
+// hypervisorInterrupts.S
+//
+// Written: Neil Chulani nchulani@g.hmc.edu 03 May 2026
+//
+// Purpose: Unit tests for implemented hypervisor interrupt behavior.
+//
+// A component of the CORE-V-WALLY configurable RISC-V project.
+//
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+////////////////////////////////////////////////////////////////////////////////////////////////
+
+// load code to initialize stack, handle interrupts, terminate
+#include "WALLY-init-lib.h"
+
+.equ CSR_HSTATUS,    0x600
+.equ CSR_HIDELEG,    0x603
+.equ CSR_HIE,        0x604
+.equ CSR_HGEIE,      0x607
+.equ CSR_HIP,        0x644
+.equ CSR_HVIP,       0x645
+.equ CSR_HGEIP,      0xE12
+.equ CSR_VSIE,       0x204
+.equ CSR_VSIP,       0x244
+.equ CSR_MEDELEG,    0x302
+.equ CSR_MIDELEG,    0x303
+.equ CSR_MIE,        0x304
+.equ CSR_SSTATUS,    0x100
+.equ CSR_SEPC,       0x141
+.equ CSR_SCAUSE,     0x142
+.equ CSR_MCAUSE,     0x342
+
+.equ MIE_BASE,       0x0000000000000080
+.equ HSTATUS_BASE,   0x0000000200000000
+.equ HSTATUS_VGEIN1, 0x0000000200001000
+.equ MIDELEG_RO1,    0x0000000000001444
+.equ HIDELEG_MASK,   0x0000000000000444
+.equ HGEIE_MASK,     0x0000000000000002
+.equ HIE_MASK,       0x0000000000001444
+.equ HIE_SGEIE_MASK, 0x0000000000001000
+.equ HIE_VS_MASK,    0x0000000000000444
+.equ VSIE_MASK,      0x0000000000000222
+.equ MIE_AFTER_HIE,  0x14C4
+.equ MIE_AFTER_VSIE, 0x4C4
+.equ HVIP_VSSIP_MASK,0x0000000000000004
+.equ HVIP_VSTIP_MASK,0x0000000000000040
+.equ HVIP_VSEIP_MASK,0x0000000000000400
+.equ HS_MARKER,      0x13579BDF2468ACE0
+.equ CAUSE_ILLEGAL,  2
+.equ CAUSE_VSSI,     0x8000000000000002
+.equ CAUSE_VSTI,     0x8000000000000006
+.equ CAUSE_VSEI,     0x800000000000000A
+.equ CAUSE_SGEI,     0x800000000000000C
+.equ SSTATUS_SIE,    0x2
+.equ HGEIP0_ADDR,    0x0200C000
+.equ TRICKEN_ADDR,   0x0200A010
+.equ TRICKEN_HGEIP,  0x40
+
+.macro CHECK_CSR_RW csr, write_val, expect_val
+    li t0, \write_val
+    csrw \csr, t0
+    csrr t1, \csr
+    li t2, \expect_val
+    bne t1, t2, fail
+.endm
+
+.macro CHECK_CSR_READ csr, expect_val
+    csrr t1, \csr
+    li t2, \expect_val
+    bne t1, t2, fail
+.endm
+
+.macro CHECK_ILLEGAL_CSR_WRITE csr, write_val, expect_val
+    csrw CSR_MCAUSE, zero
+    li t0, \write_val
+    csrw \csr, t0
+    csrr t1, CSR_MCAUSE
+    li t2, CAUSE_ILLEGAL
+    bne t1, t2, fail
+    csrr t1, \csr
+    li t2, \expect_val
+    bne t1, t2, fail
+.endm
+
+.macro TRIGGER_HVIP_INTERRUPT expect_cause, pending_mask, return_label
+    la t0, hvip_handler
+    csrw stvec, t0
+    li s1, \expect_cause
+    li s2, \pending_mask
+    la s3, \return_label
+    csrw CSR_HVIP, zero
+    li t0, \pending_mask
+    csrw CSR_HIE, t0
+    csrsi CSR_SSTATUS, SSTATUS_SIE
+    csrw CSR_HVIP, t0
+    j fail
+.endm
+
+main:
+    # GEILEN=1 should make VGEIN=1 legal, expose hgeie[1], and make the
+    # supervisor guest external interrupt cause read-only delegated past M.
+    CHECK_CSR_RW CSR_HSTATUS, 0x1000, HSTATUS_VGEIN1
+    CHECK_CSR_RW CSR_HSTATUS, 0, HSTATUS_BASE
+    CHECK_CSR_RW CSR_MIDELEG, 0, MIDELEG_RO1
+    CHECK_CSR_RW CSR_HIDELEG, -1, HIDELEG_MASK
+    CHECK_CSR_RW CSR_HGEIE, -1, HGEIE_MASK
+
+    # H interrupt enables are stored in mie and exposed through hie.
+    CHECK_CSR_RW CSR_HIE, -1, HIE_MASK
+    CHECK_CSR_READ CSR_MIE, MIE_AFTER_HIE
+
+    # VSIE writes alias into the delegated virtual interrupt-enable bits only.
+    CHECK_CSR_RW CSR_HIE, 0, 0
+    CHECK_CSR_READ CSR_MIE, MIE_BASE
+    CHECK_CSR_RW CSR_VSIE, -1, VSIE_MASK
+    CHECK_CSR_READ CSR_HIE, HIE_VS_MASK
+    CHECK_CSR_READ CSR_MIE, MIE_AFTER_VSIE
+
+    # HIP/HVIP/VSIP expose delegated virtual interrupt-pending aliases.
+    CHECK_CSR_RW CSR_HVIP, 0, 0
+    CHECK_CSR_RW CSR_HIP, -1, 0x4
+    CHECK_CSR_READ CSR_HVIP, 0x4
+    CHECK_CSR_READ CSR_VSIP, 0x2
+    CHECK_CSR_RW CSR_HVIP, -1, HIDELEG_MASK
+    CHECK_CSR_READ CSR_HIP, HIDELEG_MASK
+    CHECK_CSR_READ CSR_VSIP, VSIE_MASK
+    CHECK_CSR_RW CSR_HVIP, 0, 0
+    CHECK_CSR_RW CSR_VSIP, -1, 0x2
+    CHECK_CSR_READ CSR_HIP, 0x4
+    CHECK_CSR_READ CSR_HVIP, 0x4
+    CHECK_CSR_RW CSR_HVIP, 0, 0
+
+    # HGEIP is source-driven and read-only from the CSR path.
+    CHECK_ILLEGAL_CSR_WRITE CSR_HGEIP, -1, 0
+
+    # Enter HS through the shared ecall helper, then drive guest external
+    # interrupt sources through hvip and the local TrickBox HGEIP source.
+    csrw CSR_HIDELEG, zero
+    li a0, 1
+    ecall
+
+hs_mode_entry:
+    li s0, HS_MARKER
+
+    TRIGGER_HVIP_INTERRUPT CAUSE_VSSI, HVIP_VSSIP_MASK, vssi_done
+vssi_done:
+    TRIGGER_HVIP_INTERRUPT CAUSE_VSTI, HVIP_VSTIP_MASK, vsti_done
+vsti_done:
+    TRIGGER_HVIP_INTERRUPT CAUSE_VSEI, HVIP_VSEIP_MASK, vsei_done
+vsei_done:
+
+    la t0, sgei_handler
+    csrw stvec, t0
+    li t0, TRICKEN_ADDR
+    li t1, TRICKEN_HGEIP
+    sd t1, 0(t0)
+    li t0, HGEIP0_ADDR
+    sd zero, 0(t0)
+    li t0, HGEIE_MASK
+    csrw CSR_HGEIE, t0
+    li t0, HIE_SGEIE_MASK
+    csrw CSR_HIE, t0
+    csrsi CSR_SSTATUS, SSTATUS_SIE
+    li t0, HGEIP0_ADDR
+    li t1, HGEIE_MASK
+    sd t1, 0(t0)
+    j fail
+
+.align 4
+sgei_handler:
+    csrr t1, CSR_SCAUSE
+    li t2, CAUSE_SGEI
+    bne t1, t2, fail
+    csrr t1, CSR_HGEIP
+    li t2, HGEIE_MASK
+    bne t1, t2, fail
+    csrr t1, CSR_HIP
+    li t2, HIE_SGEIE_MASK
+    bne t1, t2, fail
+    li t0, HGEIP0_ADDR
+    sd zero, 0(t0)
+    li t0, TRICKEN_ADDR
+    sd zero, 0(t0)
+    csrw CSR_HIE, zero
+    csrw CSR_HGEIE, zero
+    csrci CSR_SSTATUS, SSTATUS_SIE
+    la t0, sgei_done
+    csrw CSR_SEPC, t0
+    sret
+
+.align 4
+hvip_handler:
+    csrr t1, CSR_SCAUSE
+    bne t1, s1, fail
+    csrr t1, CSR_HVIP
+    bne t1, s2, fail
+    csrr t1, CSR_HIP
+    bne t1, s2, fail
+    csrw CSR_HVIP, zero
+    csrw CSR_HIE, zero
+    csrci CSR_SSTATUS, SSTATUS_SIE
+    csrw CSR_SEPC, s3
+    sret
+
+sgei_done:
+    li a0, 3
+    ecall
+
+back_in_m_from_hs:
+    li t0, HS_MARKER
+    bne s0, t0, fail
+    csrw CSR_MIDELEG, zero
+    csrw CSR_HVIP, zero
+    csrw CSR_HIE, zero
+    csrw CSR_HGEIE, zero
+    j done
+
+fail:
+    la t1, tohost
+    li t0, 3
+    sw t0, 0(t1)
+fail_loop:
+    j fail_loop

--- a/tests/coverage/hypervisorUnitTests.S
+++ b/tests/coverage/hypervisorUnitTests.S
@@ -39,18 +39,29 @@
 .equ CSR_VSTIMECMP,  0x24D
 .equ CSR_MENVCFG,    0x30A
 .equ CSR_MEDELEG,    0x302
+.equ CSR_MIDELEG,    0x303
 .equ CSR_MIE,        0x304
+.equ CSR_SSTATUS,    0x100
+.equ CSR_SEPC,       0x141
+.equ CSR_SCAUSE,     0x142
 .equ CSR_MCAUSE,     0x342
 .equ CSR_MTINST,     0x34A
 .equ CSR_MTVAL2,     0x34B
 
 .equ MIE_BASE,       0x0000000000000080
+.equ HSTATUS_BASE,   0x0000000200000000
 .equ HSTATUS_EXPECT, 0x00000002007003E0
+.equ HSTATUS_VGEIN1, 0x0000000200001000
 .equ HEDELEG_MASK,   0x000000000000B1FE
+.equ MIDELEG_RO1,    0x0000000000001444
 .equ HIDELEG_MASK,   0x0000000000000444
-.equ HIE_MASK,       0x0000000000000444
+.equ HGEIE_MASK,     0x0000000000000002
+.equ HIE_MASK,       0x0000000000001444
+.equ HIE_SGEIE_MASK, 0x0000000000001000
+.equ HIE_VS_MASK,    0x0000000000000444
 .equ VSIE_MASK,      0x0000000000000222
-.equ MIE_AFTER_HIE,  0x4C4
+.equ MIE_AFTER_HIE,  0x14C4
+.equ MIE_AFTER_VSIE, 0x4C4
 .equ HCOUNTEREN_VAL, 0x00000000A5A55A5A
 .equ HENVCFG_EXPECT, 0xE0000000000000F1
 .equ HTIMEDELTA_VAL, 0x0123456789ABCDEF
@@ -71,6 +82,11 @@
 .equ MTINST_VAL,     0xDEADBEEFCAFEBABE
 .equ MTVAL2_VAL,     0x0BADF00D12345678
 .equ CAUSE_ILLEGAL,  2
+.equ CAUSE_SGEI,     0x800000000000000C
+.equ SSTATUS_SIE,    0x2
+.equ HGEIP0_ADDR,    0x0200C000
+.equ TRICKEN_ADDR,   0x0200A010
+.equ TRICKEN_HGEIP,  0x40
 
 .macro CHECK_CSR_RW csr, write_val, expect_val
     li t0, \write_val
@@ -104,10 +120,13 @@ main:
     CHECK_CSR_RW CSR_MTINST, MTINST_VAL, MTINST_VAL
     CHECK_CSR_RW CSR_MTVAL2, MTVAL2_VAL, MTVAL2_VAL
     CHECK_CSR_RW CSR_HSTATUS, -1, HSTATUS_EXPECT
+    CHECK_CSR_RW CSR_HSTATUS, 0x1000, HSTATUS_VGEIN1
+    CHECK_CSR_RW CSR_HSTATUS, 0, HSTATUS_BASE
     CHECK_CSR_RW CSR_HEDELEG, -1, HEDELEG_MASK
+    CHECK_CSR_RW CSR_MIDELEG, 0, MIDELEG_RO1
     CHECK_CSR_RW CSR_HIDELEG, -1, HIDELEG_MASK
     CHECK_CSR_RW CSR_HCOUNTEREN, HCOUNTEREN_VAL, HCOUNTEREN_VAL
-    CHECK_CSR_RW CSR_HGEIE, -1, 0
+    CHECK_CSR_RW CSR_HGEIE, -1, HGEIE_MASK
     CHECK_CSR_RW CSR_HTVAL, HTVAL_VAL, HTVAL_VAL
     CHECK_CSR_RW CSR_HTINST, HTINST_VAL, HTINST_VAL
     CHECK_CSR_RW CSR_HGATP, HGATP_WRITE, HGATP_EXPECT
@@ -128,8 +147,8 @@ main:
     CHECK_CSR_RW CSR_HIE, 0, 0
     CHECK_CSR_READ CSR_MIE, MIE_BASE
     CHECK_CSR_RW CSR_VSIE, -1, VSIE_MASK
-    CHECK_CSR_READ CSR_HIE, HIE_MASK
-    CHECK_CSR_READ CSR_MIE, MIE_AFTER_HIE
+    CHECK_CSR_READ CSR_HIE, HIE_VS_MASK
+    CHECK_CSR_READ CSR_MIE, MIE_AFTER_VSIE
 
     # HIP/HVIP/VSIP are partially aliased through the delegated virtual interrupt bits.
     CHECK_CSR_RW CSR_HVIP, 0, 0
@@ -143,6 +162,7 @@ main:
     CHECK_CSR_RW CSR_VSIP, -1, 0x2
     CHECK_CSR_READ CSR_HIP, 0x4
     CHECK_CSR_READ CSR_HVIP, 0x4
+    CHECK_CSR_RW CSR_HVIP, 0, 0
 
     # Timer/configuration CSRs are tested late so earlier HIP reads are not
     # disturbed by virtual timer pending state.
@@ -151,7 +171,7 @@ main:
     CHECK_CSR_RW CSR_HENVCFG, -1, HENVCFG_EXPECT
     CHECK_CSR_RW CSR_HTIMEDELTA, HTIMEDELTA_VAL, HTIMEDELTA_VAL
 
-    # HGEIP is read-only until a guest-external interrupt source is integrated.
+    # HGEIP is source-driven and read-only from the CSR path.
     CHECK_ILLEGAL_CSR_WRITE CSR_HGEIP, -1, 0
 
     # Enter HS via the existing ecall privilege-change helper and exercise an
@@ -170,6 +190,48 @@ hs_mode_entry:
     csrr t0, CSR_HSTATUS
     .word 0x62000073 # hfence.gvma x0, x0
     li s0, HS_MARKER
+
+    # Drive guest external interrupt 1 through the CLINT/TrickBox HGEIP slot.
+    # With GEILEN=1, hgeie[1] and hie.SGEIE should deliver an HS-level SGEI.
+    la t0, sgei_handler
+    csrw stvec, t0
+    li t0, TRICKEN_ADDR
+    li t1, TRICKEN_HGEIP
+    sd t1, 0(t0)
+    li t0, HGEIP0_ADDR
+    sd zero, 0(t0)
+    li t0, HGEIE_MASK
+    csrw CSR_HGEIE, t0
+    li t0, HIE_SGEIE_MASK
+    csrw CSR_HIE, t0
+    csrsi CSR_SSTATUS, SSTATUS_SIE
+    li t0, HGEIP0_ADDR
+    li t1, HGEIE_MASK
+    sd t1, 0(t0)
+    j fail
+
+sgei_handler:
+    csrr t1, CSR_SCAUSE
+    li t2, CAUSE_SGEI
+    bne t1, t2, fail
+    csrr t1, CSR_HGEIP
+    li t2, HGEIE_MASK
+    bne t1, t2, fail
+    csrr t1, CSR_HIP
+    li t2, HIE_SGEIE_MASK
+    bne t1, t2, fail
+    li t0, HGEIP0_ADDR
+    sd zero, 0(t0)
+    li t0, TRICKEN_ADDR
+    sd zero, 0(t0)
+    csrw CSR_HIE, zero
+    csrw CSR_HGEIE, zero
+    csrci CSR_SSTATUS, SSTATUS_SIE
+    la t0, sgei_done
+    csrw CSR_SEPC, t0
+    sret
+
+sgei_done:
 
     li a0, 3
     ecall
@@ -204,7 +266,7 @@ back_in_m_from_hs:
 fail:
     la t1, tohost
     li t0, 3
-    sd t0, 0(t1)
+    sw t0, 0(t1)
 hs_trap_fail:
     j fail
 fail_loop:


### PR DESCRIPTION
- Adds configurable GEILEN and sets H configs to GEILEN=1
- Routes HGEIPIn from uncore through the core into csrh
- Adds SGEI cause selection in trap.sv
- Instantiates TrickBox in H configs as the local test source for guest external interrupts
- Fixes TrickBox indexing/default/width issues
- Adds hypervisorInterrupts.S and extends hypervisorUnitTests.S for GEILEN/SGEI coverage.