### PR TITLE
Implement bare mode HLV/HLVX/HSV path and coverage

### DIFF
--- a/src/ieu/controller.sv
+++ b/src/ieu/controller.sv
@@ -296,11 +296,12 @@ module controller import cvw::*;  #(parameter cvw_t P) (
                       ControlsD = `CTRLW'b1_000_01_00_000_0_0_1_1_0_0_0_0_0_00_0_0; // jalr
       7'b1101111:     ControlsD = `CTRLW'b1_011_11_00_000_0_0_1_1_0_0_0_0_0_00_0_0; // jal
       7'b1110011: if (P.ZICSR_SUPPORTED) begin
-                   if (HLVHSVInstrD & HLVHSVLoadD)
-                      ControlsD = `CTRLW'b1_101_01_10_001_0_0_0_0_0_0_0_0_0_00_0_0; // HLV/HLVX: zero-offset virtual-machine load
-                   else if (HLVHSVInstrD)
-                      ControlsD = `CTRLW'b0_101_01_01_000_0_0_0_0_0_0_0_0_0_00_0_0; // HSV: zero-offset virtual-machine store
-                   else if (PFunctD)
+                   if (HLVHSVInstrD) begin
+                     if (HLVHSVLoadD)
+                       ControlsD = `CTRLW'b1_101_01_10_001_0_0_0_0_0_0_0_0_0_00_0_0; // HLV/HLVX: zero-offset virtual-machine load
+                     else
+                       ControlsD = `CTRLW'b0_101_01_01_000_0_0_0_0_0_0_0_0_0_00_0_0; // HSV: zero-offset virtual-machine store
+                   end else if (PFunctD)
                       ControlsD = `CTRLW'b0_000_00_00_000_0_0_0_0_0_0_1_0_0_00_0_0; // privileged; decoded further in privdec modules
                    else if (CSRFunctD)
                       ControlsD = `CTRLW'b1_000_00_00_010_0_0_0_0_0_1_0_0_0_00_0_0; // csrs

--- a/src/ieu/controller.sv
+++ b/src/ieu/controller.sv
@@ -215,22 +215,36 @@ module controller import cvw::*;  #(parameter cvw_t P) (
   assign IWValidFunct3D   = Funct3D == 3'b000 | Funct3D == 3'b001 | Funct3D == 3'b101;
 
   // H-extension virtual-machine load/store strict decoding
-  logic HLVHSVValidD;
-  always_comb begin
-    case (Funct7D[2:0])
-      3'b000: HLVHSVValidD = (Rs2D == 5'b00000) | (Rs2D == 5'b00001);
-      3'b001: HLVHSVValidD = (RdD == 5'b00000);
-      3'b010: HLVHSVValidD = (Rs2D == 5'b00000) | (Rs2D == 5'b00001) | (Rs2D == 5'b00011);
-      3'b011: HLVHSVValidD = (RdD == 5'b00000);
-      3'b100: HLVHSVValidD = (Rs2D == 5'b00000) | (Rs2D == 5'b00011) | ((P.XLEN == 64) & (Rs2D == 5'b00001));
-      3'b101: HLVHSVValidD = (RdD == 5'b00000);
-      3'b110: HLVHSVValidD = (P.XLEN == 64) & (Rs2D == 5'b00000);
-      3'b111: HLVHSVValidD = (P.XLEN == 64) & (RdD == 5'b00000);
-      default: HLVHSVValidD = 1'b0;
-    endcase
+  logic HLVHSVLoadD;
+  logic [2:0] LSUFunct3D;
+  if (P.H_SUPPORTED) begin: hlsv_decode
+    logic HLVHSVValidD;
+    logic [2:0] HLVHSVFunct3D;
+    always_comb begin
+      case (Funct7D[2:0])
+        3'b000: HLVHSVValidD = (Rs2D == 5'b00000) | (Rs2D == 5'b00001);
+        3'b001: HLVHSVValidD = (RdD == 5'b00000);
+        3'b010: HLVHSVValidD = (Rs2D == 5'b00000) | (Rs2D == 5'b00001) | (Rs2D == 5'b00011);
+        3'b011: HLVHSVValidD = (RdD == 5'b00000);
+        3'b100: HLVHSVValidD = (Rs2D == 5'b00000) | (Rs2D == 5'b00011) | ((P.XLEN == 64) & (Rs2D == 5'b00001));
+        3'b101: HLVHSVValidD = (RdD == 5'b00000);
+        3'b110: HLVHSVValidD = (P.XLEN == 64) & (Rs2D == 5'b00000);
+        3'b111: HLVHSVValidD = (P.XLEN == 64) & (RdD == 5'b00000);
+        default: HLVHSVValidD = 1'b0;
+      endcase
+    end
+    assign HLVHSVInstrD = (OpD == 7'b1110011) & (Funct3D == 3'b100) &
+                          (Funct7D[6:3] == 4'b0110) & HLVHSVValidD;
+    assign HLVHSVLoadD = ~Funct7D[0];
+    // HLV/HLVX/HSV have SYSTEM encodings but execute as zero-offset loads/stores.
+    // Convert their width/sign encoding to the ordinary LSU Funct3 format.
+    assign HLVHSVFunct3D = HLVHSVLoadD ? {Rs2D[0], Funct7D[2:1]} : {1'b0, Funct7D[2:1]};
+    assign LSUFunct3D = HLVHSVInstrD ? HLVHSVFunct3D : Funct3D;
+  end else begin: nohlsv_decode
+    assign HLVHSVInstrD = 1'b0;
+    assign HLVHSVLoadD = 1'b0;
+    assign LSUFunct3D = Funct3D;
   end
-  assign HLVHSVInstrD = P.H_SUPPORTED & (OpD == 7'b1110011) & (Funct3D == 3'b100) &
-                        (Funct7D[6:3] == 4'b0110) & HLVHSVValidD;
 
   // Main Instruction Decoder
   /* verilator lint_off CASEINCOMPLETE */
@@ -282,7 +296,11 @@ module controller import cvw::*;  #(parameter cvw_t P) (
                       ControlsD = `CTRLW'b1_000_01_00_000_0_0_1_1_0_0_0_0_0_00_0_0; // jalr
       7'b1101111:     ControlsD = `CTRLW'b1_011_11_00_000_0_0_1_1_0_0_0_0_0_00_0_0; // jal
       7'b1110011: if (P.ZICSR_SUPPORTED) begin
-                   if (PFunctD)
+                   if (HLVHSVInstrD & HLVHSVLoadD)
+                      ControlsD = `CTRLW'b1_101_01_10_001_0_0_0_0_0_0_0_0_0_00_0_0; // HLV/HLVX: zero-offset virtual-machine load
+                   else if (HLVHSVInstrD)
+                      ControlsD = `CTRLW'b0_101_01_01_000_0_0_0_0_0_0_0_0_0_00_0_0; // HSV: zero-offset virtual-machine store
+                   else if (PFunctD)
                       ControlsD = `CTRLW'b0_000_00_00_000_0_0_0_0_0_0_1_0_0_00_0_0; // privileged; decoded further in privdec modules
                    else if (CSRFunctD)
                       ControlsD = `CTRLW'b1_000_00_00_010_0_0_0_0_0_1_0_0_0_00_0_0; // csrs
@@ -415,7 +433,7 @@ module controller import cvw::*;  #(parameter cvw_t P) (
 
   // Execute stage pipeline control register and logic
   flopenrc #(46) controlregE(clk, reset, FlushE, ~StallE,
-                           {ALUSelectD, RegWriteD, ResultSrcD, MemRWD, JumpD, BranchD, ALUSrcAD, ALUSrcBD, ALUResultSrcD, CSRReadD, CSRWriteD, PrivilegedD, Funct3D, Funct7D, W64D, BUW64D, SubArithD, MDUD, AtomicD, InvalidateICacheD, FlushDCacheD, FenceD, CMOpD, IFUPrefetchD, LSUPrefetchD, CZeroD, InstrValidD, HLVHSVInstrD},
+                           {ALUSelectD, RegWriteD, ResultSrcD, MemRWD, JumpD, BranchD, ALUSrcAD, ALUSrcBD, ALUResultSrcD, CSRReadD, CSRWriteD, PrivilegedD, LSUFunct3D, Funct7D, W64D, BUW64D, SubArithD, MDUD, AtomicD, InvalidateICacheD, FlushDCacheD, FenceD, CMOpD, IFUPrefetchD, LSUPrefetchD, CZeroD, InstrValidD, HLVHSVInstrD},
                            {ALUSelectE, IEURegWriteE, ResultSrcE, MemRWE, JumpE, BranchE, ALUSrcAE, ALUSrcBE, ALUResultSrcE, CSRReadE, CSRWriteE, PrivilegedE, Funct3E, Funct7E, W64E, UW64E, SubArithE, MDUE, AtomicE, InvalidateICacheE, FlushDCacheE, FenceE, CMOpE, IFUPrefetchE, LSUPrefetchE, CZeroE, InstrValidE, HLVHSVInstrE});
   flopenrc #(5)  Rs1EReg(clk, reset, FlushE, ~StallE, Rs1D, Rs1E);
   flopenrc #(5)  Rs2EReg(clk, reset, FlushE, ~StallE, Rs2D, Rs2E);

--- a/src/ieu/extend.sv
+++ b/src/ieu/extend.sv
@@ -47,7 +47,7 @@ module extend import cvw::*;  #(parameter cvw_t P) (
       3'b011:   ImmExtD = {{(P.XLEN-20){InstrD[31]}}, InstrD[19:12], InstrD[20], InstrD[30:21], 1'b0};
       // U-type (lui, auipc)
       3'b100:   ImmExtD = {{(P.XLEN-31){InstrD[31]}}, InstrD[30:12], 12'b0};
