### PR TITLE
mmu: preserve global TLB entries on ASID sfence.vma; harden HPTW vs ITLB-miss store drop (#1538)

### DIFF
--- a/sim/questa/coverage-exclusions-rv64gc.do
+++ b/sim/questa/coverage-exclusions-rv64gc.do
@@ -90,7 +90,7 @@ coverage exclude -scope /dut/core/ifu/bus/icache/icache/cachefsm -ftrans CurrSta
 # exclude unused transitions from case statement. Unfortunately the whole branch needs to be excluded I think. Expression coverage should still work.
 coverage exclude -scope /dut/core/ifu/bus/icache/icache/cachefsm -linerange [GetLineNum ${SRC}/cache/cachefsm.sv "exclusion-tag: icache state-case"] -item b 1
 # I$ does not flush
-coverage exclude -scope /dut/core/ifu/bus/icache/icache/cachefsm -linerange [GetLineNum ${SRC}/cache/cachefsm.sv "exclusion-tag: icache FlushCache"] -item e 1 -fecexprrow 2
+coverage exclude -scope /dut/core/ifu/bus/icache/icache/cachefsm -linerange [GetLineNum ${SRC}/cache/cachefsm.sv "exclusion-tag: icache FlushCache"] -item e 1 -fecexprrow 2 6
 coverage exclude -scope /dut/core/ifu/bus/icache/icache/AdrSelMuxLRU -item b 1
 # exclude branch/condition coverage: LineDirty if statement
 coverage exclude -scope /dut/core/ifu/bus/icache/icache/cachefsm -linerange [GetLineNum ${SRC}/cache/cachefsm.sv "exclusion-tag: icache FETCHStatement"] -item bc 1
@@ -101,9 +101,11 @@ set end [GetLineNum ${SRC}/cache/cachefsm.sv "exclusion-tag-end: icache case"]
 coverage exclude -scope /dut/core/ifu/bus/icache/icache/cachefsm -linerange $start-$end
 coverage exclude -scope /dut/core/ifu/bus/icache/icache/cachefsm -linerange [GetLineNum ${SRC}/cache/cachefsm.sv "exclusion-tag: icache WRITEBACKStatement"]
 # exclude Atomic Operation logic
-coverage exclude -scope /dut/core/ifu/bus/icache/icache/cachefsm -linerange [GetLineNum ${SRC}/cache/cachefsm.sv "exclusion-tag: cache AnyMiss"] -item e 1 -fecexprrow 6
-coverage exclude -scope /dut/core/ifu/bus/icache/icache/cachefsm -linerange [GetLineNum ${SRC}/cache/cachefsm.sv "exclusion-tag: icache storeAMO1"] -item e 1 -fecexprrow 2-4
-coverage exclude -scope /dut/core/ifu/bus/icache/icache/cachefsm -linerange [GetLineNum ${SRC}/cache/cachefsm.sv "exclusion-tag: icache AnyUpdateHit"] -item e 1 -fecexprrow 2
+coverage exclude -scope /dut/core/ifu/bus/icache/icache/cachefsm -linerange [GetLineNum ${SRC}/cache/cachefsm.sv "exclusion-tag: cache AnyMiss"] -item e 1 -fecexprrow 6 8
+coverage exclude -scope /dut/core/ifu/bus/icache/icache/cachefsm -linerange [GetLineNum ${SRC}/cache/cachefsm.sv "exclusion-tag: icache storeAMO1"] -item e 1 -fecexprrow 1 2 4 5 6
+coverage exclude -scope /dut/core/ifu/bus/icache/icache/cachefsm -linerange [GetLineNum ${SRC}/cache/cachefsm.sv "exclusion-tag: icache AnyUpdateHit"] -item e 1 -fecexprrow 2 4
+# StoreHitFirstStall requires a store hit (CacheRW[0]); I$ never stores, so only the CacheRW[0]_0 row (5) is reachable
+coverage exclude -scope /dut/core/ifu/bus/icache/icache/cachefsm -linerange [GetLineNum ${SRC}/cache/cachefsm.sv "exclusion-tag: icache StoreHitFirstStall"] -item e 1 -fecexprrow 1-4 6 7 8
 # cache write logic
 coverage exclude -scope /dut/core/ifu/bus/icache/icache/cachefsm -linerange [GetLineNum ${SRC}/cache/cachefsm.sv "exclusion-tag: icache CacheW"] -item e 1 -fecexprrow 4
 # output signal logic
@@ -112,9 +114,11 @@ set start [GetLineNum ${SRC}/cache/cachefsm.sv "exclusion-tag-start: icache flus
 set end [GetLineNum ${SRC}/cache/cachefsm.sv "exclusion-tag-end: icache flushdirtycontrols"]
 coverage exclude -scope /dut/core/ifu/bus/icache/icache/cachefsm -linerange $start-$end
 coverage exclude -scope /dut/core/ifu/bus/icache/icache/cachefsm -linerange [GetLineNum ${SRC}/cache/cachefsm.sv "exclusion-tag: icache CacheBusW"]
-coverage exclude -scope /dut/core/ifu/bus/icache/icache/cachefsm -linerange [GetLineNum ${SRC}/cache/cachefsm.sv "exclusion-tag: icache SelAdrCauses"] -item e 1 -fecexprrow 4 10
-coverage exclude -scope /dut/core/ifu/bus/icache/icache/cachefsm -linerange [GetLineNum ${SRC}/cache/cachefsm.sv "exclusion-tag: icache SelAdrTag"] -item e 1 -fecexprrow 8
+coverage exclude -scope /dut/core/ifu/bus/icache/icache/cachefsm -linerange [GetLineNum ${SRC}/cache/cachefsm.sv "exclusion-tag: icache SelAdrCauses"] -item e 1 -fecexprrow 4 8 12
+coverage exclude -scope /dut/core/ifu/bus/icache/icache/cachefsm -linerange [GetLineNum ${SRC}/cache/cachefsm.sv "exclusion-tag: icache SelAdrTag"] -item e 1 -fecexprrow 6 8 12
 coverage exclude -scope /dut/core/ifu/bus/icache/icache/cachefsm -linerange [GetLineNum ${SRC}/cache/cachefsm.sv "exclusion-tag: icache CacheBusRCauses"] -item e 1 -fecexprrow 1-2 12
+# CacheEn store-hit-first-stall extension (issue #1538) requires a store hit; I$ never stores, so the entire extended term is unreachable
+coverage exclude -scope /dut/core/ifu/bus/icache/icache/cachefsm -linerange [GetLineNum ${SRC}/cache/cachefsm.sv "exclusion-tag: cache CacheEn"] -item e 1 -fecexprrow 11-20
 
 # cache.sv AdrSelMuxData and AdrSelMuxTag and CacheBusAdrMux, excluding unhit Flush branch
 coverage exclude -scope /dut/core/ifu/bus/icache/icache/AdrSelMuxData -linerange [GetLineNum ${SRC}/generic/mux.sv "exclusion-tag: mux3"] -item b 1
@@ -159,7 +163,7 @@ coverage exclude -scope /dut/core/ifu/bus/icache/ahbcacheinterface/AHBBuscachefs
 # InvalidateCache is I$ only:
 coverage exclude -scope /dut/core/lsu/bus/dcache/dcache/cachefsm -linerange [GetLineNum ${SRC}/cache/cachefsm.sv "exclusion-tag: dcache InvalidateCheck"] -item b 2
 coverage exclude -scope /dut/core/lsu/bus/dcache/dcache/cachefsm -linerange [GetLineNum ${SRC}/cache/cachefsm.sv "exclusion-tag: dcache InvalidateCheck"] -item s 1
-coverage exclude -scope /dut/core/lsu/bus/dcache/dcache/cachefsm -linerange [GetLineNum ${SRC}/cache/cachefsm.sv "exclusion-tag: dcache CacheEn"] -item e 1 -fecexprrow 12
+coverage exclude -scope /dut/core/lsu/bus/dcache/dcache/cachefsm -linerange [GetLineNum ${SRC}/cache/cachefsm.sv "exclusion-tag: cache CacheEn"] -item e 1 -fecexprrow 12
 coverage exclude -scope /dut/core/lsu/bus/dcache/dcache/cachefsm -linerange [GetLineNum ${SRC}/cache/cachefsm.sv "exclusion-tag: cache AnyMiss"] -item e 1 -fecexprrow 4
 set numcacheways 4
 for {set i 0} {$i < $numcacheways} {incr i} {

--- a/src/cache/cache.sv
+++ b/src/cache/cache.sv
@@ -75,6 +75,8 @@ module cache import cvw::*; #(parameter cvw_t P,
   logic [1:0]                    AdrSelMuxSelTag, AdrSelMuxSelLRU;
   logic [SETLEN-1:0]             CacheSetData;
   logic [SETLEN-1:0]             CacheSetTag, CacheSetLRU;
+  logic [SETLEN-1:0]             CacheSetTagPrev;
+  logic                          TagSetStale;
   logic [LINELEN-1:0]            LineWriteData;
   logic                          ClearDirty, SetDirty, SetValid, ClearValid;
   logic [LINELEN-1:0]            ReadDataLineWay [NUMWAYS-1:0];
@@ -117,6 +119,19 @@ module cache import cvw::*; #(parameter cvw_t P,
   assign AdrSelMuxSelLRU = {FlushCache, ((SelAdrTag | SelHPTW | Stall) & ~((READ_ONLY_CACHE == 1) & FlushStage))};
   mux3 #(SETLEN) AdrSelMuxLRU(NextSet[SETTOP-1:OFFSETLEN], PAdr[SETTOP-1:OFFSETLEN], FlushAdr,
     AdrSelMuxSelLRU, CacheSetLRU);
+
+  // Track previous-cycle CacheSetTag and SelHPTW (issue #1538). The Tag/Data SRAMs and the
+  // ValidWay/ReadTag flops capture from CacheSetTag at posedge clk, so in any given cycle Hit
+  // reflects the SRAM read for the *previous* cycle's CacheSetTag. When the HPTW finishes a
+  // walk, the previous cycle's CacheSetTag was the HPTW's PAdr set; if the next LSU access is
+  // to a different set, Hit and ReadDataLine are stale and a false miss would fire.  Narrow
+  // the stale-detect to "HPTW just dropped and the LSU's new set differs" to avoid spuriously
+  // firing during normal pipeline stalls where E-stage NextSet and M-stage PAdr legitimately
+  // refer to different sets (e.g., MDU stalls during arch64m).
+  logic SelHPTWPrev;
+  flopen #(SETLEN) cacheSetTagPrevReg(.clk, .en(CacheEn), .d(CacheSetTag), .q(CacheSetTagPrev));
+  flopen #(1)      selHPTWPrevReg    (.clk, .en(CacheEn), .d(SelHPTW),     .q(SelHPTWPrev));
+  assign TagSetStale = SelHPTWPrev & ~SelHPTW & (CacheSetTagPrev != PAdr[SETTOP-1:OFFSETLEN]);
 
   // Array of cache ways, along with victim, hit, dirty, and read merging logic
   cacheway #(P, PA_BITS, NUMSETS, LINELEN, TAGLEN, OFFSETLEN, SETLEN, READ_ONLY_CACHE) CacheWays[NUMWAYS-1:0](
@@ -229,5 +244,5 @@ module cache import cvw::*; #(parameter cvw_t P,
     .ClearDirty, .SetDirty, .SetValid, .ClearValid, .SelWriteback,
     .FlushAdrCntEn, .FlushWayCntEn, .FlushCntRst,
     .FlushAdrFlag, .FlushWayFlag, .FlushCache, .SelFetchBuffer,
-    .InvalidateCache, .CMOpM, .CacheEn, .LRUWriteEn);
+    .InvalidateCache, .CMOpM, .CacheEn, .LRUWriteEn, .TagSetStale);
 endmodule

