### PR TITLE
cvwsoc: Fix on Wally PLIC.

### DIFF
--- a/src/uncore/plic_apb.sv
+++ b/src/uncore/plic_apb.sv
@@ -101,7 +101,7 @@ module plic_apb import cvw::*;  #(parameter cvw_t P) (
   // =======
 
   assign memwrite = PWRITE & PENABLE & PSEL;  // only write in access phase
-  assign memread  = ~PWRITE & PSEL;           // read at start of access phase.  PENABLE hasn't set up before this
+  assign memread  = ~PWRITE & PSEL & ~PENABLE; // read once, in APB setup phase
   assign PREADY   = 1'b1;                     // PLIC never takes >1 cycle to respond
   assign entry    = {PADDR[23:2],2'b0};
   assign One[P.PLIC_NUM_SRC-1:1] = '0; assign One[0] = 1'b1; // Vivado does not like this as a single assignment.
@@ -134,9 +134,13 @@ module plic_apb import cvw::*;  #(parameter cvw_t P) (
           PLIC_INTEN01:        if (P.PLIC_NUM_SRC >= 32) intEn[0][PLIC_SRC_TOP:PLIC_SRC_BOT]         <= Din[PLIC_SRC_DINTOP:0];
           PLIC_INTEN11:        if (P.PLIC_NUM_SRC >= 32) intEn[1][PLIC_SRC_TOP:PLIC_SRC_BOT]         <= Din[PLIC_SRC_DINTOP:0];
           PLIC_THRESHOLD0:     intThreshold[0]         <= Din[2:0];
-          PLIC_CLAIMCOMPLETE0: intInProgress           <= intInProgress & ~(One << (Din[5:0]-1)); // lower "InProgress" to signify completion
+          PLIC_CLAIMCOMPLETE0:
+            if (Din[5:0] != 6'd0)
+              intInProgress <= intInProgress & ~(One << (Din[5:0]-1)); // lower "InProgress" to signify completion
           PLIC_THRESHOLD1:     intThreshold[1]         <= Din[2:0];
-          PLIC_CLAIMCOMPLETE1: intInProgress           <= intInProgress & ~(One << (Din[5:0]-1)); // lower "InProgress" to signify completion
+          PLIC_CLAIMCOMPLETE1:
+            if (Din[5:0] != 6'd0)
+              intInProgress <= intInProgress & ~(One << (Din[5:0]-1)); // lower "InProgress" to signify completion
         endcase
 
       // Read synchronously because a read can have side effect of changing intInProgress
@@ -153,12 +157,14 @@ module plic_apb import cvw::*;  #(parameter cvw_t P) (
           PLIC_THRESHOLD0:   Dout <= {29'b0,intThreshold[0]};
           PLIC_CLAIMCOMPLETE0: begin
             Dout <= {26'b0,intClaim[0]};
-            intInProgress <= intInProgress | (One << (intClaim[0]-1)); // claimed requests are currently in progress of being serviced until they are completed
+            if (intClaim[0] != 6'd0) // not an invalid request
+              intInProgress <= intInProgress | (One << (intClaim[0]-1)); // claimed requests are currently in progress of being serviced until they are completed
           end
           PLIC_THRESHOLD1:   Dout <= {29'b0,intThreshold[1]};
           PLIC_CLAIMCOMPLETE1: begin
             Dout <= {26'b0,intClaim[1]};
-            intInProgress <= intInProgress | (One << (intClaim[1]-1)); // claimed requests are currently in progress of being serviced until they are completed
+            if (intClaim[1] != 6'd0) // not an invalid request
+              intInProgress <= intInProgress | (One << (intClaim[1]-1));  // claimed requests are currently in progress of being serviced until they are completed
           end
           default:           Dout <= 32'h0; // invalid access
         endcase


### PR DESCRIPTION
During long simulation with SDHCI SD card boot an issue was found with the PLIC. Linux would eventually print a trace like this:

[   17.088271] mmc0: Timeout waiting for hardware interrupt.
[   17.089596] mmc0: sdhci: ============ SDHCI REGISTER DUMP ===========
[   17.090858] mmc0: sdhci: Sys addr:  0x00000000 | Version:  0x00000000
[   17.092153] mmc0: sdhci: Blk size:  0x00000200 | Blk cnt:  0x0000002f
[   17.093458] mmc0: sdhci: Argument:  0x00013622 | Trn mode: 0x00000032
[   17.094762] mmc0: sdhci: Present:   0x010f0a06 | Host ctl: 0x00000002
[   17.096061] mmc0: sdhci: Power:     0x00000000 | Blk gap:  0x00000000
[   17.097356] mmc0: sdhci: Wake-up:   0x00000000 | Clock:    0x00000407
[   17.098655] mmc0: sdhci: Timeout:   0x0000000a | Int stat: 0x00000020
[   17.099948] mmc0: sdhci: Int enab:  0x007f00b3 | Sig enab: 0x007f00b3
[   17.101264] mmc0: sdhci: ACmd stat: 0x00000000 | Slot int: 0x00000001
[   17.102559] mmc0: sdhci: Caps:      0x010032b2 | Caps_1:   0x00000200
[   17.103866] mmc0: sdhci: Cmd:       0x0000123a | Max curr: 0x00000000
[   17.105175] mmc0: sdhci: Resp[0]:   0x00000920 | Resp[1]:  0x0000ff00
[   17.106482] mmc0: sdhci: Resp[2]:   0x32005900 | Resp[3]:  0x00400000
[   17.107793] mmc0: sdhci: Host ctl2: 0x00000000
[   17.108785] mmc0: sdhci: ============================================

But it was clear that interrupts were being received. After deeper debugging of the PLIC and SDHCI peripheral it was found that the interrupt was received but the system was in a state where it would not process the interrupt (CPU) but the PLIC was still waiting for processing to finish by the CPU.

This commit has two parts:
a) The fix: do the 'memread' processing only in APB setup phase 
b) Prevent certain PLIC ops with invalid values.

More details:
- This happened in a system with lots of interrupts due to SD card storage
- CPU starts reading PLIC claim register
- at almost the same time, AXIDummyIntr reasserts
- PLIC sees pending IRQ 16
- claim read side effect marks IRQ 16 as in-progress
- but Linux did not actually receive/handle claim ID 16

And the PLIC gets stuck in this state:
- AXIDummyIntr         = 1
- intInProgress[16]    = 1
- intPending[16]       = 0
- SExtInt              = 0