-      // Store Conditional, AMO, CMO, HLV/HLVX/HSV: zero offset
+      // Store Conditional, Atomics, CMO, HLV/HLVX/HSV: zero offset
       3'b101:  if (P.ZALRSC_SUPPORTED | P.ZAAMO_SUPPORTED | P.ZICBOM_SUPPORTED | P.ZICBOZ_SUPPORTED | P.H_SUPPORTED) ImmExtD = '0;
                else             ImmExtD = undefined;
       default: ImmExtD = undefined; // undefined

--- a/src/ieu/extend.sv
+++ b/src/ieu/extend.sv
@@ -47,8 +47,8 @@ module extend import cvw::*;  #(parameter cvw_t P) (
       3'b011:   ImmExtD = {{(P.XLEN-20){InstrD[31]}}, InstrD[19:12], InstrD[20], InstrD[30:21], 1'b0};
       // U-type (lui, auipc)
       3'b100:   ImmExtD = {{(P.XLEN-31){InstrD[31]}}, InstrD[30:12], 12'b0};
-      // Store Conditional: zero offset
-      3'b101:  if (P.ZALRSC_SUPPORTED | P.ZAAMO_SUPPORTED | P.ZICBOM_SUPPORTED | P.ZICBOZ_SUPPORTED) ImmExtD = '0;
+      // Store Conditional, AMO, CMO, HLV/HLVX/HSV: zero offset
+      3'b101:  if (P.ZALRSC_SUPPORTED | P.ZAAMO_SUPPORTED | P.ZICBOM_SUPPORTED | P.ZICBOZ_SUPPORTED | P.H_SUPPORTED) ImmExtD = '0;
                else             ImmExtD = undefined;
       default: ImmExtD = undefined; // undefined
     endcase

--- a/src/ifu/ifu.sv
+++ b/src/ifu/ifu.sv
@@ -186,6 +186,8 @@ module ifu import cvw::*;  #(parameter cvw_t P) (
     flopr #(1) StallMReg(.clk, .reset, .d(StallM), .q(StallMQ));
     assign TLBFlush = sfencevmaM & ~StallMQ;
 