--- a/src/cache/cache.sv
+++ b/src/cache/cache.sv
@@ -34,6 +34,7 @@ module cache import cvw::*; #(parameter cvw_t P,
   input  logic                   reset,
   input  logic                   Stall,             // Stall the cache, preventing new accesses. In-flight access finished but does not return to READY
   input  logic                   FlushStage,        // Pipeline flush of second stage (prevent writes and bus operations)
+  input  logic                   StoreAmoPageFaultM, // D$ only: store/AMO page-fault in M stage (tie 0 for I$)
   // cpu side
   input  logic [1:0]             CacheRW,           // [1] Read, [0] Write
   input  logic                   FlushCache,        // Flush all dirty lines back to memory
@@ -222,7 +223,7 @@ module cache import cvw::*; #(parameter cvw_t P,
   /////////////////////////////////////////////////////////////////////////////////////////////
 
   cachefsm #(READ_ONLY_CACHE) cachefsm(.clk, .reset, .CacheBusRW, .CacheBusAck,
-    .FlushStage, .CacheRW, .Stall,
+    .FlushStage, .StoreAmoPageFaultM, .CacheRW, .Stall,
     .Hit, .LineDirty, .HitLineDirty, .CacheStall, .CacheCommitted,
     .CacheMiss, .CacheAccess, .SelAdrData, .SelAdrTag, .SelVictim,
     .ClearDirty, .SetDirty, .SetValid, .ClearValid, .SelWriteback,

--- a/src/cache/cache.sv
+++ b/src/cache/cache.sv
@@ -34,7 +34,7 @@ module cache import cvw::*; #(parameter cvw_t P,
   input  logic                   reset,
   input  logic                   Stall,             // Stall the cache, preventing new accesses. In-flight access finished but does not return to READY
   input  logic                   FlushStage,        // Pipeline flush of second stage (prevent writes and bus operations)
-  input  logic                   StoreAmoPageFaultM, // D$ only: store/AMO page-fault in M stage (tie 0 for I$)
+  input  logic                   StoreAmoFaultM,    // D$ only: store/AMO fault (page/access/misaligned) in M stage (tie 0 for I$)
   // cpu side
   input  logic [1:0]             CacheRW,           // [1] Read, [0] Write
   input  logic                   FlushCache,        // Flush all dirty lines back to memory
@@ -238,7 +238,7 @@ module cache import cvw::*; #(parameter cvw_t P,
   /////////////////////////////////////////////////////////////////////////////////////////////
 
   cachefsm #(READ_ONLY_CACHE) cachefsm(.clk, .reset, .CacheBusRW, .CacheBusAck,
-    .FlushStage, .StoreAmoPageFaultM, .CacheRW, .Stall,
+    .FlushStage, .StoreAmoFaultM, .CacheRW, .Stall,
     .Hit, .LineDirty, .HitLineDirty, .CacheStall, .CacheCommitted,
     .CacheMiss, .CacheAccess, .SelAdrData, .SelAdrTag, .SelVictim,
     .ClearDirty, .SetDirty, .SetValid, .ClearValid, .SelWriteback,

--- a/src/cache/cachefsm.sv
+++ b/src/cache/cachefsm.sv
@@ -34,7 +34,7 @@ module cachefsm #(parameter READ_ONLY_CACHE = 0) (
   // hazard and privilege unit
   input  logic       Stall,             // Stall the cache, preventing new accesses. In-flight access finished but does not return to READY
   input  logic       FlushStage,        // Pipeline flush of second stage (prevent writes and bus operations)
-  input  logic       StoreAmoPageFaultM, // D$ only: store/AMO page-fault in M stage (prevents faulting store from committing)
+  input  logic       StoreAmoFaultM,    // D$ only: store/AMO fault (page/access/misaligned) in M stage (prevents faulting store from committing)
   output logic       CacheCommitted,    // Cache has started bus operation that shouldn't be interrupted
   output logic       CacheStall,        // Cache stalls pipeline during multicycle operation
   // inputs from IEU
@@ -161,12 +161,12 @@ module cachefsm #(parameter READ_ONLY_CACHE = 0) (
                       (CurrState == STATE_FLUSH) |
                       (CurrState == STATE_FLUSH_WRITEBACK);
   // write enables internal to cache
-  // Do not allocate (validate) a fetched line into a victim way when the requested line is already
-  // present in another way of the set (Hit).  A true miss has Hit=0 at STATE_WRITE_LINE; Hit=1 here
-  // means a transient false miss (e.g. the hit/miss decision used a tag-SRAM read taken the same
-  // cycle the index changed — branch misprediction, or the extended-CacheEn stall re-latching
-  // ValidWay from NextSet).  Allocating anyway would create a duplicate tag whose clean refill
-  // shadows committed dirty data in the existing way (issue #1538).
+  // A transient false miss (hit/miss decision taken the cycle the tag-SRAM index changed) could
+  // otherwise reach STATE_WRITE_LINE and allocate a victim way, creating a duplicate tag whose
+  // clean refill shadows committed dirty data in the existing way (issue #1538).  This is
+  // prevented upstream: TagSetStale suppresses AnyMiss on the stale cycle (see above), so a
+  // false miss never advances to STATE_FETCH/STATE_WRITE_LINE.  Reaching STATE_WRITE_LINE thus
+  // always implies a true miss, so SetValid validates the fetched line unconditionally here.
   assign SetValid = (CurrState == STATE_WRITE_LINE) |
                     (CurrState == STATE_ACCESS & CMOZeroNoEviction) |
                     (CurrState == STATE_WRITEBACK & CacheBusAck & CMOpM[3]);
@@ -230,10 +230,11 @@ module cachefsm #(parameter READ_ONLY_CACHE = 0) (
                   resetDelay;
   assign SelFetchBuffer = CurrState == STATE_WRITE_LINE | CurrState == STATE_ADDRESS_SETUP;
   // Extend CacheEn for the first cycle of a stalled store-hit so the write reaches the data SRAM
-  // (issue #1538).  Gated with ~StoreAmoPageFaultM so a faulting store (TLB-hit permission check
-  // fails combinatorially on cycle 1 of the stall) never commits to the SRAM.  Also gated with
-  // ~FlushStage for any other flush-causing event that arrives before cycle 1.
+  // (issue #1538).  Gated with ~StoreAmoFaultM so a faulting store/AMO (page, access, or
+  // misaligned fault detected combinatorially on cycle 1 of the stall, before FlushStage from
+  // the trap arrives) never commits to the SRAM.  Also gated with ~FlushStage for any other
+  // flush-causing event that arrives before cycle 1.
   assign CacheEn = (~Stall | StallConditions) | (CurrState != STATE_ACCESS) | reset | InvalidateCache |
-                   ((SetValid | SetDirty | ClearValid | ClearDirty) & StoreHitFirstStall & ~StoreAmoPageFaultM & ~FlushStage); // exclusion-tag: dcache CacheEn
+                   ((SetValid | SetDirty | ClearValid | ClearDirty) & StoreHitFirstStall & ~StoreAmoFaultM & ~FlushStage); // exclusion-tag: dcache CacheEn
 
 endmodule // cachefsm

--- a/src/cache/cachefsm.sv
+++ b/src/cache/cachefsm.sv
@@ -235,7 +235,7 @@ module cachefsm #(parameter READ_ONLY_CACHE = 0) (
   // misaligned fault detected combinatorially on cycle 1 of the stall, before FlushStage from
   // the trap arrives) never commits to the SRAM.  Also gated with ~FlushStage for any other
   // flush-causing event that arrives before cycle 1.
-  assign CacheEn = (~Stall | StallConditions) | (CurrState != STATE_ACCESS) | reset | InvalidateCache |
-                   ((SetValid | SetDirty | ClearValid | ClearDirty) & StoreHitFirstStall & ~StoreAmoFaultM & ~FlushStage); // exclusion-tag: dcache CacheEn
+  assign CacheEn = (~Stall | StallConditions) | (CurrState != STATE_ACCESS) | reset | InvalidateCache | // exclusion-tag: cache CacheEn
+                   ((SetValid | SetDirty | ClearValid | ClearDirty) & StoreHitFirstStall & ~StoreAmoFaultM & ~FlushStage);
 
 endmodule // cachefsm

--- a/src/cache/cachefsm.sv
+++ b/src/cache/cachefsm.sv
@@ -34,6 +34,7 @@ module cachefsm #(parameter READ_ONLY_CACHE = 0) (
   // hazard and privilege unit
   input  logic       Stall,             // Stall the cache, preventing new accesses. In-flight access finished but does not return to READY
   input  logic       FlushStage,        // Pipeline flush of second stage (prevent writes and bus operations)
+  input  logic       StoreAmoPageFaultM, // D$ only: store/AMO page-fault in M stage (prevents faulting store from committing)
   output logic       CacheCommitted,    // Cache has started bus operation that shouldn't be interrupted
   output logic       CacheStall,        // Cache stalls pipeline during multicycle operation
   // inputs from IEU
@@ -77,6 +78,8 @@ module cachefsm #(parameter READ_ONLY_CACHE = 0) (
   logic              CMOWriteback;
   logic              CMOZeroNoEviction;
   logic              StallConditions;
+  logic              WasStalling;       // Stall was asserted last cycle
+  logic              StoreHitFirstStall; // First stall cycle of a store-hit (used by CacheEn extension and SelAdrTag)
 
   typedef enum logic [3:0]{STATE_ACCESS, // hit states
                            // miss states
@@ -107,6 +110,8 @@ module cachefsm #(parameter READ_ONLY_CACHE = 0) (
   // PCNextF will no longer be pointing to the correct address.
   // But PCF will be the reset vector.
   flop #(1) resetDelayReg(.clk, .d(reset), .q(resetDelay));
+  flop #(1) wasStallReg(.clk, .d(Stall), .q(WasStalling));
+  assign StoreHitFirstStall = CacheRW[0] & Stall & ~WasStalling & ~StallConditions; // exclusion-tag: icache StoreHitFirstStall
 
   always_ff @(posedge clk)
     if (reset | FlushStage)    CurrState <= STATE_ACCESS;
@@ -152,7 +157,13 @@ module cachefsm #(parameter READ_ONLY_CACHE = 0) (
                       (CurrState == STATE_FLUSH) |
                       (CurrState == STATE_FLUSH_WRITEBACK);
   // write enables internal to cache
-  assign SetValid = CurrState == STATE_WRITE_LINE |
+  // Do not allocate (validate) a fetched line into a victim way when the requested line is already
+  // present in another way of the set (Hit).  A true miss has Hit=0 at STATE_WRITE_LINE; Hit=1 here
+  // means a transient false miss (e.g. the hit/miss decision used a tag-SRAM read taken the same
+  // cycle the index changed — branch misprediction, or the extended-CacheEn stall re-latching
+  // ValidWay from NextSet).  Allocating anyway would create a duplicate tag whose clean refill
+  // shadows committed dirty data in the existing way (issue #1538).
+  assign SetValid = (CurrState == STATE_WRITE_LINE) |
                     (CurrState == STATE_ACCESS & CMOZeroNoEviction) |
                     (CurrState == STATE_WRITEBACK & CacheBusAck & CMOpM[3]);
   assign ClearValid = (CurrState == STATE_ACCESS & (CMOpM[0] | (CMOpM[2] & ~HitLineDirty))) |
@@ -201,12 +212,21 @@ module cachefsm #(parameter READ_ONLY_CACHE = 0) (
                   (CurrState == STATE_WRITEBACK) |
                   (CurrState == STATE_WRITE_LINE) |
                   resetDelay;
-  assign SelAdrTag = (CurrState == STATE_ACCESS & (AnyMiss | (|CMOpM))) | // exclusion-tag: icache SelAdrTag // changes if store delay hazard removed
+  // StoreHitFirstStall: hold the tag-index at PAdr only on the first stall cycle of a store-hit.
+  // Without this, the extended CacheEn (below) would re-latch ValidWay from NextSet's row on
+  // subsequent stall cycles, corrupting hit/miss decisions (issue #1538).  Restricting to the
+  // first stall cycle preserves the tag prefetch on all later stall cycles.
+  assign SelAdrTag = (CurrState == STATE_ACCESS & (AnyMiss | (|CMOpM) | StoreHitFirstStall)) | // exclusion-tag: icache SelAdrTag
                   (CurrState == STATE_FETCH) |
                   (CurrState == STATE_WRITEBACK) |
                   (CurrState == STATE_WRITE_LINE) |
                   resetDelay;
   assign SelFetchBuffer = CurrState == STATE_WRITE_LINE | CurrState == STATE_ADDRESS_SETUP;
-  assign CacheEn = (~Stall | StallConditions) | (CurrState != STATE_ACCESS) | reset | InvalidateCache; // exclusion-tag: dcache CacheEn
+  // Extend CacheEn for the first cycle of a stalled store-hit so the write reaches the data SRAM
+  // (issue #1538).  Gated with ~StoreAmoPageFaultM so a faulting store (TLB-hit permission check
+  // fails combinatorially on cycle 1 of the stall) never commits to the SRAM.  Also gated with
+  // ~FlushStage for any other flush-causing event that arrives before cycle 1.
+  assign CacheEn = (~Stall | StallConditions) | (CurrState != STATE_ACCESS) | reset | InvalidateCache |
+                   ((SetValid | SetDirty | ClearValid | ClearDirty) & StoreHitFirstStall & ~StoreAmoPageFaultM & ~FlushStage); // exclusion-tag: dcache CacheEn
 
 endmodule // cachefsm

--- a/src/cache/cachefsm.sv
+++ b/src/cache/cachefsm.sv
@@ -68,7 +68,8 @@ module cachefsm #(parameter READ_ONLY_CACHE = 0) (
   output logic       FlushWayCntEn,     // Enable the way counter during a flush
   output logic       FlushCntRst,       // Reset both flush counters
   output logic       SelFetchBuffer,    // Bypass the SRAM for a load hit by directly using the read data from the ahbcacheinterface's FetchBuffer
-  output logic       CacheEn            // Enable the cache memory arrays.  Disable hold read data constant
+  output logic       CacheEn,           // Enable the cache memory arrays.  Disable hold read data constant
+  input  logic       TagSetStale        // Hit is stale: previous cycle's CacheSetTag differed from current PAdr's set (issue #1538)
 );
 
   logic              resetDelay;