+    // HLV/HLVX/HSV explicit accesses are data-side only; tie off their controls for the IMMU.
+    // TODO: Full VS/VU instruction fetch needs separate two-stage VSATP/HGATP translation plumbing.
     mmu #(.P(P), .TLB_ENTRIES(P.ITLB_ENTRIES), .IMMU(1))
     immu(.clk, .reset, .SATP_REGW, .STATUS_MXR, .STATUS_SUM, .STATUS_MPRV, .STATUS_MPP,
          .HSTATUS_SPVP(1'b0), .HLVHSVLegalM(1'b0), .ENVCFG_PBMTE, .ENVCFG_ADUE,

--- a/src/ifu/ifu.sv
+++ b/src/ifu/ifu.sv
@@ -187,7 +187,8 @@ module ifu import cvw::*;  #(parameter cvw_t P) (
     assign TLBFlush = sfencevmaM & ~StallMQ;
 
     mmu #(.P(P), .TLB_ENTRIES(P.ITLB_ENTRIES), .IMMU(1))
-    immu(.clk, .reset, .SATP_REGW, .STATUS_MXR, .STATUS_SUM, .STATUS_MPRV, .STATUS_MPP, .ENVCFG_PBMTE, .ENVCFG_ADUE,
+    immu(.clk, .reset, .SATP_REGW, .STATUS_MXR, .STATUS_SUM, .STATUS_MPRV, .STATUS_MPP,
+         .HSTATUS_SPVP(1'b0), .HLVHSVLegalM(1'b0), .ENVCFG_PBMTE, .ENVCFG_ADUE,
          .PrivilegeModeW, .DisableTranslation(1'b0),
          .VAdr(PCFExt),
          .Size(2'b10),

--- a/src/lsu/lsu.sv
+++ b/src/lsu/lsu.sv
@@ -40,6 +40,8 @@ module lsu import cvw::*;  #(parameter cvw_t P) (
   input  logic [2:0]              Funct3M,                              // Size of memory operation
   input  logic [6:0]              Funct7M,                              // Atomic memory operation function
   input  logic [1:0]              AtomicM,                              // Atomic memory operation
+  input  logic                    HLVHSVInstrM,                         // Valid HLV/HLVX/HSV encoding in Memory stage
+  input  logic                    HLVHSVLegalM,                         // HLV/HLVX/HSV may issue its LSU access
   input  logic                    FlushDCacheM,                         // Flush D cache to next level of memory
   input  logic [3:0]              CMOpM,                                // 1: cbo.inval; 2: cbo.flush; 4: cbo.clean; 8: cbo.zero
   input  logic                    LSUPrefetchM,                         // Prefetch; presently unused
@@ -84,6 +86,7 @@ module lsu import cvw::*;  #(parameter cvw_t P) (
   input  logic [P.XLEN-1:0]       SATP_REGW,                            // SATP (supervisor address translation and protection) CSR
   input  logic                    STATUS_MXR, STATUS_SUM, STATUS_MPRV,  // STATUS CSR bits: make executable readable, supervisor user memory, machine privilege
   input  logic [1:0]              STATUS_MPP,                           // Machine previous privilege mode
+  input  logic                    HSTATUS_SPVP,                         // HLV/HLVX/HSV effective privilege: 0=VU, 1=VS
   input  logic                    ENVCFG_PBMTE,                         // Page-based memory types enabled
   input  logic                    ENVCFG_ADUE,                          // HPTW A/D Update enable
   input  logic [P.XLEN-1:0]       PCSpillF,                             // Fetch PC
@@ -104,6 +107,7 @@ module lsu import cvw::*;  #(parameter cvw_t P) (
   logic [P.XLEN+1:0]     IHAdrM;                                 // Either IEU or HPTW memory address
 
   logic [1:0]            PreLSURWM;                              // IEU or HPTW Read/Write signal
+  logic [1:0]            GatedMemRWM;                            // MemRWM suppressed for HLV/HSV traps
   logic [1:0]            LSURWM;                                 // IEU or HPTW Read/Write signal gated by LR/SC
   logic [2:0]            LSUFunct3M;                             // IEU or HPTW memory operation size
   logic [6:0]            LSUFunct7M;                             // AMO function gated by HPTW
@@ -157,12 +161,20 @@ module lsu import cvw::*;  #(parameter cvw_t P) (
   // Zero-extend address to 34 bits for XLEN=32
   /////////////////////////////////////////////////////////////////////////////////////////////
 
+  // HLV/HLVX/HSV decode enters the LSU as a normal memory op, but V-mode,
+  // U-mode-with-HU=0, and non-Bare cases trap in privdec and must not access memory.
+  if (P.H_SUPPORTED) begin: hlsv_gating
+    assign GatedMemRWM = (HLVHSVInstrM & ~HLVHSVLegalM) ? 2'b00 : MemRWM;
+  end else begin: nohlsv_gating
+    assign GatedMemRWM = MemRWM;
+  end
+
   flopenrc #(P.XLEN) AddressMReg(clk, reset, FlushM, ~StallM, IEUAdrE, IEUAdrM);
   if(MISALIGN_SUPPORT) begin : ziccslm_align
     logic [P.XLEN-1:0] IEUAdrSpillE;
     logic [P.XLEN-1:0] IEUAdrSpillM;
     align #(P) align(.clk, .reset, .StallM, .FlushM, .IEUAdrE, .IEUAdrM, .Funct3M, .FpLoadStoreM,
-                     .MemRWM,
+                     .MemRWM(GatedMemRWM),
                      .DCacheReadDataWordM, .CacheBusHPWTStall, .SelHPTW,
                      .ByteMaskM, .ByteMaskExtendedM, .LSUWriteDataM, .ByteMaskSpillM, .LSUWriteDataSpillM,
                      .IEUAdrSpillE, .IEUAdrSpillM, .IEUAdrxTvalM, .SelSpillE, .DCacheReadDataWordSpillM, .SpillStallM);
@@ -175,7 +187,7 @@ module lsu import cvw::*;  #(parameter cvw_t P) (
     assign DCacheReadDataWordSpillM = DCacheReadDataWordM;
     assign ByteMaskSpillM = ByteMaskM;
     assign LSUWriteDataSpillM = LSUWriteDataM;
-    assign MemRWSpillM = MemRWM;
+    assign MemRWSpillM = GatedMemRWM;
     assign {SpillStallM} = 1'b0;
     assign IEUAdrxTvalM = IEUAdrM;
   end
@@ -192,7 +204,7 @@ module lsu import cvw::*;  #(parameter cvw_t P) (
   /////////////////////////////////////////////////////////////////////////////////////////////
 
   if(P.VIRTMEM_SUPPORTED) begin : hptw
-    hptw #(P) hptw(.clk, .reset, .MemRWM, .AtomicM, .ITLBMissOrUpdateAF, .ITLBWriteF,
+    hptw #(P) hptw(.clk, .reset, .MemRWM(GatedMemRWM), .AtomicM, .ITLBMissOrUpdateAF, .ITLBWriteF,
       .DTLBMissOrUpdateDAM, .DTLBWriteM,
       .FlushW, .DCacheBusStallM, .SATP_REGW, .PCSpillF,
       .STATUS_MXR, .STATUS_SUM, .STATUS_MPRV, .STATUS_MPP, .ENVCFG_ADUE, .PrivilegeModeW,
@@ -205,7 +217,7 @@ module lsu import cvw::*;  #(parameter cvw_t P) (
       .LoadPageFaultM, .StoreAmoPageFaultM, .LSULoadPageFaultM, .LSUStoreAmoPageFaultM, .HPTWInstrPageFaultF
 );
   end else begin // No HPTW, so signals are not multiplexed
-    assign PreLSURWM = MemRWM;
+    assign PreLSURWM = GatedMemRWM;
     assign IHAdrM = IEUAdrExtM;
     assign LSUFunct3M = Funct3M;
     assign LSUFunct7M = Funct7M;
@@ -234,14 +246,21 @@ module lsu import cvw::*;  #(parameter cvw_t P) (
   // MMU and misalignment fault logic required if privileged unit exists
   /////////////////////////////////////////////////////////////////////////////////////////////
   if(P.ZICSR_SUPPORTED == 1) begin : dmmu
-    logic DisableTranslation;                             // During HPTW walk or D$ flush disable virtual memory address translation
+    logic DisableTranslation;                             // During HPTW walk, D$ flush, or Bare/Bare HLV/HSV, disable virtual translation
     logic WriteAccessM;
     logic DataUpdateDAM;                                  // DTLB hit needs to update dirty or access bits
 
-    assign DisableTranslation = SelHPTW | FlushDCacheM;
+    // norm:hlsv_trans requires two-stage translation for HLV/HLVX/HSV. This
+    // first path only supports VSATP/HGATP Bare/Bare; privdec traps non-Bare
+    // cases so the LSU never silently applies HS-stage translation here.
+    if (P.H_SUPPORTED) begin: hlsv_disabletranslation
+      assign DisableTranslation = SelHPTW | FlushDCacheM | HLVHSVLegalM;
+    end else begin: nohlsv_disabletranslation
+      assign DisableTranslation = SelHPTW | FlushDCacheM;
+    end
     assign WriteAccessM = PreLSURWM[0];
     mmu #(.P(P), .TLB_ENTRIES(P.DTLB_ENTRIES), .IMMU(0))
-    dmmu(.clk, .reset, .SATP_REGW, .STATUS_MXR, .STATUS_SUM, .STATUS_MPRV, .STATUS_MPP, .ENVCFG_PBMTE, .ENVCFG_ADUE,
+    dmmu(.clk, .reset, .SATP_REGW, .STATUS_MXR, .STATUS_SUM, .STATUS_MPRV, .STATUS_MPP, .HSTATUS_SPVP, .HLVHSVLegalM, .ENVCFG_PBMTE, .ENVCFG_ADUE,
       .PrivilegeModeW, .DisableTranslation, .VAdr(IHAdrM), .Size(LSUFunct3M[1:0]),
       .PTE, .PageTypeWriteVal(PageType), .TLBWrite(DTLBWriteM), .TLBFlush(sfencevmaM),
       .PhysicalAddress(PAdrM), .TLBMiss(DTLBMissM), .Cacheable(CacheableM), .Idempotent(), .SelTIM(SelDTIM),
@@ -282,7 +301,7 @@ module lsu import cvw::*;  #(parameter cvw_t P) (
     logic [1:0]           DTIMMemRWM;
 
     // The DTIM uses untranslated addresses, so it is not compatible with virtual memory.
-    mux2 #(P.PA_BITS) DTIMAdrMux(IEUAdrExtE[P.PA_BITS-1:0], IEUAdrExtM[P.PA_BITS-1:0], MemRWM[0], DTIMAdr);
+    mux2 #(P.PA_BITS) DTIMAdrMux(IEUAdrExtE[P.PA_BITS-1:0], IEUAdrExtM[P.PA_BITS-1:0], GatedMemRWM[0], DTIMAdr);
     assign DTIMMemRWM = SelDTIM ? LSURWM : 0;
     dtim #(P) dtim(.clk, .reset, .ce(~GatedStallW),
               .MemRWM(DTIMMemRWM),

--- a/src/mmu/mmu.sv
+++ b/src/mmu/mmu.sv
@@ -35,6 +35,8 @@ module mmu import cvw::*;  #(parameter cvw_t P,
   input  logic                 STATUS_SUM,         // Status CSR: Supervisor access to user memory
   input  logic                 STATUS_MPRV,        // Status CSR: modify machine privilege
   input  logic [1:0]           STATUS_MPP,         // Status CSR: previous machine privilege level
+  input  logic                 HSTATUS_SPVP,       // HLV/HLVX/HSV effective privilege: 0=VU, 1=VS
+  input  logic                 HLVHSVLegalM,       // HLV/HLVX/HSV memory access in Bare/Bare path
   input  logic                 ENVCFG_PBMTE,       // Page-based memory types enabled
   input  logic                 ENVCFG_ADUE,        // HPTW A/D Update enable
   input  logic [1:0]           PrivilegeModeW,     // Current privilege level of the processeor
@@ -80,7 +82,16 @@ module mmu import cvw::*;  #(parameter cvw_t P,
 
   // Get Effective Privilege Mode
   // for DLB, when mstatus.MPRV=1, use mstatus.MPP rather than the current privilege mode
-  assign EffectivePrivilegeModeW = IMMU ? PrivilegeModeW : (STATUS_MPRV ? STATUS_MPP : PrivilegeModeW);
+  if (IMMU) begin: effpriv_immu
+    assign EffectivePrivilegeModeW = PrivilegeModeW;
+  end else if (P.H_SUPPORTED) begin: effpriv_dmmu_h
+    // norm:hlsv_priv/norm:mstatus_mprv_hlsv: HLV/HLVX/HSV use hstatus.SPVP
+    // (VU when 0, VS when 1) and override mstatus.MPRV.
+    assign EffectivePrivilegeModeW = HLVHSVLegalM ? {1'b0, HSTATUS_SPVP} :
+                                     (STATUS_MPRV ? STATUS_MPP : PrivilegeModeW);
+  end else begin: effpriv_dmmu_noh
+    assign EffectivePrivilegeModeW = STATUS_MPRV ? STATUS_MPP : PrivilegeModeW;
+  end
 
   // only instantiate TLB if Virtual Memory is supported
   if (P.VIRTMEM_SUPPORTED) begin:tlb

--- a/src/privileged/csr.sv
+++ b/src/privileged/csr.sv
@@ -55,6 +55,7 @@ module csr import cvw::*;  #(parameter cvw_t P) (
   input  logic [1:0]               NextPrivilegeModeM,        // STATUS bits updated based on next privilege mode
   input  logic [1:0]               PrivilegeModeW,            // current privilege mode
   input  logic                     VirtModeW,                 // current V Bit
+  input  logic                     HLVHSVLegalM,              // Legal HLV/HLVX/HSV memory access in M stage
   input  logic [4:0]               CauseM,                    // Trap cause
   input  logic                     SelHPTW,                   // hardware page table walker active, so base endianness on supervisor mode
   // inputs for performance counters
@@ -80,6 +81,7 @@ module csr import cvw::*;  #(parameter cvw_t P) (
   output logic                     MSTATUS_MPV,
   output logic                     STATUS_SPP, STATUS_TSR, STATUS_TVM,
   output logic                     HSTATUS_SPV,
+  output logic                     HSTATUS_SPVP,
   output logic                     HSTATUS_VTSR, HSTATUS_VTW, HSTATUS_VTVM,
   output logic                     HSTATUS_HU,
   output logic                     VSSTATUS_SPP, VSSTATUS_SIE,
@@ -107,6 +109,7 @@ module csr import cvw::*;  #(parameter cvw_t P) (
   output logic                     IllegalCSRAccessM,         // Illegal CSR access: CSR doesn't exist or is inaccessible at this privilege level
   output logic                     VirtualCSRAccessM,         // CSR access that raises a virtual-instruction exception
   output logic                     VirtualCMOInstrM,          // CBO instruction that raises a virtual-instruction exception
+  output logic                     HLVHSVBareM,               // VS-stage and G-stage translation are both Bare for HLV/HSV
   output logic                     BigEndianM                 // memory access is big-endian based on privilege mode and STATUS register endian fields
 );
 
@@ -287,7 +290,7 @@ module csr import cvw::*;  #(parameter cvw_t P) (
   if (P.H_SUPPORTED) begin: csradr_h
     csrhvirt #(P) csrhvirt(.CSRAdrM_In, .CSRReadM, .CSRWriteM, .TrapM, .ExceptionM,
       .VirtModeW, .PrivilegeModeW, .MCOUNTEREN_REGW, .HCOUNTEREN_REGW, .HENVCFG_REGW,
-      .VirtualCSRCAccessM, .TrapWritesVAToTvalM, .CSRAdrM, .VirtualCSRAccessM, .TrapGVAM);
+      .VirtualCSRCAccessM, .TrapWritesVAToTvalM, .HLVHSVLegalM, .CSRAdrM, .VirtualCSRAccessM, .TrapGVAM);
   end else begin: csradr_noh
     assign CSRAdrM = CSRAdrM_In;
     assign VirtualCSRAccessM = 1'b0;
@@ -374,7 +377,7 @@ module csr import cvw::*;  #(parameter cvw_t P) (
       .NextEPCM, .NextCauseM, .NextTvalM, .NextHtvalM, .HIE_REGW,
       .CSRHReadValM, .IllegalCSRHAccessM,
       .HSTATUS_SPV, .HSTATUS_VTSR, .HSTATUS_VTW, .HSTATUS_VTVM,
-      .HSTATUS_HU,
+      .HSTATUS_SPVP, .HSTATUS_HU,
       .HSTATUS_VSBE, .VSSTATUS_SPP, .VSSTATUS_SIE, .VSSTATUS_SUM, .VSSTATUS_MXR, .VSSTATUS_UBE, .VSSTATUS_FS,
       .HEDELEG_REGW, .HIDELEG_REGW, .WriteHIEM, .WriteVSIEM, .HGEIE_REGW, .HCOUNTEREN_REGW, .HVIP_REGW, .HIP_MIP_REGW, .HTIMEDELTA_REGW, .HENVCFG_REGW,
       .VSTVEC_REGW, .VSEPC_REGW, .VSATP_REGW, .HGATP_REGW);
@@ -382,6 +385,7 @@ module csr import cvw::*;  #(parameter cvw_t P) (
     assign CSRHReadValM = '0;
     assign IllegalCSRHAccessM = 1'b1;
     assign HSTATUS_SPV = 1'b0;
+    assign HSTATUS_SPVP = 1'b0;
     assign HSTATUS_VTSR = 1'b0;
     assign HSTATUS_VTW = 1'b0;
     assign HSTATUS_VTVM = 1'b0;
@@ -419,6 +423,16 @@ module csr import cvw::*;  #(parameter cvw_t P) (
   // Until two-stage translation is integrated, htval trap writes stay zero.
   assign NextHtvalM = '0;
 
+  if (P.H_SUPPORTED & P.VIRTMEM_SUPPORTED) begin: hlsv_bare
+    if (P.XLEN == 64) begin: hlsv_bare64
+      assign HLVHSVBareM = (VSATP_REGW[63:60] == 4'h0) & (HGATP_REGW[63:60] == 4'h0);
+    end else begin: hlsv_bare32
+      assign HLVHSVBareM = ~VSATP_REGW[31] & ~HGATP_REGW[31];
+    end
+  end else begin: hlsv_novirtmem
+    assign HLVHSVBareM = 1'b1;
+  end
+
   // Effective status bits for VS-mode
   if (P.H_SUPPORTED) begin: status_vs
     assign STATUS_MXR = VirtModeW ? VSSTATUS_MXR : STATUS_MXR_INT;
@@ -432,9 +446,11 @@ module csr import cvw::*;  #(parameter cvw_t P) (
 
   if (P.BIGENDIAN_SUPPORTED) begin: endian
     if (P.H_SUPPORTED) begin: endian_h
-      logic BigEndianVirtM;
+      logic BigEndianVirtM, BigEndianHLVHSVM, BigEndianVirtSelM;
       assign BigEndianVirtM = (PrivilegeModeW == P.S_MODE) ? HSTATUS_VSBE : VSSTATUS_UBE;
-      mux2 #(1) bigendianmux(BigEndianM_Int, BigEndianVirtM, VirtModeW & ~SelHPTW, BigEndianM);
+      assign BigEndianHLVHSVM = HSTATUS_SPVP ? HSTATUS_VSBE : VSSTATUS_UBE;
+      mux2 #(1) bigendianvirtmux(BigEndianM_Int, BigEndianVirtM, VirtModeW & ~SelHPTW, BigEndianVirtSelM);
+      mux2 #(1) bigendianhlsvmux(BigEndianVirtSelM, BigEndianHLVHSVM, HLVHSVLegalM, BigEndianM);
     end else begin: endian_noh
       assign BigEndianM = BigEndianM_Int;
     end

--- a/src/privileged/csrh.sv
+++ b/src/privileged/csrh.sv
@@ -62,6 +62,7 @@ module csrh import cvw::*;  #(parameter cvw_t P) (
   output logic [P.XLEN-1:0] CSRHReadValM,
   output logic              IllegalCSRHAccessM,
   output logic              HSTATUS_SPV,
+  output logic              HSTATUS_SPVP,
   output logic              HSTATUS_VTSR, HSTATUS_VTW, HSTATUS_VTVM,
   output logic              HSTATUS_HU,
   output logic              HSTATUS_VSBE,
@@ -87,7 +88,7 @@ module csrh import cvw::*;  #(parameter cvw_t P) (
   logic [P.XLEN-1:0] MTVAL2_REGW;
   logic [P.XLEN-1:0] HSTATUS_REGW;
   logic [P.XLEN-1:0] VSSTATUS_REGW;
-  logic              HSTATUS_GVA, HSTATUS_SPVP;
+  logic              HSTATUS_GVA;
   logic [5:0]        HSTATUS_VGEIN;
   logic [1:0]        HSTATUS_VSXL, HSTATUS_HUPMM;
   logic              VSSTATUS_SD, VSSTATUS_SPELP, VSSTATUS_SDT;

--- a/src/privileged/csrhvirt.sv
+++ b/src/privileged/csrhvirt.sv
@@ -2,10 +2,9 @@
 // csrhvirt.sv
 //
 // Written: nchulani@hmc.edu 27 April 2026
-// Purpose: Hypervisor CSR address substitution and virtual-instruction classification
+// Purpose: Combinational H-extension CSR virtualization: VS address substitution,
+//          virtual-instruction classification, and trap GVA generation
 //          See RISC-V Privileged Mode Specification (Hypervisor Extension)
-//
-// Documentation: RISC-V System on Chip Design
 //
 // A component of the CORE-V-WALLY configurable RISC-V project.
 // https://github.com/openhwgroup/cvw

--- a/src/privileged/csrhvirt.sv
+++ b/src/privileged/csrhvirt.sv
@@ -36,6 +36,7 @@ module csrhvirt import cvw::*;  #(parameter cvw_t P) (
   input  logic [63:0]       HENVCFG_REGW,
   input  logic              VirtualCSRCAccessM,
   input  logic              TrapWritesVAToTvalM,
+  input  logic              HLVHSVLegalM,
   output logic [11:0]       CSRAdrM,
   output logic              VirtualCSRAccessM,
   output logic              TrapGVAM
@@ -164,6 +165,7 @@ module csrhvirt import cvw::*;  #(parameter cvw_t P) (
                                          VirtualVSTimecmpAccessM | VirtualCSRCAccessM);
 
   // GVA gets set when traps from virtualized execution write a VA to tval.
-  // TODO: Include HS-mode HLV/HLVX/HSV fault cases when those paths are integrated.
-  assign TrapGVAM = TrapM & ExceptionM & VirtModeW & TrapWritesVAToTvalM;
+  // H spec hstatus.GVA note: HLV/HLVX/HSV address faults write guest virtual
+  // addresses even though V=0 for the executing hypervisor instruction.
+  assign TrapGVAM = TrapM & ExceptionM & (VirtModeW | HLVHSVLegalM) & TrapWritesVAToTvalM;
 endmodule

--- a/src/privileged/privdec.sv
+++ b/src/privileged/privdec.sv
@@ -38,13 +38,12 @@ module privdec import cvw::*;  #(parameter cvw_t P) (
   input  logic         VirtualCSRAccessM,                   // CSR access that should trap as virtual instruction
   input  logic         VirtualCMOInstrM,                    // CBO instruction that should trap as virtual instruction
   input  logic         HLVHSVInstrM,                        // Valid HLV/HLVX/HSV system-instruction encoding
+  input  logic         HLVHSVBareM,                         // VS-stage and G-stage translation are both Bare for HLV/HSV
   input  logic [1:0]   PrivilegeModeW,                      // current privilege level
   input  logic         VirtModeW,                           // current V
   input  logic         STATUS_TSR, STATUS_TVM, STATUS_TW,   // status bits (HS)
   input  logic         HSTATUS_VTSR, HSTATUS_VTVM, HSTATUS_VTW, // status bits (VS)
-  /* verilator lint_off UNUSEDSIGNAL */                     // reserved for future U-mode HLV/HLVX/HSV legality checks
   input  logic         HSTATUS_HU,
-  /* verilator lint_on UNUSEDSIGNAL */
   output logic         IllegalInstrFaultM,                  // Illegal instruction
   output logic         VirtualInstrFaultM,                  // Virtual instruction exception
   output logic         EcallFaultM, BreakpointFaultM,       // Ecall or breakpoint; must retire, so don't flush it when the trap occurs
@@ -65,6 +64,7 @@ module privdec import cvw::*;  #(parameter cvw_t P) (
   logic                hvvmaM, hgvmaM;                      // HFENCE/HINVAL operations
   logic                fenceinvalM;                         // sfence.w.inval or sfence.inval.ir
   logic                TSRM, TVMM;
+  logic                HLVHSVIllegalM;                      // HLV/HLVX/HSV illegal-instruction cases
 
   ///////////////////////////////////////////
   // Decode privileged instructions
@@ -164,10 +164,12 @@ module privdec import cvw::*;  #(parameter cvw_t P) (
 
     assign VSTSRFault = PrivilegedM & is_sret & VirtModeW & HSTATUS_VTSR;
     assign HVFenceFault = PrivilegedM & VirtModeW & (hvvmaM | hgvmaM);
-    // Legal non-V execution remains TODO until the LSU/MMU path can honor
-    // SPVP, VS/VU translation, HLVX execute-permission semantics, and
-    // hstatus.HU for U-mode HLV/HLVX/HSV enable.
     assign HLVHSVFault = HLVHSVInstrM & VirtModeW; // norm:hlsv_virtinst: V=1 -> virtual instruction
+    // norm:hlsv_mode/norm:hlsv_illegalinst: HLV/HLVX/HSV are valid in M/HS
+    // and in U only when hstatus.HU=1. norm:hlsv_trans requires two-stage
+    // translation; until that is integrated, only Bare/Bare execution is legal.
+    assign HLVHSVIllegalM = HLVHSVInstrM & ~VirtModeW &
+                            (((PrivilegeModeW == P.U_MODE) & ~HSTATUS_HU) | ~HLVHSVBareM);
     assign WFIShouldTrapVirtM = wfiM & WFITimeoutM & ~STATUS_TW;
     assign VUWfiFault = WFIShouldTrapVirtM & VirtModeW & (PrivilegeModeW == P.U_MODE);
     assign VSWfiFault = WFIShouldTrapVirtM & VirtModeW & (PrivilegeModeW == P.S_MODE) & HSTATUS_VTW;
@@ -184,9 +186,10 @@ module privdec import cvw::*;  #(parameter cvw_t P) (
                                 HLVHSVFault | VUWfiFault | VSWfiFault | VUSupFault;
   end else begin: novirtinstr
     assign VirtualInstrFaultM = 1'b0;
+    assign HLVHSVIllegalM = 1'b0;
   end
 
   // Prevent double-reporting. If it's Virtual, it's not Illegal.
   assign IllegalInstrFaultM = (IllegalIEUFPUInstrM | IllegalPrivilegedInstrM | IllegalCSRAccessM |
-                               WFITimeoutM) & ~VirtualInstrFaultM;
+                               HLVHSVIllegalM | WFITimeoutM) & ~VirtualInstrFaultM;
 endmodule