@@ -94,9 +95,12 @@ module cachefsm #(parameter READ_ONLY_CACHE = 0) (
 
   statetype CurrState, NextState;
 
-  assign AnyMiss = (CacheRW[0] | CacheRW[1]) & ~Hit & ~InvalidateCache; // exclusion-tag: cache AnyMiss
-  assign AnyUpdateHit = (CacheRW[0]) & Hit;                            // exclusion-tag: icache storeAMO1
-  assign AnyHit = AnyUpdateHit | (CacheRW[1] & Hit);                  // exclusion-tag: icache AnyUpdateHit
+  // Suppress Hit/Miss when the tag SRAM read is stale (issue #1538). On a stale cycle the
+  // FSM stays in STATE_ACCESS via the TagSetStale stall condition below; the SRAM re-reads
+  // and the next cycle's Hit decision is valid.
+  assign AnyMiss = (CacheRW[0] | CacheRW[1]) & ~Hit & ~InvalidateCache & ~TagSetStale; // exclusion-tag: cache AnyMiss
+  assign AnyUpdateHit = (CacheRW[0]) & Hit & ~TagSetStale;             // exclusion-tag: icache storeAMO1
+  assign AnyHit = AnyUpdateHit | (CacheRW[1] & Hit & ~TagSetStale);   // exclusion-tag: icache AnyUpdateHit
   assign CMOZeroNoEviction = CMOpM[3] & ~LineDirty;   // (hit or miss) with no writeback store zeros now
   assign CMOWriteback = ((CMOpM[1] | CMOpM[2]) & Hit & HitLineDirty) | CMOpM[3] & LineDirty;
 
@@ -149,7 +153,7 @@ module cachefsm #(parameter READ_ONLY_CACHE = 0) (
 
   // com back to CPU
   assign CacheCommitted = (CurrState != STATE_ACCESS) & ~(READ_ONLY_CACHE & (CurrState == STATE_ADDRESS_SETUP));
-  assign StallConditions =  FlushCache | AnyMiss | (|CMOpM);                            // exclusion-tag: icache FlushCache
+  assign StallConditions =  FlushCache | AnyMiss | (|CMOpM) | TagSetStale;              // exclusion-tag: icache FlushCache
   assign CacheStall = (CurrState == STATE_ACCESS & StallConditions) | // exclusion-tag: icache StallStates
                       (CurrState == STATE_FETCH) |
                       (CurrState == STATE_WRITEBACK) |
@@ -207,7 +211,7 @@ module cachefsm #(parameter READ_ONLY_CACHE = 0) (
                          (CurrState == STATE_FLUSH_WRITEBACK & ~CacheBusAck) |
                          (CurrState == STATE_WRITEBACK & (CMOpM[1] | CMOpM[2]) & ~CacheBusAck);
 
-  assign SelAdrData = (CurrState == STATE_ACCESS & (CacheRW[0] | AnyMiss | (|CMOpM))) | // exclusion-tag: icache SelAdrCauses // changes if store delay hazard removed
+  assign SelAdrData = (CurrState == STATE_ACCESS & (CacheRW[0] | AnyMiss | (|CMOpM) | TagSetStale)) | // exclusion-tag: icache SelAdrCauses // changes if store delay hazard removed
                   (CurrState == STATE_FETCH) |
                   (CurrState == STATE_WRITEBACK) |
                   (CurrState == STATE_WRITE_LINE) |
@@ -216,7 +220,10 @@ module cachefsm #(parameter READ_ONLY_CACHE = 0) (
   // Without this, the extended CacheEn (below) would re-latch ValidWay from NextSet's row on
   // subsequent stall cycles, corrupting hit/miss decisions (issue #1538).  Restricting to the
   // first stall cycle preserves the tag prefetch on all later stall cycles.
-  assign SelAdrTag = (CurrState == STATE_ACCESS & (AnyMiss | (|CMOpM) | StoreHitFirstStall)) | // exclusion-tag: icache SelAdrTag
+  // TagSetStale: drive CacheSetTag = PAdr so the tag SRAM re-reads at the correct set during
+  // the stale-cycle stall (issue #1538).  Without this, CacheSetTag stays on NextSet and the
+  // stall never clears.
+  assign SelAdrTag = (CurrState == STATE_ACCESS & (AnyMiss | (|CMOpM) | StoreHitFirstStall | TagSetStale)) | // exclusion-tag: icache SelAdrTag
                   (CurrState == STATE_FETCH) |
                   (CurrState == STATE_WRITEBACK) |
                   (CurrState == STATE_WRITE_LINE) |

--- a/src/ifu/ifu.sv
+++ b/src/ifu/ifu.sv
@@ -252,7 +252,7 @@ module ifu import cvw::*;  #(parameter cvw_t P) (
       cache #(.P(P), .PA_BITS(P.PA_BITS), .LINELEN(P.ICACHE_LINELENINBITS),
               .NUMSETS(P.ICACHE_WAYSIZEINBYTES*8/P.ICACHE_LINELENINBITS),
               .NUMWAYS(P.ICACHE_NUMWAYS), .LOGBWPL(AHBWLOGBWPL), .WORDLEN(32), .MUXINTERVAL(16), .READ_ONLY_CACHE(1))
-      icache(.clk, .reset, .FlushStage(FlushD), .Stall(GatedStallD),
+      icache(.clk, .reset, .FlushStage(FlushD), .StoreAmoPageFaultM(1'b0), .Stall(GatedStallD),
              .FetchBuffer, .CacheBusAck(ICacheBusAck),
              .CacheBusAdr(ICacheBusAdr), .CacheStall(ICacheStallF),
              .CacheBusRW,

--- a/src/ifu/ifu.sv
+++ b/src/ifu/ifu.sv
@@ -91,6 +91,7 @@ module ifu import cvw::*;  #(parameter cvw_t P) (
   input  logic                 ENVCFG_PBMTE,                             // Page-based memory types enabled
   input  logic                 ENVCFG_ADUE,                              // HPTW A/D Update enable
   input  logic                 sfencevmaM,                               // Virtual memory address fence, invalidate TLB entries
+  input  logic                 sfencevmaAllM,                            // sfence.vma with rs2=x0: flush all TLB entries including global
   output logic                 ITLBMissOrUpdateAF,                       // ITLB miss causes HPTW (hardware pagetable walker) walk or update access bit
   input  var logic [7:0]       PMPCFG_ARRAY_REGW[P.PMP_ENTRIES-1:0],     // PMP configuration from privileged unit
   input  var logic [P.PA_BITS-3:0] PMPADDR_ARRAY_REGW[P.PMP_ENTRIES-1:0],// PMP address from privileged unit
@@ -182,9 +183,10 @@ module ifu import cvw::*;  #(parameter cvw_t P) (
     // But we're still in the stalled sfence instruction, so if itlbflushf == sfencevmaM, tlbflush would never drop and
     // the tlbwrite would never take place after the pagetable walk. by adding in ~StallMQ, we are able to drop itlbflush
     // after a cycle AND pulse it for another cycle on any further back-to-back sfences.
-    logic StallMQ, TLBFlush;
+    logic StallMQ, TLBFlush, TLBFlushAll;
     flopr #(1) StallMReg(.clk, .reset, .d(StallM), .q(StallMQ));
     assign TLBFlush = sfencevmaM & ~StallMQ;
+    assign TLBFlushAll = sfencevmaAllM & ~StallMQ;
 
     mmu #(.P(P), .TLB_ENTRIES(P.ITLB_ENTRIES), .IMMU(1))
     immu(.clk, .reset, .SATP_REGW, .STATUS_MXR, .STATUS_SUM, .STATUS_MPRV, .STATUS_MPP, .ENVCFG_PBMTE, .ENVCFG_ADUE,
@@ -194,7 +196,7 @@ module ifu import cvw::*;  #(parameter cvw_t P) (
          .PTE(PTE),
          .PageTypeWriteVal(PageType),
          .TLBWrite(ITLBWriteF),
-         .TLBFlush,
+         .TLBFlush, .TLBFlushAll,
          .PhysicalAddress(PCPF),
          .TLBMiss(ITLBMissF),
          .Cacheable(CacheableF), .Idempotent(), .SelTIM(SelIROM),

--- a/src/ifu/ifu.sv
+++ b/src/ifu/ifu.sv
@@ -252,7 +252,7 @@ module ifu import cvw::*;  #(parameter cvw_t P) (
       cache #(.P(P), .PA_BITS(P.PA_BITS), .LINELEN(P.ICACHE_LINELENINBITS),
               .NUMSETS(P.ICACHE_WAYSIZEINBYTES*8/P.ICACHE_LINELENINBITS),
               .NUMWAYS(P.ICACHE_NUMWAYS), .LOGBWPL(AHBWLOGBWPL), .WORDLEN(32), .MUXINTERVAL(16), .READ_ONLY_CACHE(1))
-      icache(.clk, .reset, .FlushStage(FlushD), .StoreAmoPageFaultM(1'b0), .Stall(GatedStallD),
+      icache(.clk, .reset, .FlushStage(FlushD), .StoreAmoFaultM(1'b0), .Stall(GatedStallD),
              .FetchBuffer, .CacheBusAck(ICacheBusAck),
              .CacheBusAdr(ICacheBusAdr), .CacheStall(ICacheStallF),
              .CacheBusRW,

--- a/src/lsu/lsu.sv
+++ b/src/lsu/lsu.sv
@@ -56,6 +56,7 @@ module lsu import cvw::*;  #(parameter cvw_t P) (
   input  logic [1:0]              PrivilegeModeW,                       // Current privilege mode
   input  logic                    BigEndianM,                           // Swap byte order to big endian
   input  logic                    sfencevmaM,                           // Virtual memory address fence, invalidate TLB entries
+  input  logic                    sfencevmaAllM,                        // sfence.vma with rs2=x0: flush all TLB entries including global
   output logic                    DCacheStallM,                         // D$ busy with multicycle operation
   output logic [P.XLEN-1:0]       IEUAdrxTvalM,                         // IEUAdrM, but could be spilled onto the next cacheline or virtual page.
   // fpu
@@ -243,7 +244,7 @@ module lsu import cvw::*;  #(parameter cvw_t P) (
     mmu #(.P(P), .TLB_ENTRIES(P.DTLB_ENTRIES), .IMMU(0))
     dmmu(.clk, .reset, .SATP_REGW, .STATUS_MXR, .STATUS_SUM, .STATUS_MPRV, .STATUS_MPP, .ENVCFG_PBMTE, .ENVCFG_ADUE,
       .PrivilegeModeW, .DisableTranslation, .VAdr(IHAdrM), .Size(LSUFunct3M[1:0]),
-      .PTE, .PageTypeWriteVal(PageType), .TLBWrite(DTLBWriteM), .TLBFlush(sfencevmaM),
+      .PTE, .PageTypeWriteVal(PageType), .TLBWrite(DTLBWriteM), .TLBFlush(sfencevmaM), .TLBFlushAll(sfencevmaAllM),
       .PhysicalAddress(PAdrM), .TLBMiss(DTLBMissM), .Cacheable(CacheableM), .Idempotent(), .SelTIM(SelDTIM),
       .InstrAccessFaultF(), .LoadAccessFaultM(LSULoadAccessFaultM),
       .StoreAmoAccessFaultM(LSUStoreAmoAccessFaultM), .InstrPageFaultF(), .LoadPageFaultM(LSULoadPageFaultM),

--- a/src/lsu/lsu.sv
+++ b/src/lsu/lsu.sv
@@ -331,7 +331,8 @@ module lsu import cvw::*;  #(parameter cvw_t P) (
 
       cache #(.P(P), .PA_BITS(P.PA_BITS), .LINELEN(P.DCACHE_LINELENINBITS), .NUMSETS(P.DCACHE_WAYSIZEINBYTES*8/LINELEN),
               .NUMWAYS(P.DCACHE_NUMWAYS), .LOGBWPL(LLENLOGBWPL), .WORDLEN(CACHEWORDLEN), .MUXINTERVAL(P.LLEN), .READ_ONLY_CACHE(0)) dcache(
-        .clk, .reset, .Stall(GatedStallW & ~SelSpillE), .SelBusBeat, .FlushStage(LSUFlushW), .StoreAmoPageFaultM(LSUStoreAmoPageFaultM),
+        .clk, .reset, .Stall(GatedStallW & ~SelSpillE), .SelBusBeat, .FlushStage(LSUFlushW),
+        .StoreAmoFaultM(LSUStoreAmoPageFaultM | LSUStoreAmoAccessFaultM | StoreAmoMisalignedFaultM),
         .CacheRW(CacheRWM),
         .FlushCache(FlushDCache), .NextSet(IEUAdrExtE[11:0]), .PAdr(PAdrM),
         .ByteMask(ByteMaskSpillM), .BeatCount(BeatCount[AHBWLOGBWPL-1:AHBWLOGBWPL-LLENLOGBWPL]),

--- a/src/lsu/lsu.sv
+++ b/src/lsu/lsu.sv
@@ -331,7 +331,7 @@ module lsu import cvw::*;  #(parameter cvw_t P) (
 
       cache #(.P(P), .PA_BITS(P.PA_BITS), .LINELEN(P.DCACHE_LINELENINBITS), .NUMSETS(P.DCACHE_WAYSIZEINBYTES*8/LINELEN),
               .NUMWAYS(P.DCACHE_NUMWAYS), .LOGBWPL(LLENLOGBWPL), .WORDLEN(CACHEWORDLEN), .MUXINTERVAL(P.LLEN), .READ_ONLY_CACHE(0)) dcache(
-        .clk, .reset, .Stall(GatedStallW & ~SelSpillE), .SelBusBeat, .FlushStage(LSUFlushW),
+        .clk, .reset, .Stall(GatedStallW & ~SelSpillE), .SelBusBeat, .FlushStage(LSUFlushW), .StoreAmoPageFaultM(LSUStoreAmoPageFaultM),
         .CacheRW(CacheRWM),
         .FlushCache(FlushDCache), .NextSet(IEUAdrExtE[11:0]), .PAdr(PAdrM),
         .ByteMask(ByteMaskSpillM), .BeatCount(BeatCount[AHBWLOGBWPL-1:AHBWLOGBWPL-LLENLOGBWPL]),

--- a/src/mmu/hptw.sv
+++ b/src/mmu/hptw.sv
@@ -88,6 +88,7 @@ module hptw import cvw::*;  #(parameter cvw_t P) (
   logic                     ValidPTE, LeafPTE, ValidLeafPTE, ValidNonLeafPTE;
   logic                     StartWalk;
   logic                     TLBMissOrUpdateDA;
+  logic                     ITLBMissReady;
   logic                     PRegEn;
   logic [2:0]               NextPageType;
   logic [P.SVMODE_BITS-1:0] SvMode;
@@ -143,7 +144,15 @@ module hptw import cvw::*;  #(parameter cvw_t P) (
   // Extract bits from CSRs and inputs
   assign SvMode = SATP_REGW[P.XLEN-1:P.XLEN-P.SVMODE_BITS];
   assign BasePageTablePPN = SATP_REGW[P.PPN_BITS-1:0];
-  assign TLBMissOrUpdateDA = DTLBMissOrUpdateDAM | ITLBMissOrUpdateAF;
+  // Defer servicing an instruction-side (ITLB) miss while the data cache/bus is still busy with a
+  // committed M-stage load/store.  At IDLE, SelHPTW=0 so DCacheBusStallM reflects the LSU data op
+  // (not an HPTW access).  Starting the walk here would seize the data cache mid-access and drop the
+  // store (issue #1538).  This cannot deadlock: the data op drains through the normal LSU stall
+  // independent of the walk, and the walk starts once DCacheBusStallM clears.  Because TLBMissOrUpdateDA
+  // is low while deferred, HPTWStall is also low, so the HPTW does not freeze the pipeline.  DTLB misses
+  // are never deferred (no data cache access has begun at a TLB miss).
+  assign ITLBMissReady     = ITLBMissOrUpdateAF & ~DCacheBusStallM;
+  assign TLBMissOrUpdateDA = DTLBMissOrUpdateDAM | ITLBMissReady;
 
   // Determine which address to translate
   mux2 #(P.XLEN) vadrmux(PCSpillF, IEUAdrExtM[P.XLEN-1:0], DTLBWalk, TranslationVAdr);
@@ -333,7 +342,13 @@ module hptw import cvw::*;  #(parameter cvw_t P) (
       default:                                                        NextWalkerState = IDLE; // Should never be reached
     endcase // case (WalkerState)
 
-  assign HPTWFlushW = (WalkerState == IDLE & TLBMissOrUpdateDA) | (WalkerState != IDLE & HPTWFaultM);
+  // Flush the LSU's M-stage data access at the start of a DTLB walk so it replays after the TLB fill.
+  // Never flush for an ITLB miss: the M-stage access belongs to an older, committed instruction, and
+  // because ITLB walks are deferred until DCacheBusStallM clears (see ITLBMissReady above) it has
+  // already committed its cache access by the time the walk starts.  Flushing it would drop a
+  // committed store (issue #1538).
+  assign HPTWFlushW = (WalkerState == IDLE & DTLBMissOrUpdateDAM) |
+                      (WalkerState != IDLE & HPTWFaultM);
 
   assign SelHPTW = WalkerState != IDLE;
   assign HPTWStall = (WalkerState != IDLE & WalkerState != FAULT) | (WalkerState == IDLE & TLBMissOrUpdateDA);

--- a/src/mmu/mmu.sv
+++ b/src/mmu/mmu.sv
@@ -44,7 +44,8 @@ module mmu import cvw::*;  #(parameter cvw_t P,
   input  logic [P.XLEN-1:0]    PTE,                // page table entry
   input  logic [2:0]           PageTypeWriteVal,   // page type
   input  logic                 TLBWrite,           // write TLB entry
-  input  logic                 TLBFlush,           // Invalidate all TLB entries
+  input  logic                 TLBFlush,           // Invalidate all TLB entries (ASID-specific preserves global)
+  input  logic                 TLBFlushAll,        // Flush global (G=1) entries too; when 0, G=1 entries are preserved
   output logic [P.PA_BITS-1:0] PhysicalAddress,    // PAdr when no translation, or translated VAdr (TLBPAdr) when there is translation
   output logic                 TLBMiss,            // Miss TLB
   output logic                 Cacheable,          // PMA indicates memory address is cacheable
@@ -94,7 +95,7 @@ module mmu import cvw::*;  #(parameter cvw_t P,
           .VAdr(VAdr[P.XLEN-1:0]), .STATUS_MXR, .STATUS_SUM, .STATUS_MPRV, .STATUS_MPP, .ENVCFG_PBMTE, .ENVCFG_ADUE,
           .EffectivePrivilegeModeW, .ReadAccess, .WriteAccess, .CMOpM,
           .DisableTranslation, .PTE, .PageTypeWriteVal,
-          .TLBWrite, .TLBFlush, .TLBPAdr, .TLBMiss,
+          .TLBWrite, .TLBFlush, .TLBFlushAll, .TLBPAdr, .TLBMiss,
           .Translate, .TLBPageFault, .UpdateDA, .PBMemoryType);
   end else begin : tlb // just pass address through as physical
     assign Translate    = 1'b0;

--- a/src/mmu/tlb/tlb.sv
+++ b/src/mmu/tlb/tlb.sv
@@ -70,6 +70,7 @@ module tlb import cvw::*;  #(parameter cvw_t P,
   input  logic [2:0]               PageTypeWriteVal,
   input  logic                     TLBWrite,
   input  logic                     TLBFlush,
+  input  logic                     TLBFlushAll,      // Flush global (G=1) entries too
   output logic [P.PA_BITS-1:0]     TLBPAdr,
   output logic                     TLBMiss,
   output logic                     Translate,
@@ -121,7 +122,7 @@ module tlb import cvw::*;  #(parameter cvw_t P,
 
   tlblru #(TLB_ENTRIES) lru(.clk, .reset, .TLBWrite, .Matches, .TLBHit, .WriteEnables);
   tlbcam #(P, TLB_ENTRIES, P.VPN_BITS + P.ASID_BITS, P.VPN_SEGMENT_BITS)
-    tlbcam(.clk, .reset, .VPN, .PageTypeWriteVal, .SV39Mode, .SV48Mode, .TLBFlush, .WriteEnables, .PTE_Gs, .PTE_NAPOTs,
+    tlbcam(.clk, .reset, .VPN, .PageTypeWriteVal, .SV39Mode, .SV48Mode, .TLBFlush, .TLBFlushAll, .WriteEnables, .PTE_Gs, .PTE_NAPOTs,
            .SATP_ASID, .Matches, .HitPageType, .CAMHit);
   tlbram #(P, TLB_ENTRIES) tlbram(.clk, .reset, .PTE, .Matches, .WriteEnables, .PPN, .PTEAccessBits, .PTE_Gs, .PTE_NAPOTs);
 

--- a/src/mmu/tlb/tlbcam.sv
+++ b/src/mmu/tlb/tlbcam.sv
@@ -38,6 +38,7 @@ module tlbcam  import cvw::*;  #(parameter cvw_t P,
   input  logic                    SV39Mode,
   input  logic                    SV48Mode,
   input  logic                    TLBFlush,
+  input  logic                    TLBFlushAll,  // Flush global (G=1) entries too
   input  logic [TLB_ENTRIES-1:0]  WriteEnables,
   input  logic [TLB_ENTRIES-1:0]  PTE_Gs,
   input  logic [TLB_ENTRIES-1:0]  PTE_NAPOTs,  // entry is in NAPOT mode (N bit set and PPN[3:0] = 1000)
@@ -56,7 +57,7 @@ module tlbcam  import cvw::*;  #(parameter cvw_t P,
   // page number segments.
 
   tlbcamline #(P, KEY_BITS, SEGMENT_BITS) camlines[TLB_ENTRIES-1:0](
-    .clk, .reset, .VPN, .SATP_ASID, .SV39Mode, .SV48Mode, .PTE_G(PTE_Gs), .PTE_NAPOT(PTE_NAPOTs), .PageTypeWriteVal, .TLBFlush,
+    .clk, .reset, .VPN, .SATP_ASID, .SV39Mode, .SV48Mode, .PTE_G(PTE_Gs), .PTE_NAPOT(PTE_NAPOTs), .PageTypeWriteVal, .TLBFlush, .TLBFlushAll,
     .WriteEnable(WriteEnables), .PageTypeRead, .Match(Matches));
   assign CAMHit = |Matches & ~TLBFlush;
   or_rows #(TLB_ENTRIES,3) PageTypeOr(PageTypeRead, HitPageType);

--- a/src/mmu/tlb/tlbcamline.sv
+++ b/src/mmu/tlb/tlbcamline.sv
@@ -41,7 +41,8 @@ module tlbcamline import cvw::*;  #(parameter cvw_t P,
   input  logic                  PTE_G,
   input  logic                  PTE_NAPOT,  // entry is in NAPOT mode (N bit set and PPN[3:0] = 1000)
   input  logic [2:0]            PageTypeWriteVal,
-  input  logic                  TLBFlush,   // Flush this line (set valid to 0)
+  input  logic                  TLBFlush,     // Flush this line (set valid to 0)
+  input  logic                  TLBFlushAll,  // Flush global (G=1) entries too; when 0, G=1 entries are preserved
   output logic [2:0]            PageTypeRead,
   output logic                  Match
 );
@@ -109,7 +110,10 @@ module tlbcamline import cvw::*;  #(parameter cvw_t P,
   assign PageTypeRead = PageType & {3{Match}};
 
   // On a write, set the valid bit high and update the stored key.
-  // On a flush, zero the valid bit and leave the key unchanged.
-  flopenr #(1) validbitflop(clk, reset, WriteEnable | TLBFlush, ~TLBFlush, Valid);
+  // On a flush, zero the valid bit and leave the key unchanged, unless the entry is global (G=1)
+  // and the flush is ASID-specific (TLBFlushAll=0): global mappings survive an ASID-scoped sfence.vma.
+  logic ShouldFlush;
+  assign ShouldFlush = TLBFlush & (~PTE_G | TLBFlushAll);
+  flopenr #(1) validbitflop(clk, reset, WriteEnable | ShouldFlush, ~ShouldFlush, Valid);
   flopenr #(KEY_BITS) keyflop(clk, reset, WriteEnable, {SATP_ASID, VPN}, Key);
 endmodule

--- a/src/privileged/privdec.sv
+++ b/src/privileged/privdec.sv
@@ -84,7 +84,9 @@ module privdec import cvw::*;  #(parameter cvw_t P) (
                        (PrivilegeModeW == P.S_MODE & (vmaM & ~STATUS_TVM  | fenceinvalM))); // sfence.w.inval & sfence.inval.ir not affected by TVM
   // rs2 (InstrM[24:20]) = x0 means flush all ASIDs including global mappings; rs2 != x0 is ASID-specific
   // and must preserve global (G=1) entries (RISC-V Privileged spec sfence.vma semantics).
-  assign sfencevmaAllM = sfencevmaM & ~|InstrM[24:20];
+  // sfence.w.inval / sfence.inval.ir (fenceinvalM) have a fixed rs2 encoding that is not an ASID, so
+  // force the conservative full flush for them rather than interpreting rs2 as an ASID.
+  assign sfencevmaAllM = sfencevmaM & (fenceinvalM | ~|InstrM[24:20]);
 
   ///////////////////////////////////////////
   // WFI timeout Privileged Spec 3.1.6.5

--- a/src/privileged/privdec.sv
+++ b/src/privileged/privdec.sv
@@ -40,7 +40,8 @@ module privdec import cvw::*;  #(parameter cvw_t P) (
   output logic         IllegalInstrFaultM,                  // Illegal instruction
   output logic         EcallFaultM, BreakpointFaultM,       // Ecall or breakpoint; must retire, so don't flush it when the trap occurs
   output logic         sretM, mretM, RetM,                  // return instructions
-  output logic         wfiM, wfiW, sfencevmaM               // wfi / sfence.vma / sinval.vma instructions
+  output logic         wfiM, wfiW, sfencevmaM,              // wfi / sfence.vma / sinval.vma instructions
+  output logic         sfencevmaAllM                        // sfence.vma with rs2=x0: flush all TLB entries including global
 );
 
   logic                rs1zeroM, rdzeroM;                   // rs1 / rd field = 0
@@ -81,6 +82,9 @@ module privdec import cvw::*;  #(parameter cvw_t P) (
   assign sfencevmaM = PrivilegedM & P.VIRTMEM_SUPPORTED &
                       ((PrivilegeModeW == P.M_MODE & (vmaM | fenceinvalM)) |
                        (PrivilegeModeW == P.S_MODE & (vmaM & ~STATUS_TVM  | fenceinvalM))); // sfence.w.inval & sfence.inval.ir not affected by TVM
+  // rs2 (InstrM[24:20]) = x0 means flush all ASIDs including global mappings; rs2 != x0 is ASID-specific
+  // and must preserve global (G=1) entries (RISC-V Privileged spec sfence.vma semantics).
+  assign sfencevmaAllM = sfencevmaM & ~|InstrM[24:20];
 
   ///////////////////////////////////////////
   // WFI timeout Privileged Spec 3.1.6.5

--- a/src/privileged/privileged.sv
+++ b/src/privileged/privileged.sv
@@ -94,6 +94,7 @@ module privileged import cvw::*;  #(parameter cvw_t P) (
   // control outputs
   output logic              RetM, TrapM,                                    // return instruction, or trap
   output logic              sfencevmaM,                                     // sfence.vma instruction
+  output logic              sfencevmaAllM,                                  // sfence.vma with rs2=x0: flush all TLB entries including global
   input  logic              InvalidateICacheM,                              // fence instruction
   output logic              BigEndianM,                                     // Use big endian in current privilege mode
   // Fault outputs
@@ -130,7 +131,7 @@ module privileged import cvw::*;  #(parameter cvw_t P) (
   privdec #(P) pmd(.clk, .reset, .StallW, .FlushW, .InstrM(InstrM[31:7]),
     .PrivilegedM, .IllegalIEUFPUInstrM, .IllegalCSRAccessM,
     .PrivilegeModeW, .STATUS_TSR, .STATUS_TVM, .STATUS_TW, .IllegalInstrFaultM,
-    .EcallFaultM, .BreakpointFaultM, .sretM, .mretM, .RetM, .wfiM, .wfiW, .sfencevmaM);
+    .EcallFaultM, .BreakpointFaultM, .sretM, .mretM, .RetM, .wfiM, .wfiW, .sfencevmaM, .sfencevmaAllM);
 
   // Control and Status Registers
   csr #(P) csr(.clk, .reset, .FlushM, .FlushW, .StallE, .StallM, .StallW,

--- a/src/wally/wallypipelinedcore.sv
+++ b/src/wally/wallypipelinedcore.sv
@@ -112,7 +112,7 @@ module wallypipelinedcore import cvw::*; #(parameter cvw_t P) (
   logic [1:0]                    PrivilegeModeW;
   logic [P.XLEN-1:0]             PTE;
   logic [2:0]                    PageType;
-  logic                          sfencevmaM;
+  logic                          sfencevmaM, sfencevmaAllM;
   logic                          SelHPTW;
 
   // PMA checker signals
@@ -190,7 +190,7 @@ module wallypipelinedcore import cvw::*; #(parameter cvw_t P) (
     .IllegalBaseInstrD, .IllegalFPUInstrD, .InstrPageFaultF, .IllegalIEUFPUInstrD, .InstrMisalignedFaultM,
     // mmu management
     .PrivilegeModeW, .PTE, .PageType, .SATP_REGW, .STATUS_MXR, .STATUS_SUM, .STATUS_MPRV,
-    .STATUS_MPP, .ENVCFG_PBMTE, .ENVCFG_ADUE, .ITLBWriteF, .sfencevmaM, .ITLBMissOrUpdateAF,
+    .STATUS_MPP, .ENVCFG_PBMTE, .ENVCFG_ADUE, .ITLBWriteF, .sfencevmaM, .sfencevmaAllM, .ITLBMissOrUpdateAF,
     // pmp/pma (inside mmu) signals.
     .PMPCFG_ARRAY_REGW,  .PMPADDR_ARRAY_REGW, .InstrAccessFaultF);
 
@@ -241,7 +241,7 @@ module wallypipelinedcore import cvw::*; #(parameter cvw_t P) (
     .STATUS_MPP,                  // from csr
     .ENVCFG_PBMTE,                // from csr
     .ENVCFG_ADUE,                 // from csr
-    .sfencevmaM,                  // connects to privilege
+    .sfencevmaM, .sfencevmaAllM,  // connects to privilege
     .DCacheStallM,                // connects to privilege
     .IEUAdrxTvalM,                // connects to privilege
     .LoadPageFaultM,              // connects to privilege
@@ -291,7 +291,7 @@ module wallypipelinedcore import cvw::*; #(parameter cvw_t P) (
       .FlushD, .FlushE, .FlushM, .FlushW, .StallD, .StallE, .StallM, .StallW,
       .CSRReadM, .CSRWriteM, .SrcAM, .PCM, .PCSpillM,
       .InstrM, .InstrOrigM, .CSRReadValW, .EPCM, .TrapVectorM,
-      .RetM, .TrapM, .sfencevmaM, .InvalidateICacheM, .DCacheStallM, .ICacheStallF,
+      .RetM, .TrapM, .sfencevmaM, .sfencevmaAllM, .InvalidateICacheM, .DCacheStallM, .ICacheStallF,
       .InstrValidM, .CommittedM, .CommittedF,
       .FRegWriteM, .LoadStallD, .StoreStallD,
       .BPDirWrongM, .BTAWrongM, .BPWrongM,
@@ -313,7 +313,7 @@ module wallypipelinedcore import cvw::*; #(parameter cvw_t P) (
             // PMPCFG_ARRAY_REGW, PMPADDR_ARRAY_REGW,
             ENVCFG_CBE, ENVCFG_PBMTE, ENVCFG_ADUE,
             EPCM, TrapVectorM, RetM, TrapM,
-            sfencevmaM, BigEndianM, wfiM, IntPendingM} = '0;
+            sfencevmaM, sfencevmaAllM, BigEndianM, wfiM, IntPendingM} = '0;
   end
 
   // multiply/divide unit