--- a/src/privileged/privileged.sv
+++ b/src/privileged/privileged.sv
@@ -84,6 +84,7 @@ module privileged import cvw::*;  #(parameter cvw_t P) (
   output logic [P.XLEN-1:0] SATP_REGW,                                      // supervisor address translation register
   output logic              STATUS_MXR, STATUS_SUM, STATUS_MPRV,            // status register bits
   output logic [1:0]        STATUS_MPP, STATUS_FS,                          // status register bits
+  output logic              HSTATUS_SPVP,                                   // HLV/HLVX/HSV effective privilege
   output var logic [7:0]    PMPCFG_ARRAY_REGW[P.PMP_ENTRIES-1:0],           // PMP configuration entries to MMU
   output var logic [P.PA_BITS-3:0] PMPADDR_ARRAY_REGW [P.PMP_ENTRIES-1:0],  // PMP address entries to MMU
   output logic [2:0]        FRM_REGW,                                       // FPU rounding mode
@@ -96,6 +97,7 @@ module privileged import cvw::*;  #(parameter cvw_t P) (
   // control outputs
   output logic              RetM, TrapM,                                    // return instruction, or trap
   output logic              sfencevmaM,                                     // sfence.vma instruction
+  output logic              HLVHSVLegalM,                                   // HLV/HLVX/HSV may issue its LSU access
   input  logic              InvalidateICacheM,                              // fence instruction
   output logic              BigEndianM,                                     // Use big endian in current privilege mode
   // Fault outputs