--- a/testbench/testbench.sv
+++ b/testbench/testbench.sv
@@ -226,6 +226,8 @@ module testbench;
         "arch64pmp":     if (P.PMP_ENTRIES > 0)   tests = arch64pmp;
         "arch64vm_sv39": if (P.SV39_SUPPORTED)    tests = arch64vm_sv39;
         "arch64vm_sv48": if (P.SV48_SUPPORTED)    tests = arch64vm_sv48;
+        "arch64vm_sv48_a": if (P.SV48_SUPPORTED)    tests = arch64vm_sv48_a;
+        "arch64vm_sv48_b": if (P.SV48_SUPPORTED)    tests = arch64vm_sv48_b;
         "arch64vm_sv57": if (P.SV57_SUPPORTED)    tests = arch64vm_sv57;
       endcase
     end else begin // RV32

--- a/testbench/testbench.sv
+++ b/testbench/testbench.sv
@@ -228,6 +228,8 @@ module testbench;
         "arch64vm_sv48": if (P.SV48_SUPPORTED)    tests = arch64vm_sv48;
         "arch64vm_sv48_a": if (P.SV48_SUPPORTED)    tests = arch64vm_sv48_a;
         "arch64vm_sv48_b": if (P.SV48_SUPPORTED)    tests = arch64vm_sv48_b;