@@ -135,8 +137,11 @@ module privileged import cvw::*;  #(parameter cvw_t P) (
   logic                     MSTATUS_MPV;     // from CSR (prev V for MRET)
   logic                     HSTATUS_SPV;     // from CSR (prev V for SRET in HS)
   logic                     HSTATUS_VTSR, HSTATUS_VTW, HSTATUS_VTVM, HSTATUS_HU;
+  logic                     HLVHSVBareM;     // VSATP/HGATP both Bare for initial HLV/HSV path
   logic                     VSSTATUS_SPP, VSSTATUS_SIE;
   logic                     TrapToM, TrapToHSM, TrapToVSM; // trap target one-hots
+  assign HLVHSVLegalM = P.H_SUPPORTED & HLVHSVInstrM & ~VirtModeW & HLVHSVBareM &
+                        ((PrivilegeModeW != P.U_MODE) | HSTATUS_HU);
 
   // track the current privilege level
   privmode #(P) privmode(.clk, .reset, .StallW, .TrapM, .mretM, .sretM, .DelegateM,
@@ -147,7 +152,7 @@ module privileged import cvw::*;  #(parameter cvw_t P) (
   logic VirtualInstrFaultM;
   privdec #(P) pmd(.clk, .reset, .StallW, .FlushW, .InstrM(InstrM[31:7]),
     .PrivilegedM, .IllegalIEUFPUInstrM, .IllegalCSRAccessM, .VirtualCSRAccessM, .VirtualCMOInstrM, .HLVHSVInstrM,
-    .PrivilegeModeW, .VirtModeW, .STATUS_TSR, .STATUS_TVM, .STATUS_TW,
+    .HLVHSVBareM, .PrivilegeModeW, .VirtModeW, .STATUS_TSR, .STATUS_TVM, .STATUS_TW,
     .HSTATUS_VTSR, .HSTATUS_VTVM, .HSTATUS_VTW, .HSTATUS_HU, .IllegalInstrFaultM, .VirtualInstrFaultM,
     .EcallFaultM, .BreakpointFaultM, .sretM, .mretM, .RetM, .wfiM, .wfiW, .sfencevmaM);
 
@@ -160,15 +165,15 @@ module privileged import cvw::*;  #(parameter cvw_t P) (
     .BPDirWrongM, .BTAWrongM, .RASPredPCWrongM, .BPWrongM,
     .sfencevmaM, .ExceptionM, .InvalidateICacheM, .ICacheStallF, .DCacheStallM, .DivBusyE, .FDivBusyE,
     .IClassWrongM, .IClassM, .DCacheMiss, .DCacheAccess, .ICacheMiss, .ICacheAccess,
-    .NextPrivilegeModeM, .PrivilegeModeW, .VirtModeW, .CauseM, .SelHPTW,
+    .NextPrivilegeModeM, .PrivilegeModeW, .VirtModeW, .HLVHSVLegalM, .CauseM, .SelHPTW,
     .STATUS_MPP, .MSTATUS_MPV, .STATUS_SPP, .STATUS_TSR, .STATUS_TVM,
     .STATUS_MIE, .STATUS_SIE, .STATUS_MXR, .STATUS_SUM, .STATUS_MPRV, .STATUS_TW, .STATUS_FS,
-    .HSTATUS_SPV, .HSTATUS_VTSR, .HSTATUS_VTW, .HSTATUS_VTVM, .HSTATUS_HU, .VSSTATUS_SPP, .VSSTATUS_SIE,
+    .HSTATUS_SPV, .HSTATUS_SPVP, .HSTATUS_VTSR, .HSTATUS_VTW, .HSTATUS_VTVM, .HSTATUS_HU, .VSSTATUS_SPP, .VSSTATUS_SIE,
     .MEDELEG_REGW, .HEDELEG_REGW, .HIDELEG_REGW, .HIE_REGW, .HGEIE_REGW, .MIP_REGW, .MIE_REGW, .MIDELEG_REGW,
     .SATP_REGW, .PMPCFG_ARRAY_REGW, .PMPADDR_ARRAY_REGW,
     .SetFflagsM, .FRM_REGW, .ENVCFG_CBE, .ENVCFG_PBMTE, .ENVCFG_ADUE,
     .EPCM, .TrapVectorM,
-    .CSRReadValW, .IllegalCSRAccessM, .VirtualCSRAccessM, .VirtualCMOInstrM, .BigEndianM);
+    .CSRReadValW, .IllegalCSRAccessM, .VirtualCSRAccessM, .VirtualCMOInstrM, .HLVHSVBareM, .BigEndianM);
 
   // pipeline early-arriving trap sources
   privpiperegs ppr(.clk, .reset, .StallD, .StallE, .StallM, .FlushD, .FlushE, .FlushM,

--- a/src/wally/wallypipelinedcore.sv
+++ b/src/wally/wallypipelinedcore.sv
@@ -89,6 +89,8 @@ module wallypipelinedcore import cvw::*; #(parameter cvw_t P) (
   logic [3:0]                    CMOpM;                           // 1: cbo.inval; 2: cbo.flush; 4: cbo.clean; 8: cbo.zero
   logic                          IFUPrefetchE, LSUPrefetchM;      // instruction / data prefetch hints
   logic                          HLVHSVInstrM;                    // Valid HLV/HLVX/HSV encoding in Memory stage
+  logic                          HLVHSVLegalM;                    // HLV/HLVX/HSV may issue its LSU access
+  logic                          HSTATUS_SPVP;                    // HLV/HLVX/HSV effective privilege
 
   // floating point unit signals
   logic [2:0]                    FRM_REGW;
@@ -224,7 +226,7 @@ module wallypipelinedcore import cvw::*; #(parameter cvw_t P) (
   lsu #(P) lsu(
     .clk, .reset, .StallM, .FlushM, .StallW, .FlushW,
     // CPU interface
-    .MemRWE, .MemRWM, .Funct3M, .Funct7M(InstrM[31:25]), .AtomicM,
+    .MemRWE, .MemRWM, .Funct3M, .Funct7M(InstrM[31:25]), .AtomicM, .HLVHSVInstrM, .HLVHSVLegalM,
     .CommittedM, .DCacheMiss, .DCacheAccess, .SquashSCW,
     .FpLoadStoreM, .FWriteDataM, .IEUAdrE, .IEUAdrM, .WriteDataM,
     .ReadDataW, .FlushDCacheM, .CMOpM, .LSUPrefetchM,
@@ -241,6 +243,7 @@ module wallypipelinedcore import cvw::*; #(parameter cvw_t P) (
     .STATUS_SUM,                  // from csr
     .STATUS_MPRV,                 // from csr
     .STATUS_MPP,                  // from csr
+    .HSTATUS_SPVP,                // from csr
     .ENVCFG_PBMTE,                // from csr
     .ENVCFG_ADUE,                 // from csr
     .sfencevmaM,                  // connects to privilege
@@ -307,6 +310,7 @@ module wallypipelinedcore import cvw::*; #(parameter cvw_t P) (
       .InstrAccessFaultF, .HPTWInstrAccessFaultF, .HPTWInstrPageFaultF, .LoadAccessFaultM, .StoreAmoAccessFaultM, .SelHPTW,
       .PrivilegeModeW, .SATP_REGW,
       .STATUS_MXR, .STATUS_SUM, .STATUS_MPRV, .STATUS_MPP, .STATUS_FS,
+      .HSTATUS_SPVP, .HLVHSVLegalM,
       .PMPCFG_ARRAY_REGW, .PMPADDR_ARRAY_REGW,
       .FRM_REGW, .ENVCFG_CBE, .ENVCFG_PBMTE, .ENVCFG_ADUE, .wfiM, .IntPendingM, .BigEndianM);
   end else begin
@@ -315,7 +319,7 @@ module wallypipelinedcore import cvw::*; #(parameter cvw_t P) (
             // PMPCFG_ARRAY_REGW, PMPADDR_ARRAY_REGW,
             ENVCFG_CBE, ENVCFG_PBMTE, ENVCFG_ADUE,
             EPCM, TrapVectorM, RetM, TrapM,
-            sfencevmaM, BigEndianM, wfiM, IntPendingM} = '0;
+            sfencevmaM, HSTATUS_SPVP, HLVHSVLegalM, BigEndianM, wfiM, IntPendingM} = '0;
   end
 
   // multiply/divide unit

--- a/tests/coverage/README.md
+++ b/tests/coverage/README.md
@@ -1,67 +1,41 @@
 # Coverage Tests
 
-## Hypervisor Unit Tests
+## Hypervisor Coverage Tests
 
-`hypervisorUnitTests.S` is a targeted coverage test for the currently implemented parts of Wally's RISC-V Hypervisor extension support. It is intended to run on `rv64gch` against ImperasDV lockstep.
+The hypervisor coverage tests are targeted checks for the currently implemented
+parts of Wally's RISC-V Hypervisor extension support. They are intended to run
+on `rv64gch` against ImperasDV lockstep.
 
-This is not a full H-extension architectural compliance test. In particular, it does not currently attempt a stable checked-in VS/VU execution test because the RTL still has incomplete guest execution and two-stage translation support.
+These are not full H-extension architectural compliance tests. In particular,
+the checked-in tests do not yet cover non-Bare two-stage translation, full guest
+page-fault plumbing, or stable VS/VU normal execution.
 
-### What It Tests
+<details>
+<summary>Common build and ImperasDV setup</summary>
 
-- Hypervisor CSR read/write and WARL behavior from M-mode:
-  - `mtinst`, `mtval2`
-  - `hstatus`, `hedeleg`, `mideleg`, `hideleg`, `hcounteren`, `hgeie`
-  - `htval`, `htinst`, `hgatp`
-  - `vsstatus`, `vstvec`, `vsscratch`, `vsepc`, `vscause`, `vstval`, `vsatp`
-
-- Hypervisor interrupt CSR aliasing:
-  - GEILEN=1 behavior for `hstatus.VGEIN`, `hgeie`, and `mideleg`.SGEI
-  - `hie` writes reflected in `mie`
-  - `vsie` writes reflected through delegated `hie`/`mie` bits
-  - `hip`, `hvip`, and `vsip` delegated virtual interrupt aliases
-
-- Timer and environment CSRs:
-  - `vstimecmp`
-  - `menvcfg` / `henvcfg`
-  - `htimedelta`
-
-- Read-only / illegal CSR behavior:
-  - `hgeip` write attempts trap as illegal; pending state is driven by the test MMIO source
-
-- HS-mode execution test:
-  - enters HS using the shared `WALLY-init-lib.h` ecall privilege-change helper
-  - executes `hfence.gvma x0, x0` in HS
-  - drives guest external interrupt 1 through the local TrickBox HGEIP source and checks HS-level SGEI delivery
-  - returns to M-mode and verifies a marker register to confirm the HS block ran
-
-- Hypervisor privileged instruction decode:
-  - legal `hfence.vvma x0, x0` in M-mode
-  - legal `hfence.gvma x0, x0` in M-mode
-  - illegal HFENCE-like encoding with nonzero `rd`, expecting `mcause = 2`
-
-### Known Limitations
-
-- VS/VU execution is not included yet. Earlier experiments could enter virtualized state but were not stable enough for this coverage test because guest execution, trap behavior, and two-stage translation support are still incomplete.
-- The test is primarily for implemented CSR behavior, RVVI/Imperas lockstep visibility, and privileged decode coverage.
-
-### Build
-
-From the repository root:
+Build an individual test from the repository root:
 
 ```sh
 source ./setup.sh
-make -C tests/coverage hypervisorUnitTests.elf hypervisorUnitTests.elf.objdump
+make -C tests/coverage <test>.elf <test>.elf.objdump
 ```
 
-Useful generated files:
+Run an individual test with ImperasDV lockstep:
 
-- `tests/coverage/hypervisorUnitTests.elf`
-- `tests/coverage/hypervisorUnitTests.elf.objdump`
-- `tests/coverage/hypervisorUnitTests.elf.memfile`
+```sh
+wsim rv64gch --elf tests/coverage/<test>.elf --lockstepverbose > <test>.log 2>&1
+```
 
-### Run With ImperasDV Lockstep
+A successful lockstep run should report:
 
-The active target configuration is `rv64gch`.
+```text
+Mismatches            : 0
+```
+
+The test should write `tohost = 1`, then stop at the normal coverage-test self
+loop / testbench stop point. If a self-check fails, these tests write
+`tohost = 3` with a store word so the testbench terminates instead of repeatedly
+writing `tohost`.
 
 The `rv64gch` ImperasDV run needs a local configuration file at:
 
@@ -69,13 +43,16 @@ The `rv64gch` ImperasDV run needs a local configuration file at:
 config/deriv/rv64gch/imperas.ic
 ```
 
-`config/deriv` is ignored by git, so first generate the derived configurations from the repository root:
+`config/deriv` is ignored by git, so first generate the derived configurations
+from the repository root:
 
 ```sh
 make deriv
 ```
 
-Then create the local Imperas config if needed. Copy and paste the contents of `config/rv64gc/imperas.ic` into `config/deriv/rv64gch/imperas.ic`, then make these edits:
+Then create the local Imperas config if needed. Copy and paste the contents of
+`config/rv64gc/imperas.ic` into `config/deriv/rv64gch/imperas.ic`, then make
+these edits:
 
 1. Change the variant line from `--variant RV64GCK` to `--variant RV64GCH`.
 2. Add `--override cpu/GEILEN=1`.
@@ -96,82 +73,218 @@ mkdir -p config/deriv/rv64gch
 touch config/deriv/rv64gch/imperas.ic
 ```
 