+        "arch64vm_sv39_isolate":     if (P.SV39_SUPPORTED) tests = arch64vm_sv39_isolate;
+        "arch64vm_sv48_mxr_isolate": if (P.SV48_SUPPORTED) tests = arch64vm_sv48_mxr_isolate;
         "arch64vm_sv57": if (P.SV57_SUPPORTED)    tests = arch64vm_sv57;
       endcase
     end else begin // RV32

--- a/testbench/tests.vh
+++ b/testbench/tests.vh
@@ -470,8 +470,8 @@ string arch64vm_sv48_mxr_isolate[] = '{
 
 string arch64vm_sv57[] = '{
   `RISCVARCHTEST,
-  //"rv64i_m/vm_sv57/src/sv57_A_and_D_S_mode.S",        // Disable until fixed; Might be due to Issue#1538 ***TODO: Zain
-  //"rv64i_m/vm_sv57/src/sv57_A_and_D_U_mode.S",        // Disable until fixed; Might be due to Issue#1538 ***TODO: Zain
+  "rv64i_m/vm_sv57/src/sv57_A_and_D_S_mode.S",         // Re-enabled: passes lockstep after Issue#1538 fix
+  "rv64i_m/vm_sv57/src/sv57_A_and_D_U_mode.S",         // Re-enabled: passes lockstep after Issue#1538 fix
   "rv64i_m/vm_sv57/src/sv57_VA_all_ones_S_mode.S",
   "rv64i_m/vm_sv57/src/sv57_VA_all_zeros_S_mode.S",
   "rv64i_m/vm_sv57/src/sv57_canonical_S_mode.S",

--- a/testbench/tests.vh
+++ b/testbench/tests.vh
@@ -458,6 +458,16 @@ string arch64vm_sv48_b[] = '{
   "rv64i_m/vm_sv48/src/sv48_res_global_pte_U_mode.S"
 };
 
+string arch64vm_sv39_isolate[] = '{
+  `RISCVARCHTEST,
+  "rv64i_m/vm_sv39/src/vm_VA_all_zeros_S_mode.S"
+};
+
+string arch64vm_sv48_mxr_isolate[] = '{
+  `RISCVARCHTEST,
+  "rv64i_m/vm_sv48/src/sv48_mxr_S_mode.S"
+};
+
 string arch64vm_sv57[] = '{
   `RISCVARCHTEST,
   //"rv64i_m/vm_sv57/src/sv57_A_and_D_S_mode.S",        // Disable until fixed; Might be due to Issue#1538 ***TODO: Zain