-Then paste in the contents from `config/rv64gc/imperas.ic` and make the edits above.
+Then paste in the contents from `config/rv64gc/imperas.ic` and make the edits
+above.
 
-From the repository root:
+</details>
+
+<details>
+<summary>hypervisorUnitTests.S</summary>
+
+`hypervisorUnitTests.S` is a broad unit test for implemented H-extension CSR,
+aliasing, interrupt CSR, and privileged decode behavior.
+
+What it tests:
+
+- Hypervisor CSR read/write and WARL behavior from M-mode:
+  - `mtinst`, `mtval2`
+  - `hstatus`, `hedeleg`, `mideleg`, `hideleg`, `hcounteren`, `hgeie`
+  - `htval`, `htinst`, `hgatp`
+  - `vsstatus`, `vstvec`, `vsscratch`, `vsepc`, `vscause`, `vstval`, `vsatp`
+- Hypervisor interrupt CSR aliasing:
+  - GEILEN=1 behavior for `hstatus.VGEIN`, `hgeie`, and `mideleg`.SGEI
+  - `hie` writes reflected in `mie`
+  - `vsie` writes reflected through delegated `hie`/`mie` bits
+  - `hip`, `hvip`, and `vsip` delegated virtual interrupt aliases
+- Timer and environment CSRs:
+  - `vstimecmp`
+  - `menvcfg` / `henvcfg`
+  - `htimedelta`
+- Read-only / illegal CSR behavior:
+  - `hgeip` write attempts trap as illegal; pending state is driven by the
+    test MMIO source
+- HS-mode execution:
+  - enters HS using the shared `WALLY-init-lib.h` ecall privilege-change helper
+  - executes `hfence.gvma x0, x0` in HS
+  - drives guest external interrupt 1 through the local TrickBox HGEIP source
+    and checks HS-level SGEI delivery
+  - returns to M-mode and verifies a marker register to confirm the HS block ran
+- Hypervisor privileged instruction decode:
+  - legal `hfence.vvma x0, x0` in M-mode
+  - legal `hfence.gvma x0, x0` in M-mode
+  - illegal HFENCE-like encoding with nonzero `rd`, expecting `mcause = 2`
+
+Known limitations:
+
+- VS/VU execution is not included yet. Earlier experiments could enter
+  virtualized state but were not stable enough for this coverage test because
+  guest execution, trap behavior, and two-stage translation support are still
+  incomplete.
+- The test is primarily for implemented CSR behavior, RVVI/Imperas lockstep
+  visibility, and privileged decode coverage.
+
+Build:
+
+```sh
+source ./setup.sh
+make -C tests/coverage hypervisorUnitTests.elf hypervisorUnitTests.elf.objdump
+```
+
+Run:
 
 ```sh
 wsim rv64gch --elf tests/coverage/hypervisorUnitTests.elf --lockstepverbose > hypervisorUnitTests.log 2>&1
 ```
 
-### Expected Successful Result
+Useful generated files:
 
-A successful lockstep run should report:
+- `tests/coverage/hypervisorUnitTests.elf`
+- `tests/coverage/hypervisorUnitTests.elf.objdump`
+- `tests/coverage/hypervisorUnitTests.elf.memfile`
 
-```text
-Mismatches            : 0
-```
+The guest-external interrupt check uses the CLINT-range TrickBox sidecar:
+`TRICKEN[6]` is written at `0x0200A010`, then HGEIP bit 1 is driven through the
+slot at `0x0200C000`.
 
-The test should write `tohost = 1`, then stop at the normal coverage-test self loop / testbench stop point.
-
-If a self-check fails, the test writes `tohost = 3` with a store word so the testbench terminates instead of repeatedly writing `tohost`.
-
-The guest-external interrupt check uses the CLINT-range TrickBox sidecar: `TRICKEN[6]` is written at `0x0200A010`, then HGEIP bit 1 is driven through the slot at `0x0200C000`.
-
-In `--lockstepverbose` output, the HS-mode test can be identified by the instruction trace around `hs_mode_entry`, where Imperas prints the privilege label as `Supervisor`:
+In `--lockstepverbose` output, the HS-mode test can be identified by the
+instruction trace around `hs_mode_entry`, where Imperas prints the privilege
+label as `Supervisor`:
 
 ```text
 0x000000008000545a(hs_mode_entry): Supervisor ...
 0x000000008000545e(hs_mode_entry+4): Supervisor 62000073 hfence.gvma x0,x0
 ```
 
-In this test context, `Supervisor` with virtualization mode `V=0` corresponds to HS-mode.
+In this test context, `Supervisor` with virtualization mode `V=0` corresponds
+to HS-mode.
 
-## Hypervisor Interrupt Tests
+</details>
 
-`hypervisorInterrupts.S` is a focused companion test for implemented H-extension interrupt behavior. It currently covers:
+<details>
+<summary>hypervisorInterrupts.S</summary>
 
-- `GEILEN=1` interrupt-visible CSR behavior for `hstatus.VGEIN`, `hgeie`, and read-only-one `mideleg`.SGEI
+`hypervisorInterrupts.S` is a focused companion test for implemented
+H-extension interrupt behavior.
+
+What it tests:
+
+- `GEILEN=1` interrupt-visible CSR behavior for `hstatus.VGEIN`, `hgeie`, and
+  read-only-one `mideleg`.SGEI
 - `hie` / `mie` aliasing for SGEIE and VS interrupt-enable bits
 - `vsie` delegated interrupt-enable aliasing
 - `hip`, `hvip`, and `vsip` delegated virtual interrupt-pending aliases
 - read-only `hgeip` CSR behavior
 - HS-mode delivery of software-injected VSSI, VSTI, and VSEI through `hvip`
-- HS-mode supervisor guest external interrupt delivery through the local TrickBox HGEIP source
+- HS-mode supervisor guest external interrupt delivery through the local
+  TrickBox HGEIP source
 
-Build it from the repository root with:
+Build:
 
 ```sh
 source ./setup.sh
 make -C tests/coverage hypervisorInterrupts.elf hypervisorInterrupts.elf.objdump
 ```
 
-Run it with ImperasDV lockstep using the same `rv64gch` setup described above:
+Run:
 
 ```sh
 wsim rv64gch --elf tests/coverage/hypervisorInterrupts.elf --lockstepverbose > hypervisorInterrupts.log 2>&1
 ```
 
-The same local ImperasDV `GEILEN=1` override and HGEIP TrickBox addresses described for `hypervisorUnitTests.S` apply to this test.
+The same local ImperasDV `GEILEN=1` override and HGEIP TrickBox addresses
+described for `hypervisorUnitTests.S` apply to this test.
 
-## Hypervisor Exception Tests
+</details>
 
-`hypervisorExceptions.S` is a focused companion test for hypervisor exception classification and trap CSR side effects. It currently covers:
+<details>
+<summary>hypervisorExceptions.S</summary>
 
-- VS-mode virtual-instruction traps for H CSR access, HFENCE, HLV, CBO/envcfg, SATP under `hstatus.VTVM`, and SRET under `hstatus.VTSR`
+`hypervisorExceptions.S` is a focused companion test for hypervisor exception
+classification and trap CSR side effects.
+
+What it tests:
+
+- VS-mode virtual-instruction traps for H CSR access, HFENCE, HLV,
+  CBO/envcfg, SATP under `hstatus.VTVM`, and SRET under `hstatus.VTSR`
 - `mtval` contents for those virtual-instruction traps
-- HS-mode illegal-instruction delegation for `hfence.gvma` when `mstatus.TVM=1`
+- HS-mode illegal-instruction delegation for `hfence.gvma` when
+  `mstatus.TVM=1`
 - `stval` contents for the delegated HS illegal-instruction trap
 
-Build it from the repository root with:
+Build:
 
 ```sh
 source ./setup.sh
 make -C tests/coverage hypervisorExceptions.elf hypervisorExceptions.elf.objdump
 ```
 
-Run it with ImperasDV lockstep using the same `rv64gch` setup described above:
+Run:
 
 ```sh
 wsim rv64gch --elf tests/coverage/hypervisorExceptions.elf --lockstepverbose > hypervisorExceptions.log 2>&1
 ```