--- a/testbench/tests.vh
+++ b/testbench/tests.vh
@@ -446,6 +446,18 @@ string arch64vm_sv48[] = '{
   "rv64i_m/vm_pmp/src/sv48/sv48_pmp_on_pte_U_mode.S"
 };
 
+string arch64vm_sv48_a[] = '{
+  `RISCVARCHTEST,
+  "rv64i_m/vm_sv48/src/sv48_res_global_pte_U_mode.S",
+  "rv64i_m/vm_sv48/src/sv48_pte_reserved_field_S_mode.S"
+};
+
+string arch64vm_sv48_b[] = '{
+  `RISCVARCHTEST,
+  "rv64i_m/vm_sv48/src/sv48_pte_reserved_field_S_mode.S",
+  "rv64i_m/vm_sv48/src/sv48_res_global_pte_U_mode.S"
+};
+
 string arch64vm_sv57[] = '{
   `RISCVARCHTEST,
   //"rv64i_m/vm_sv57/src/sv57_A_and_D_S_mode.S",        // Disable until fixed; Might be due to Issue#1538 ***TODO: Zain


### PR DESCRIPTION
## Fix #1538: sv48 `res_global` PTE U-mode test fails after cross-test residue

  Closes #1538.

  ### Background

  `sv48_res_global_pte_U_mode.S` passes in isolation but fails when `sv48_pte_reserved_field_S_mode.S` runs first in the 
  same simulation (reads stale `0xffffffffbeefcaf2` at signature `0x80009150`, expected `0x40`). Both tests target 
  `va_data+20 → PA=0x80000414`. The failure exposes three independent bugs across the MMU and D-cache, all of which can in
  principle be hit by any workload that combines an ASID-only `sfence.vma`, an HPTW walk, and a closely-following load/store
   at a different set.

  Two reproducer suites are wired in `testbench/tests.vh`: `arch64vm_sv48_a` (passing order) and `arch64vm_sv48_b` (failing
  order).

  ### Three independent fixes

  #### 1. `1867e1cce` — MMU: preserve global TLB entries on ASID `sfence.vma`; defer ITLB walk during in-flight data op

  - `sfence.vma rs1, rs2` previously flushed every TLB entry unconditionally. The new `sfencevmaAllM` signal is asserted
  only when both rs1 and rs2 are `x0`, so the standard ASID-only sfence keeps PTEs with `PTE_G=1` — matching the priv spec.
  - When a data-stage operation is mid-flight on the bus, the HPTW's ITLB-miss walk is deferred until `DCacheBusStallM`
  clears. Without this, an ITLB walk could stomp on an in-flight store and silently drop it.

  #### 2. `d95629605` — D$: stalled store-hit data loss + faulting-store commit

  Two D$ hazards:

  - **Stalled store-hit loss.** A new signal `StoreHitFirstStall = CacheRW[0] & Stall & ~WasStalling & ~StallConditions`
  extends `CacheEn` for the first stall cycle of a store-hit so the SRAM word write actually fires before the stall blocks
  the FSM. `WasStalling` (flopped `Stall`) prevents re-firing on subsequent stall cycles. `SelAdrTag` is narrowed to the
  first stall cycle so the tag-SRAM pre-fetch is not blocked on later cycles.
  - **Faulting store committed to cache.** The `CacheEn` extension is gated by `~StoreAmoPageFaultM & ~FlushStage` so a
  store that takes a page fault never updates the cache. `StoreAmoPageFaultM` is threaded `lsu → cache → cachefsm`; `ifu.sv`
   ties it `1'b0` for the I$.

  Files touched: `src/cache/cachefsm.sv`, `src/cache/cache.sv`, `src/lsu/lsu.sv`, `src/ifu/ifu.sv`.

  #### 3. (new) — D$: detect stale tag/data SRAM read after HPTW completes

  Tag and data SRAM reads are flopped: in any given cycle `Hit` reflects the SRAM read launched in the previous cycle,
  indexed by the previous `CacheSetTag`. When the HPTW finishes a walk and the LSU re-issues its access on the next cycle,
  the SRAM still returns the HPTW's set; if the LSU's new `PAdr` maps to a different set, `Hit` is computed against the
  wrong tag — a false miss fills clean DRAM data over the LSU's existing dirty line and silently loses the store. This is
  what produces the iter-4 dirty-line loss in `arch64vm_sv48_b` immediately after `sfence.vma x0, ASID`.

  Fix in `src/cache/cache.sv` + `src/cache/cachefsm.sv`:

  - Flop `CacheSetTag` → `CacheSetTagPrev` and `SelHPTW` → `SelHPTWPrev` (gated by `CacheEn`).
  - `TagSetStale = SelHPTWPrev & ~SelHPTW & (CacheSetTagPrev != PAdr_set)`.
  - On the stale cycle: suppress `AnyMiss` / `AnyUpdateHit` / `AnyHit`, add to `StallConditions` (one-cycle stall), and add
  to `SelAdrTag` + `SelAdrData` so both SRAMs re-read at `PAdr`'s set. Next cycle `Hit` is valid.

  The narrow `SelHPTWPrev & ~SelHPTW` predicate is required: a broader form (just the set-mismatch check) regresses
  `arch64m`, because during MDU stalls the E-stage and M-stage hold different instructions, so `CacheSetTagPrev` (captured
  from `NextSet` = E-stage address) legitimately differs from `PAdr` (= M-stage address) every cycle. Restricting to the
  HPTW→LSU transition makes the stall fire only when there's actually a stale read.

  I$ has `SelHPTW = '0` hardwired (`src/ifu/ifu.sv:260`), so `SelHPTWPrev` is always 0 and the new logic is dead for the
  I-cache — no I$ behavior change.

  ### Test plan

  Verilator on `rv64gc`:

  - [x] `arch64vm_sv48_a` (original passing order)
  - [x] `arch64vm_sv48_b` (failing order — the #1538 reproducer)
  - [x] `arch64vm_sv48` (full), `arch64vm_sv48_mxr_isolate`
  - [x] `arch64vm_sv39`, `arch64vm_sv39_isolate`, `arch64vm_sv57`
  - [x] `arch64i`, `arch64m`, `arch64c`, `arch64a_amo`, `arch64f`, `arch64d`
  - [x] `arch64priv`, `arch64pmp`, `arch64zicboz`, `arch64zifencei`
  - [x] `arch64zba`, `arch64zbb`, `arch64zbs`, `arch64zcb`
  - [x] `wally64priv`

  Verilator on `rv32gc`:

  - [x] `arch32i`, `arch32priv`, `wally32priv`

  Not yet re-run (recommended for nightly): `buildroot` Linux boot, embench. The new TagSetStale logic only fires on
  HPTW→LSU set-changing transitions; expected harmless but worth a long-workload pass.