+
+</details>
+
+<details>
+<summary>hypervisorLoadStore.S</summary>
+
+`hypervisorLoadStore.S` is a focused test for the implemented HLV, HLVX, and
+HSV execution path with both VS-stage and G-stage translation set to Bare. This
+matches the current first-pass RTL support for HLV/HLVX/HSV and intentionally
+avoids non-Bare guest translation behavior.
+
+Setup:
+
+- Clears `satp`, `vsatp`, and `hgatp`, so ordinary, VS-stage, and G-stage
+  translation are Bare.
+- Sets `hstatus.SPVP=1`, so HLV/HLVX/HSV use VS-level effective privilege.
+- Uses hand-encoded `.word` macros for HLV/HLVX/HSV so the test does not depend
+  on assembler mnemonic support.
+
+What it tests:
+
+- M-mode HLV and HLVX loads from one test doubleword:
+  - `hlv.b`
+  - `hlv.bu`
+  - `hlv.h`
+  - `hlv.hu`
+  - `hlv.w`
+  - `hlv.wu`
+  - `hlv.d`
+  - `hlvx.hu`
+  - `hlvx.wu`
+- M-mode HSV stores and ordinary load readback:
+  - `hsv.b`
+  - `hsv.h`
+  - `hsv.w`
+  - `hsv.d`
+- U-mode HLV/HSV execution when `hstatus.HU=1`:
+  - enters U-mode with the shared privilege-change helper
+  - executes `hlv.bu`
+  - executes `hsv.b`
+  - returns to M-mode and verifies the U-mode store updated memory
+
+Known limitations:
+
+- Non-Bare VS-stage and G-stage translation are not covered.
+- Guest-page-fault behavior and guest physical address reporting through
+  `mtval2` / `htval` are not covered.
+- `htinst` / `mtinst` trap transform behavior is not covered.
+- HLVX execute-permission behavior through page tables and PMP is not covered.
+- MPRV/MPV interactions for ordinary load/store instructions are not covered.
+
+Build:
+
+```sh
+source ./setup.sh
+make -C tests/coverage hypervisorLoadStore.elf hypervisorLoadStore.elf.objdump
+```
+
+Run:
+
+```sh
+wsim rv64gch --elf tests/coverage/hypervisorLoadStore.elf --lockstepverbose > hypervisorLoadStore.log 2>&1
+```
+
+</details>

--- a/tests/coverage/hypervisorLoadStore.S
+++ b/tests/coverage/hypervisorLoadStore.S
@@ -1,0 +1,198 @@
+///////////////////////////////////////////
+// hypervisorLoadStore.S
+//
+// Written: Neil Chulani nchulani@g.hmc.edu 6 May 2026
+//
+// Purpose: Unit tests for implemented hypervisor virtual-machine load/store
+//          behavior with VS-stage and G-stage translation both Bare.
+//
+// A component of the CORE-V-WALLY configurable RISC-V project.
+//
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+////////////////////////////////////////////////////////////////////////////////////////////////
+
+// load code to initialize stack, handle interrupts, terminate
+#include "WALLY-init-lib.h"
+
+.equ CSR_MSTATUS,       0x300
+.equ CSR_HSTATUS,       0x600
+.equ CSR_HGATP,         0x680
+.equ CSR_VSATP,         0x280
+.equ CSR_SATP,          0x180
+
+.equ MSTATUS_MPP_MASK,  0x0000000000001800
+.equ HSTATUS_SPVP,      0x0000000000000100
+.equ HSTATUS_HU,        0x0000000000000200
+
+.equ X_T0,              5
+.equ X_T1,              6
+.equ X_T2,              7
+
+.macro CHECK_EQ actual_reg, expect_val
+    li t6, \expect_val
+    bne \actual_reg, t6, fail
+.endm
+
+.macro HLV_B rd, rs1
+    .word 0x60004073 | (\rd << 7) | (\rs1 << 15)
+.endm
+
+.macro HLV_BU rd, rs1
+    .word 0x60104073 | (\rd << 7) | (\rs1 << 15)
+.endm
+
+.macro HLV_H rd, rs1
+    .word 0x64004073 | (\rd << 7) | (\rs1 << 15)
+.endm
+
+.macro HLV_HU rd, rs1
+    .word 0x64104073 | (\rd << 7) | (\rs1 << 15)
+.endm
+
+.macro HLV_W rd, rs1
+    .word 0x68004073 | (\rd << 7) | (\rs1 << 15)
+.endm
+
+.macro HLV_WU rd, rs1
+    .word 0x68104073 | (\rd << 7) | (\rs1 << 15)
+.endm
+
+.macro HLV_D rd, rs1
+    .word 0x6C004073 | (\rd << 7) | (\rs1 << 15)
+.endm
+
+.macro HLVX_HU rd, rs1
+    .word 0x64304073 | (\rd << 7) | (\rs1 << 15)
+.endm
+
+.macro HLVX_WU rd, rs1
+    .word 0x68304073 | (\rd << 7) | (\rs1 << 15)
+.endm
+
+.macro HSV_B rs1, rs2
+    .word 0x62004073 | (\rs1 << 15) | (\rs2 << 20)
+.endm
+
+.macro HSV_H rs1, rs2
+    .word 0x66004073 | (\rs1 << 15) | (\rs2 << 20)
+.endm
+
+.macro HSV_W rs1, rs2
+    .word 0x6A004073 | (\rs1 << 15) | (\rs2 << 20)
+.endm
+
+.macro HSV_D rs1, rs2
+    .word 0x6E004073 | (\rs1 << 15) | (\rs2 << 20)
+.endm
+
+main:
+    # The first RTL path intentionally covers the architecturally legal
+    # Bare/Bare case. Full two-stage translation coverage belongs with the
+    # later G-stage/VS-stage walker work.
+    csrw CSR_SATP, zero
+    csrw CSR_VSATP, zero
+    csrw CSR_HGATP, zero
+
+    # SPVP=1 makes HLV/HLVX/HSV accesses act as VS-level accesses per the H spec.
+    li t0, HSTATUS_SPVP
+    csrw CSR_HSTATUS, t0
+
+    la t1, hlsv_data
+
+    HLV_B X_T0, X_T1
+    CHECK_EQ t0, -128
+
+    HLV_BU X_T0, X_T1
+    CHECK_EQ t0, 0x80
+
+    HLV_H X_T0, X_T1
+    CHECK_EQ t0, 0xFFFFFFFFFFFF8080
+
+    HLV_HU X_T0, X_T1
+    CHECK_EQ t0, 0x8080
+
+    HLV_W X_T0, X_T1
+    CHECK_EQ t0, 0xFFFFFFFF81348080
+
+    HLV_WU X_T0, X_T1
+    CHECK_EQ t0, 0x81348080
+
+    HLV_D X_T0, X_T1
+    CHECK_EQ t0, 0x8877665581348080
+
+    HLVX_HU X_T0, X_T1
+    CHECK_EQ t0, 0x8080
+
+    HLVX_WU X_T0, X_T1
+    CHECK_EQ t0, 0x81348080
+
+    la t1, hlsv_store
+    sd zero, 0(t1)
+    li t0, 0xAA
+    HSV_B X_T1, X_T0
+    lbu t2, 0(t1)
+    CHECK_EQ t2, 0xAA
+
+    sd zero, 0(t1)
+    li t0, 0xBEEF
+    HSV_H X_T1, X_T0
+    lhu t2, 0(t1)
+    CHECK_EQ t2, 0xBEEF
+
+    sd zero, 0(t1)
+    li t0, 0x89ABCDEF
+    HSV_W X_T1, X_T0
+    lwu t2, 0(t1)
+    CHECK_EQ t2, 0x89ABCDEF
+
+    sd zero, 0(t1)
+    li t0, 0x0123456789ABCDEF
+    HSV_D X_T1, X_T0
+    ld t2, 0(t1)
+    CHECK_EQ t2, 0x0123456789ABCDEF
+
+    # HU=1 allows U-mode HLV/HLVX/HSV use in the same way as HS-mode.
+    li t0, HSTATUS_SPVP | HSTATUS_HU
+    csrw CSR_HSTATUS, t0
+    la t0, u_hlsv_entry
+    csrw mepc, t0
+    li t0, MSTATUS_MPP_MASK
+    csrc CSR_MSTATUS, t0
+    mret
+
+u_return_to_m:
+    la t1, hlsv_user_store
+    lbu t2, 0(t1)
+    CHECK_EQ t2, 0x5A
+
+    j done
+
+.align 4
+u_hlsv_entry:
+    la t1, hlsv_data
+    HLV_BU X_T2, X_T1
+    CHECK_EQ t2, 0x80
+
+    la t1, hlsv_user_store
+    li t0, 0x5A
+    HSV_B X_T1, X_T0
+
+    li a0, 3
+    ecall
+    j u_return_to_m
+
+fail:
+    la t1, tohost
+    li t0, 3
+    sw t0, 0(t1)
+fail_loop:
+    j fail_loop
+
+.section .data
+.align 3
+hlsv_data:
+    .dword 0x8877665581348080
+hlsv_store:
+    .dword 0
+hlsv_user_store:
+    .dword 0


### PR DESCRIPTION
- Enables basic hypervisor load/store instruction support for the implemented Bare/Bare translation case
- Adds ImperasDV lockstep coverage tests for the main HLV/HLVX/HSV load and store sizes, sign-extension behavior, and U-mode access through hstatus.HU.