### PR TITLE
Revert "mmu: preserve global TLB entries on ASID sfence.vma; harden HPTW vs ITLB-miss store drop (#1538)"

### DIFF
--- a/sim/questa/coverage-exclusions-rv64gc.do
+++ b/sim/questa/coverage-exclusions-rv64gc.do
@@ -90,7 +90,7 @@ coverage exclude -scope /dut/core/ifu/bus/icache/icache/cachefsm -ftrans CurrSta
 # exclude unused transitions from case statement. Unfortunately the whole branch needs to be excluded I think. Expression coverage should still work.
 coverage exclude -scope /dut/core/ifu/bus/icache/icache/cachefsm -linerange [GetLineNum ${SRC}/cache/cachefsm.sv "exclusion-tag: icache state-case"] -item b 1
 # I$ does not flush
-coverage exclude -scope /dut/core/ifu/bus/icache/icache/cachefsm -linerange [GetLineNum ${SRC}/cache/cachefsm.sv "exclusion-tag: icache FlushCache"] -item e 1 -fecexprrow 2 6
+coverage exclude -scope /dut/core/ifu/bus/icache/icache/cachefsm -linerange [GetLineNum ${SRC}/cache/cachefsm.sv "exclusion-tag: icache FlushCache"] -item e 1 -fecexprrow 2
 coverage exclude -scope /dut/core/ifu/bus/icache/icache/AdrSelMuxLRU -item b 1
 # exclude branch/condition coverage: LineDirty if statement
 coverage exclude -scope /dut/core/ifu/bus/icache/icache/cachefsm -linerange [GetLineNum ${SRC}/cache/cachefsm.sv "exclusion-tag: icache FETCHStatement"] -item bc 1
@@ -101,11 +101,9 @@ set end [GetLineNum ${SRC}/cache/cachefsm.sv "exclusion-tag-end: icache case"]
 coverage exclude -scope /dut/core/ifu/bus/icache/icache/cachefsm -linerange $start-$end
 coverage exclude -scope /dut/core/ifu/bus/icache/icache/cachefsm -linerange [GetLineNum ${SRC}/cache/cachefsm.sv "exclusion-tag: icache WRITEBACKStatement"]
 # exclude Atomic Operation logic
-coverage exclude -scope /dut/core/ifu/bus/icache/icache/cachefsm -linerange [GetLineNum ${SRC}/cache/cachefsm.sv "exclusion-tag: cache AnyMiss"] -item e 1 -fecexprrow 6 8
-coverage exclude -scope /dut/core/ifu/bus/icache/icache/cachefsm -linerange [GetLineNum ${SRC}/cache/cachefsm.sv "exclusion-tag: icache storeAMO1"] -item e 1 -fecexprrow 1 2 4 5 6
-coverage exclude -scope /dut/core/ifu/bus/icache/icache/cachefsm -linerange [GetLineNum ${SRC}/cache/cachefsm.sv "exclusion-tag: icache AnyUpdateHit"] -item e 1 -fecexprrow 2 4
-# StoreHitFirstStall requires a store hit (CacheRW[0]); I$ never stores, so only the CacheRW[0]_0 row (5) is reachable
-coverage exclude -scope /dut/core/ifu/bus/icache/icache/cachefsm -linerange [GetLineNum ${SRC}/cache/cachefsm.sv "exclusion-tag: icache StoreHitFirstStall"] -item e 1 -fecexprrow 1-4 6 7 8
+coverage exclude -scope /dut/core/ifu/bus/icache/icache/cachefsm -linerange [GetLineNum ${SRC}/cache/cachefsm.sv "exclusion-tag: cache AnyMiss"] -item e 1 -fecexprrow 6
+coverage exclude -scope /dut/core/ifu/bus/icache/icache/cachefsm -linerange [GetLineNum ${SRC}/cache/cachefsm.sv "exclusion-tag: icache storeAMO1"] -item e 1 -fecexprrow 2-4
+coverage exclude -scope /dut/core/ifu/bus/icache/icache/cachefsm -linerange [GetLineNum ${SRC}/cache/cachefsm.sv "exclusion-tag: icache AnyUpdateHit"] -item e 1 -fecexprrow 2
 # cache write logic
 coverage exclude -scope /dut/core/ifu/bus/icache/icache/cachefsm -linerange [GetLineNum ${SRC}/cache/cachefsm.sv "exclusion-tag: icache CacheW"] -item e 1 -fecexprrow 4
 # output signal logic
@@ -114,11 +112,9 @@ set start [GetLineNum ${SRC}/cache/cachefsm.sv "exclusion-tag-start: icache flus
 set end [GetLineNum ${SRC}/cache/cachefsm.sv "exclusion-tag-end: icache flushdirtycontrols"]
 coverage exclude -scope /dut/core/ifu/bus/icache/icache/cachefsm -linerange $start-$end
 coverage exclude -scope /dut/core/ifu/bus/icache/icache/cachefsm -linerange [GetLineNum ${SRC}/cache/cachefsm.sv "exclusion-tag: icache CacheBusW"]
-coverage exclude -scope /dut/core/ifu/bus/icache/icache/cachefsm -linerange [GetLineNum ${SRC}/cache/cachefsm.sv "exclusion-tag: icache SelAdrCauses"] -item e 1 -fecexprrow 4 8 12
-coverage exclude -scope /dut/core/ifu/bus/icache/icache/cachefsm -linerange [GetLineNum ${SRC}/cache/cachefsm.sv "exclusion-tag: icache SelAdrTag"] -item e 1 -fecexprrow 6 8 12
+coverage exclude -scope /dut/core/ifu/bus/icache/icache/cachefsm -linerange [GetLineNum ${SRC}/cache/cachefsm.sv "exclusion-tag: icache SelAdrCauses"] -item e 1 -fecexprrow 4 10
+coverage exclude -scope /dut/core/ifu/bus/icache/icache/cachefsm -linerange [GetLineNum ${SRC}/cache/cachefsm.sv "exclusion-tag: icache SelAdrTag"] -item e 1 -fecexprrow 8
 coverage exclude -scope /dut/core/ifu/bus/icache/icache/cachefsm -linerange [GetLineNum ${SRC}/cache/cachefsm.sv "exclusion-tag: icache CacheBusRCauses"] -item e 1 -fecexprrow 1-2 12
-# CacheEn store-hit-first-stall extension (issue #1538) requires a store hit; I$ never stores, so the entire extended term is unreachable
-coverage exclude -scope /dut/core/ifu/bus/icache/icache/cachefsm -linerange [GetLineNum ${SRC}/cache/cachefsm.sv "exclusion-tag: cache CacheEn"] -item e 1 -fecexprrow 11-20
 
 # cache.sv AdrSelMuxData and AdrSelMuxTag and CacheBusAdrMux, excluding unhit Flush branch
 coverage exclude -scope /dut/core/ifu/bus/icache/icache/AdrSelMuxData -linerange [GetLineNum ${SRC}/generic/mux.sv "exclusion-tag: mux3"] -item b 1
@@ -163,7 +159,7 @@ coverage exclude -scope /dut/core/ifu/bus/icache/ahbcacheinterface/AHBBuscachefs
 # InvalidateCache is I$ only:
 coverage exclude -scope /dut/core/lsu/bus/dcache/dcache/cachefsm -linerange [GetLineNum ${SRC}/cache/cachefsm.sv "exclusion-tag: dcache InvalidateCheck"] -item b 2
 coverage exclude -scope /dut/core/lsu/bus/dcache/dcache/cachefsm -linerange [GetLineNum ${SRC}/cache/cachefsm.sv "exclusion-tag: dcache InvalidateCheck"] -item s 1
-coverage exclude -scope /dut/core/lsu/bus/dcache/dcache/cachefsm -linerange [GetLineNum ${SRC}/cache/cachefsm.sv "exclusion-tag: cache CacheEn"] -item e 1 -fecexprrow 12
+coverage exclude -scope /dut/core/lsu/bus/dcache/dcache/cachefsm -linerange [GetLineNum ${SRC}/cache/cachefsm.sv "exclusion-tag: dcache CacheEn"] -item e 1 -fecexprrow 12
 coverage exclude -scope /dut/core/lsu/bus/dcache/dcache/cachefsm -linerange [GetLineNum ${SRC}/cache/cachefsm.sv "exclusion-tag: cache AnyMiss"] -item e 1 -fecexprrow 4
 set numcacheways 4
 for {set i 0} {$i < $numcacheways} {incr i} {

--- a/src/cache/cache.sv
+++ b/src/cache/cache.sv
@@ -34,7 +34,6 @@ module cache import cvw::*; #(parameter cvw_t P,
   input  logic                   reset,
   input  logic                   Stall,             // Stall the cache, preventing new accesses. In-flight access finished but does not return to READY
   input  logic                   FlushStage,        // Pipeline flush of second stage (prevent writes and bus operations)
-  input  logic                   StoreAmoFaultM,    // D$ only: store/AMO fault (page/access/misaligned) in M stage (tie 0 for I$)
   input  logic                   InvalidateFlushStage, // Pipeline flush of second stage (prevent writes and bus operations)
   // cpu side
   input  logic [1:0]             CacheRW,           // [1] Read, [0] Write
@@ -76,8 +75,6 @@ module cache import cvw::*; #(parameter cvw_t P,
   logic [1:0]                    AdrSelMuxSelTag, AdrSelMuxSelLRU;
   logic [SETLEN-1:0]             CacheSetData;
   logic [SETLEN-1:0]             CacheSetTag, CacheSetLRU;
-  logic [SETLEN-1:0]             CacheSetTagPrev;
-  logic                          TagSetStale;
   logic [LINELEN-1:0]            LineWriteData;
   logic                          ClearDirty, SetDirty, SetValid, ClearValid;
   logic [LINELEN-1:0]            ReadDataLineWay [NUMWAYS-1:0];
@@ -120,19 +117,6 @@ module cache import cvw::*; #(parameter cvw_t P,
   assign AdrSelMuxSelLRU = {FlushCache, ((SelAdrTag | SelHPTW | Stall) & ~((READ_ONLY_CACHE == 1) & FlushStage))};
   mux3 #(SETLEN) AdrSelMuxLRU(NextSet[SETTOP-1:OFFSETLEN], PAdr[SETTOP-1:OFFSETLEN], FlushAdr,
     AdrSelMuxSelLRU, CacheSetLRU);
-
-  // Track previous-cycle CacheSetTag and SelHPTW (issue #1538). The Tag/Data SRAMs and the
-  // ValidWay/ReadTag flops capture from CacheSetTag at posedge clk, so in any given cycle Hit
-  // reflects the SRAM read for the *previous* cycle's CacheSetTag. When the HPTW finishes a
-  // walk, the previous cycle's CacheSetTag was the HPTW's PAdr set; if the next LSU access is
-  // to a different set, Hit and ReadDataLine are stale and a false miss would fire.  Narrow
-  // the stale-detect to "HPTW just dropped and the LSU's new set differs" to avoid spuriously
-  // firing during normal pipeline stalls where E-stage NextSet and M-stage PAdr legitimately
-  // refer to different sets (e.g., MDU stalls during arch64m).
-  logic SelHPTWPrev;
-  flopen #(SETLEN) cacheSetTagPrevReg(.clk, .en(CacheEn), .d(CacheSetTag), .q(CacheSetTagPrev));
-  flopen #(1)      selHPTWPrevReg    (.clk, .en(CacheEn), .d(SelHPTW),     .q(SelHPTWPrev));
-  assign TagSetStale = SelHPTWPrev & ~SelHPTW & (CacheSetTagPrev != PAdr[SETTOP-1:OFFSETLEN]);
 
   // Array of cache ways, along with victim, hit, dirty, and read merging logic
   cacheway #(P, PA_BITS, NUMSETS, LINELEN, TAGLEN, OFFSETLEN, SETLEN, READ_ONLY_CACHE) CacheWays[NUMWAYS-1:0](
@@ -239,11 +223,11 @@ module cache import cvw::*; #(parameter cvw_t P,
   /////////////////////////////////////////////////////////////////////////////////////////////
 
   cachefsm #(READ_ONLY_CACHE) cachefsm(.clk, .reset, .CacheBusRW, .CacheBusAck,
-    .FlushStage, .StoreAmoFaultM, .InvalidateFlushStage, .CacheRW, .Stall,
+    .FlushStage, .InvalidateFlushStage, .CacheRW, .Stall,
     .Hit, .LineDirty, .HitLineDirty, .CacheStall, .CacheCommitted,
     .CacheMiss, .CacheAccess, .SelAdrData, .SelAdrTag, .SelVictim,
     .ClearDirty, .SetDirty, .SetValid, .ClearValid, .SelWriteback,
     .FlushAdrCntEn, .FlushWayCntEn, .FlushCntRst,
     .FlushAdrFlag, .FlushWayFlag, .FlushCache, .SelFetchBuffer,
-    .InvalidateCache, .CMOpM, .CacheEn, .LRUWriteEn, .TagSetStale);
+    .InvalidateCache, .CMOpM, .CacheEn, .LRUWriteEn);
 endmodule

--- a/src/cache/cachefsm.sv
+++ b/src/cache/cachefsm.sv
@@ -34,7 +34,6 @@ module cachefsm #(parameter READ_ONLY_CACHE = 0) (
   // hazard and privilege unit
   input  logic       Stall,             // Stall the cache, preventing new accesses. In-flight access finished but does not return to READY
   input  logic       FlushStage,        // Pipeline flush of second stage (prevent writes and bus operations)
-  input  logic       StoreAmoFaultM,    // D$ only: store/AMO fault (page/access/misaligned) in M stage (prevents faulting store from committing)
   input  logic       InvalidateFlushStage, // Pipeline flush of second stage (prevent writes and bus operations)
   output logic       CacheCommitted,    // Cache has started bus operation that shouldn't be interrupted
   output logic       CacheStall,        // Cache stalls pipeline during multicycle operation
@@ -69,8 +68,7 @@ module cachefsm #(parameter READ_ONLY_CACHE = 0) (
   output logic       FlushWayCntEn,     // Enable the way counter during a flush
   output logic       FlushCntRst,       // Reset both flush counters
   output logic       SelFetchBuffer,    // Bypass the SRAM for a load hit by directly using the read data from the ahbcacheinterface's FetchBuffer
-  output logic       CacheEn,           // Enable the cache memory arrays.  Disable hold read data constant
-  input  logic       TagSetStale        // Hit is stale: previous cycle's CacheSetTag differed from current PAdr's set (issue #1538)
+  output logic       CacheEn            // Enable the cache memory arrays.  Disable hold read data constant
 );
 
   logic              resetDelay;
@@ -80,8 +78,6 @@ module cachefsm #(parameter READ_ONLY_CACHE = 0) (
   logic              CMOWriteback;
   logic              CMOZeroNoEviction;
   logic              StallConditions;
-  logic              WasStalling;       // Stall was asserted last cycle
-  logic              StoreHitFirstStall; // First stall cycle of a store-hit (used by CacheEn extension and SelAdrTag)
 
   typedef enum logic [3:0]{STATE_ACCESS, // hit states
                            // miss states
@@ -96,12 +92,9 @@ module cachefsm #(parameter READ_ONLY_CACHE = 0) (
 
   statetype CurrState, NextState;
 
-  // Suppress Hit/Miss when the tag SRAM read is stale (issue #1538). On a stale cycle the
-  // FSM stays in STATE_ACCESS via the TagSetStale stall condition below; the SRAM re-reads
-  // and the next cycle's Hit decision is valid.
-  assign AnyMiss = (CacheRW[0] | CacheRW[1]) & ~Hit & ~InvalidateCache & ~TagSetStale; // exclusion-tag: cache AnyMiss
-  assign AnyUpdateHit = (CacheRW[0]) & Hit & ~TagSetStale;             // exclusion-tag: icache storeAMO1
-  assign AnyHit = AnyUpdateHit | (CacheRW[1] & Hit & ~TagSetStale);   // exclusion-tag: icache AnyUpdateHit
+  assign AnyMiss = (CacheRW[0] | CacheRW[1]) & ~Hit & ~InvalidateCache; // exclusion-tag: cache AnyMiss
+  assign AnyUpdateHit = (CacheRW[0]) & Hit;                            // exclusion-tag: icache storeAMO1
+  assign AnyHit = AnyUpdateHit | (CacheRW[1] & Hit);                  // exclusion-tag: icache AnyUpdateHit
   assign CMOZeroNoEviction = CMOpM[3] & ~LineDirty;   // (hit or miss) with no writeback store zeros now
   assign CMOWriteback = ((CMOpM[1] | CMOpM[2]) & Hit & HitLineDirty) | CMOpM[3] & LineDirty;
 
@@ -115,8 +108,6 @@ module cachefsm #(parameter READ_ONLY_CACHE = 0) (
   // PCNextF will no longer be pointing to the correct address.
   // But PCF will be the reset vector.
   flop #(1) resetDelayReg(.clk, .d(reset), .q(resetDelay));
-  flop #(1) wasStallReg(.clk, .d(Stall), .q(WasStalling));
-  assign StoreHitFirstStall = CacheRW[0] & Stall & ~WasStalling & ~StallConditions; // exclusion-tag: icache StoreHitFirstStall
 
   always_ff @(posedge clk)
     if (reset | FlushStage)    CurrState <= STATE_ACCESS;
@@ -154,7 +145,7 @@ module cachefsm #(parameter READ_ONLY_CACHE = 0) (
 
   // com back to CPU
   assign CacheCommitted = (CurrState != STATE_ACCESS) & ~(READ_ONLY_CACHE & (CurrState == STATE_ADDRESS_SETUP));
-  assign StallConditions =  FlushCache | AnyMiss | (|CMOpM) | TagSetStale;              // exclusion-tag: icache FlushCache
+  assign StallConditions =  FlushCache | AnyMiss | (|CMOpM);                            // exclusion-tag: icache FlushCache
   assign CacheStall = (CurrState == STATE_ACCESS & StallConditions) | // exclusion-tag: icache StallStates
                       (CurrState == STATE_FETCH) |
                       (CurrState == STATE_WRITEBACK) |
@@ -162,13 +153,7 @@ module cachefsm #(parameter READ_ONLY_CACHE = 0) (
                       (CurrState == STATE_FLUSH) |
                       (CurrState == STATE_FLUSH_WRITEBACK);
   // write enables internal to cache
-  // A transient false miss (hit/miss decision taken the cycle the tag-SRAM index changed) could
-  // otherwise reach STATE_WRITE_LINE and allocate a victim way, creating a duplicate tag whose
-  // clean refill shadows committed dirty data in the existing way (issue #1538).  This is
-  // prevented upstream: TagSetStale suppresses AnyMiss on the stale cycle (see above), so a
-  // false miss never advances to STATE_FETCH/STATE_WRITE_LINE.  Reaching STATE_WRITE_LINE thus
-  // always implies a true miss, so SetValid validates the fetched line unconditionally here.
-  assign SetValid = (CurrState == STATE_WRITE_LINE) |
+  assign SetValid = CurrState == STATE_WRITE_LINE |
                     (CurrState == STATE_ACCESS & CMOZeroNoEviction) |
                     (CurrState == STATE_WRITEBACK & CacheBusAck & CMOpM[3]);
   assign ClearValid = (CurrState == STATE_ACCESS & (CMOpM[0] | (CMOpM[2] & ~HitLineDirty))) |
@@ -212,30 +197,17 @@ module cachefsm #(parameter READ_ONLY_CACHE = 0) (
                          (CurrState == STATE_FLUSH_WRITEBACK & ~CacheBusAck) |
                          (CurrState == STATE_WRITEBACK & (CMOpM[1] | CMOpM[2]) & ~CacheBusAck);
 
-  assign SelAdrData = (CurrState == STATE_ACCESS & (CacheRW[0] | AnyMiss | (|CMOpM) | TagSetStale)) | // exclusion-tag: icache SelAdrCauses // changes if store delay hazard removed
+  assign SelAdrData = (CurrState == STATE_ACCESS & (CacheRW[0] | AnyMiss | (|CMOpM))) | // exclusion-tag: icache SelAdrCauses // changes if store delay hazard removed
                   (CurrState == STATE_FETCH) |
                   (CurrState == STATE_WRITEBACK) |
                   (CurrState == STATE_WRITE_LINE) |
                   resetDelay;
-  // StoreHitFirstStall: hold the tag-index at PAdr only on the first stall cycle of a store-hit.
-  // Without this, the extended CacheEn (below) would re-latch ValidWay from NextSet's row on
-  // subsequent stall cycles, corrupting hit/miss decisions (issue #1538).  Restricting to the
-  // first stall cycle preserves the tag prefetch on all later stall cycles.
-  // TagSetStale: drive CacheSetTag = PAdr so the tag SRAM re-reads at the correct set during
-  // the stale-cycle stall (issue #1538).  Without this, CacheSetTag stays on NextSet and the
-  // stall never clears.
-  assign SelAdrTag = (CurrState == STATE_ACCESS & (AnyMiss | (|CMOpM) | StoreHitFirstStall | TagSetStale)) | // exclusion-tag: icache SelAdrTag
+  assign SelAdrTag = (CurrState == STATE_ACCESS & (AnyMiss | (|CMOpM))) | // exclusion-tag: icache SelAdrTag // changes if store delay hazard removed
                   (CurrState == STATE_FETCH) |
                   (CurrState == STATE_WRITEBACK) |
                   (CurrState == STATE_WRITE_LINE) |
                   resetDelay;
   assign SelFetchBuffer = CurrState == STATE_WRITE_LINE | CurrState == STATE_ADDRESS_SETUP;
-  // Extend CacheEn for the first cycle of a stalled store-hit so the write reaches the data SRAM
-  // (issue #1538).  Gated with ~StoreAmoFaultM so a faulting store/AMO (page, access, or
-  // misaligned fault detected combinatorially on cycle 1 of the stall, before FlushStage from
-  // the trap arrives) never commits to the SRAM.  Also gated with ~FlushStage for any other
-  // flush-causing event that arrives before cycle 1.
-  assign CacheEn = (~Stall | StallConditions) | (CurrState != STATE_ACCESS) | reset | InvalidateCache | // exclusion-tag: cache CacheEn
-                   ((SetValid | SetDirty | ClearValid | ClearDirty) & StoreHitFirstStall & ~StoreAmoFaultM & ~FlushStage);
+  assign CacheEn = (~Stall | StallConditions) | (CurrState != STATE_ACCESS) | reset | InvalidateCache; // exclusion-tag: dcache CacheEn
 
 endmodule // cachefsm

--- a/src/ifu/ifu.sv
+++ b/src/ifu/ifu.sv
@@ -91,7 +91,6 @@ module ifu import cvw::*;  #(parameter cvw_t P) (
   input  logic                 ENVCFG_PBMTE,                             // Page-based memory types enabled
   input  logic                 ENVCFG_ADUE,                              // HPTW A/D Update enable
   input  logic                 sfencevmaM,                               // Virtual memory address fence, invalidate TLB entries
-  input  logic                 sfencevmaAllM,                            // sfence.vma with rs2=x0: flush all TLB entries including global
   output logic                 ITLBMissOrUpdateAF,                       // ITLB miss causes HPTW (hardware pagetable walker) walk or update access bit
   input  var logic [7:0]       PMPCFG_ARRAY_REGW[P.PMP_ENTRIES-1:0],     // PMP configuration from privileged unit
   input  var logic [P.PA_BITS-3:0] PMPADDR_ARRAY_REGW[P.PMP_ENTRIES-1:0],// PMP address from privileged unit
@@ -183,10 +182,9 @@ module ifu import cvw::*;  #(parameter cvw_t P) (
     // But we're still in the stalled sfence instruction, so if itlbflushf == sfencevmaM, tlbflush would never drop and
     // the tlbwrite would never take place after the pagetable walk. by adding in ~StallMQ, we are able to drop itlbflush
     // after a cycle AND pulse it for another cycle on any further back-to-back sfences.
-    logic StallMQ, TLBFlush, TLBFlushAll;
+    logic StallMQ, TLBFlush;
     flopr #(1) StallMReg(.clk, .reset, .d(StallM), .q(StallMQ));
     assign TLBFlush = sfencevmaM & ~StallMQ;
-    assign TLBFlushAll = sfencevmaAllM & ~StallMQ;
 
     mmu #(.P(P), .TLB_ENTRIES(P.ITLB_ENTRIES), .IMMU(1))
     immu(.clk, .reset, .SATP_REGW, .STATUS_MXR, .STATUS_SUM, .STATUS_MPRV, .STATUS_MPP, .ENVCFG_PBMTE, .ENVCFG_ADUE,
@@ -196,7 +194,7 @@ module ifu import cvw::*;  #(parameter cvw_t P) (
          .PTE(PTE),
          .PageTypeWriteVal(PageType),
          .TLBWrite(ITLBWriteF),
-         .TLBFlush, .TLBFlushAll,
+         .TLBFlush,
          .PhysicalAddress(PCPF),
          .TLBMiss(ITLBMissF),
          .Cacheable(CacheableF), .Idempotent(), .SelTIM(SelIROM),
@@ -252,7 +250,7 @@ module ifu import cvw::*;  #(parameter cvw_t P) (
       cache #(.P(P), .PA_BITS(P.PA_BITS), .LINELEN(P.ICACHE_LINELENINBITS),
               .NUMSETS(P.ICACHE_WAYSIZEINBYTES*8/P.ICACHE_LINELENINBITS),
               .NUMWAYS(P.ICACHE_NUMWAYS), .LOGBWPL(AHBWLOGBWPL), .WORDLEN(32), .MUXINTERVAL(16), .READ_ONLY_CACHE(1))
-      icache(.clk, .reset, .FlushStage(FlushD), .StoreAmoFaultM(1'b0), .Stall(GatedStallD),
+      icache(.clk, .reset, .FlushStage(FlushD), .Stall(GatedStallD),
              .FetchBuffer, .CacheBusAck(ICacheBusAck),
              .CacheBusAdr(ICacheBusAdr), .CacheStall(ICacheStallF),
              .CacheBusRW,

--- a/src/lsu/lsu.sv
+++ b/src/lsu/lsu.sv
@@ -56,7 +56,6 @@ module lsu import cvw::*;  #(parameter cvw_t P) (
   input  logic [1:0]              PrivilegeModeW,                       // Current privilege mode
   input  logic                    BigEndianM,                           // Swap byte order to big endian
   input  logic                    sfencevmaM,                           // Virtual memory address fence, invalidate TLB entries
-  input  logic                    sfencevmaAllM,                        // sfence.vma with rs2=x0: flush all TLB entries including global
   output logic                    DCacheStallM,                         // D$ busy with multicycle operation
   output logic [P.XLEN-1:0]       IEUAdrxTvalM,                         // IEUAdrM, but could be spilled onto the next cacheline or virtual page.
   // fpu
@@ -244,7 +243,7 @@ module lsu import cvw::*;  #(parameter cvw_t P) (
     mmu #(.P(P), .TLB_ENTRIES(P.DTLB_ENTRIES), .IMMU(0))
     dmmu(.clk, .reset, .SATP_REGW, .STATUS_MXR, .STATUS_SUM, .STATUS_MPRV, .STATUS_MPP, .ENVCFG_PBMTE, .ENVCFG_ADUE,
       .PrivilegeModeW, .DisableTranslation, .VAdr(IHAdrM), .Size(LSUFunct3M[1:0]),
-      .PTE, .PageTypeWriteVal(PageType), .TLBWrite(DTLBWriteM), .TLBFlush(sfencevmaM), .TLBFlushAll(sfencevmaAllM),
+      .PTE, .PageTypeWriteVal(PageType), .TLBWrite(DTLBWriteM), .TLBFlush(sfencevmaM),
       .PhysicalAddress(PAdrM), .TLBMiss(DTLBMissM), .Cacheable(CacheableM), .Idempotent(), .SelTIM(SelDTIM),
       .InstrAccessFaultF(), .LoadAccessFaultM(LSULoadAccessFaultM),
       .StoreAmoAccessFaultM(LSUStoreAmoAccessFaultM), .InstrPageFaultF(), .LoadPageFaultM(LSULoadPageFaultM),
@@ -332,7 +331,6 @@ module lsu import cvw::*;  #(parameter cvw_t P) (
       cache #(.P(P), .PA_BITS(P.PA_BITS), .LINELEN(P.DCACHE_LINELENINBITS), .NUMSETS(P.DCACHE_WAYSIZEINBYTES*8/LINELEN),
               .NUMWAYS(P.DCACHE_NUMWAYS), .LOGBWPL(LLENLOGBWPL), .WORDLEN(CACHEWORDLEN), .MUXINTERVAL(P.LLEN), .READ_ONLY_CACHE(0)) dcache(
         .clk, .reset, .Stall(GatedStallW & ~SelSpillE), .SelBusBeat, .FlushStage(LSUFlushW),
-        .StoreAmoFaultM(LSUStoreAmoPageFaultM | LSUStoreAmoAccessFaultM | StoreAmoMisalignedFaultM),
         .CacheRW(CacheRWM),
         .FlushCache(FlushDCache), .NextSet(IEUAdrExtE[11:0]), .PAdr(PAdrM),
         .ByteMask(ByteMaskSpillM), .BeatCount(BeatCount[AHBWLOGBWPL-1:AHBWLOGBWPL-LLENLOGBWPL]),

--- a/src/mmu/hptw.sv
+++ b/src/mmu/hptw.sv
@@ -88,7 +88,6 @@ module hptw import cvw::*;  #(parameter cvw_t P) (
   logic                     ValidPTE, LeafPTE, ValidLeafPTE, ValidNonLeafPTE;
   logic                     StartWalk;
   logic                     TLBMissOrUpdateDA;
-  logic                     ITLBMissReady;
   logic                     PRegEn;
   logic [2:0]               NextPageType;
   logic [P.SVMODE_BITS-1:0] SvMode;
@@ -144,15 +143,7 @@ module hptw import cvw::*;  #(parameter cvw_t P) (
   // Extract bits from CSRs and inputs
   assign SvMode = SATP_REGW[P.XLEN-1:P.XLEN-P.SVMODE_BITS];
   assign BasePageTablePPN = SATP_REGW[P.PPN_BITS-1:0];
-  // Defer servicing an instruction-side (ITLB) miss while the data cache/bus is still busy with a
-  // committed M-stage load/store.  At IDLE, SelHPTW=0 so DCacheBusStallM reflects the LSU data op
-  // (not an HPTW access).  Starting the walk here would seize the data cache mid-access and drop the
-  // store (issue #1538).  This cannot deadlock: the data op drains through the normal LSU stall
-  // independent of the walk, and the walk starts once DCacheBusStallM clears.  Because TLBMissOrUpdateDA
-  // is low while deferred, HPTWStall is also low, so the HPTW does not freeze the pipeline.  DTLB misses
-  // are never deferred (no data cache access has begun at a TLB miss).
-  assign ITLBMissReady     = ITLBMissOrUpdateAF & ~DCacheBusStallM;
-  assign TLBMissOrUpdateDA = DTLBMissOrUpdateDAM | ITLBMissReady;
+  assign TLBMissOrUpdateDA = DTLBMissOrUpdateDAM | ITLBMissOrUpdateAF;
 
   // Determine which address to translate
   mux2 #(P.XLEN) vadrmux(PCSpillF, IEUAdrExtM[P.XLEN-1:0], DTLBWalk, TranslationVAdr);
@@ -342,13 +333,7 @@ module hptw import cvw::*;  #(parameter cvw_t P) (
       default:                                                        NextWalkerState = IDLE; // Should never be reached
     endcase // case (WalkerState)
 
-  // Flush the LSU's M-stage data access at the start of a DTLB walk so it replays after the TLB fill.
-  // Never flush for an ITLB miss: the M-stage access belongs to an older, committed instruction, and
-  // because ITLB walks are deferred until DCacheBusStallM clears (see ITLBMissReady above) it has
-  // already committed its cache access by the time the walk starts.  Flushing it would drop a
-  // committed store (issue #1538).
-  assign HPTWFlushW = (WalkerState == IDLE & DTLBMissOrUpdateDAM) |
-                      (WalkerState != IDLE & HPTWFaultM);
+  assign HPTWFlushW = (WalkerState == IDLE & TLBMissOrUpdateDA) | (WalkerState != IDLE & HPTWFaultM);
 
   assign SelHPTW = WalkerState != IDLE;
   assign HPTWStall = (WalkerState != IDLE & WalkerState != FAULT) | (WalkerState == IDLE & TLBMissOrUpdateDA);

--- a/src/mmu/mmu.sv
+++ b/src/mmu/mmu.sv
@@ -44,8 +44,7 @@ module mmu import cvw::*;  #(parameter cvw_t P,
   input  logic [P.XLEN-1:0]    PTE,                // page table entry
   input  logic [2:0]           PageTypeWriteVal,   // page type
   input  logic                 TLBWrite,           // write TLB entry
-  input  logic                 TLBFlush,           // Invalidate all TLB entries (ASID-specific preserves global)
-  input  logic                 TLBFlushAll,        // Flush global (G=1) entries too; when 0, G=1 entries are preserved
+  input  logic                 TLBFlush,           // Invalidate all TLB entries
   output logic [P.PA_BITS-1:0] PhysicalAddress,    // PAdr when no translation, or translated VAdr (TLBPAdr) when there is translation
   output logic                 TLBMiss,            // Miss TLB
   output logic                 Cacheable,          // PMA indicates memory address is cacheable
@@ -95,7 +94,7 @@ module mmu import cvw::*;  #(parameter cvw_t P,
           .VAdr(VAdr[P.XLEN-1:0]), .STATUS_MXR, .STATUS_SUM, .STATUS_MPRV, .STATUS_MPP, .ENVCFG_PBMTE, .ENVCFG_ADUE,
           .EffectivePrivilegeModeW, .ReadAccess, .WriteAccess, .CMOpM,
           .DisableTranslation, .PTE, .PageTypeWriteVal,
-          .TLBWrite, .TLBFlush, .TLBFlushAll, .TLBPAdr, .TLBMiss,
+          .TLBWrite, .TLBFlush, .TLBPAdr, .TLBMiss,
           .Translate, .TLBPageFault, .UpdateDA, .PBMemoryType);
   end else begin : tlb // just pass address through as physical
     assign Translate    = 1'b0;

--- a/src/mmu/tlb/tlb.sv
+++ b/src/mmu/tlb/tlb.sv
@@ -70,7 +70,6 @@ module tlb import cvw::*;  #(parameter cvw_t P,
   input  logic [2:0]               PageTypeWriteVal,
   input  logic                     TLBWrite,
   input  logic                     TLBFlush,
-  input  logic                     TLBFlushAll,      // Flush global (G=1) entries too
   output logic [P.PA_BITS-1:0]     TLBPAdr,
   output logic                     TLBMiss,
   output logic                     Translate,
@@ -122,7 +121,7 @@ module tlb import cvw::*;  #(parameter cvw_t P,
 
   tlblru #(TLB_ENTRIES) lru(.clk, .reset, .TLBWrite, .Matches, .TLBHit, .WriteEnables);
   tlbcam #(P, TLB_ENTRIES, P.VPN_BITS + P.ASID_BITS, P.VPN_SEGMENT_BITS)
-    tlbcam(.clk, .reset, .VPN, .PageTypeWriteVal, .SV39Mode, .SV48Mode, .TLBFlush, .TLBFlushAll, .WriteEnables, .PTE_Gs, .PTE_NAPOTs,
+    tlbcam(.clk, .reset, .VPN, .PageTypeWriteVal, .SV39Mode, .SV48Mode, .TLBFlush, .WriteEnables, .PTE_Gs, .PTE_NAPOTs,
            .SATP_ASID, .Matches, .HitPageType, .CAMHit);
   tlbram #(P, TLB_ENTRIES) tlbram(.clk, .reset, .PTE, .Matches, .WriteEnables, .PPN, .PTEAccessBits, .PTE_Gs, .PTE_NAPOTs);
 

--- a/src/mmu/tlb/tlbcam.sv
+++ b/src/mmu/tlb/tlbcam.sv
@@ -38,7 +38,6 @@ module tlbcam  import cvw::*;  #(parameter cvw_t P,
   input  logic                    SV39Mode,
   input  logic                    SV48Mode,
   input  logic                    TLBFlush,
-  input  logic                    TLBFlushAll,  // Flush global (G=1) entries too
   input  logic [TLB_ENTRIES-1:0]  WriteEnables,
   input  logic [TLB_ENTRIES-1:0]  PTE_Gs,
   input  logic [TLB_ENTRIES-1:0]  PTE_NAPOTs,  // entry is in NAPOT mode (N bit set and PPN[3:0] = 1000)
@@ -57,7 +56,7 @@ module tlbcam  import cvw::*;  #(parameter cvw_t P,
   // page number segments.
 
   tlbcamline #(P, KEY_BITS, SEGMENT_BITS) camlines[TLB_ENTRIES-1:0](
-    .clk, .reset, .VPN, .SATP_ASID, .SV39Mode, .SV48Mode, .PTE_G(PTE_Gs), .PTE_NAPOT(PTE_NAPOTs), .PageTypeWriteVal, .TLBFlush, .TLBFlushAll,
+    .clk, .reset, .VPN, .SATP_ASID, .SV39Mode, .SV48Mode, .PTE_G(PTE_Gs), .PTE_NAPOT(PTE_NAPOTs), .PageTypeWriteVal, .TLBFlush,
     .WriteEnable(WriteEnables), .PageTypeRead, .Match(Matches));
   assign CAMHit = |Matches & ~TLBFlush;
   or_rows #(TLB_ENTRIES,3) PageTypeOr(PageTypeRead, HitPageType);

--- a/src/mmu/tlb/tlbcamline.sv
+++ b/src/mmu/tlb/tlbcamline.sv
@@ -41,8 +41,7 @@ module tlbcamline import cvw::*;  #(parameter cvw_t P,
   input  logic                  PTE_G,
   input  logic                  PTE_NAPOT,  // entry is in NAPOT mode (N bit set and PPN[3:0] = 1000)
   input  logic [2:0]            PageTypeWriteVal,
-  input  logic                  TLBFlush,     // Flush this line (set valid to 0)
-  input  logic                  TLBFlushAll,  // Flush global (G=1) entries too; when 0, G=1 entries are preserved
+  input  logic                  TLBFlush,   // Flush this line (set valid to 0)
   output logic [2:0]            PageTypeRead,
   output logic                  Match
 );
@@ -110,10 +109,7 @@ module tlbcamline import cvw::*;  #(parameter cvw_t P,
   assign PageTypeRead = PageType & {3{Match}};
 
   // On a write, set the valid bit high and update the stored key.
-  // On a flush, zero the valid bit and leave the key unchanged, unless the entry is global (G=1)
-  // and the flush is ASID-specific (TLBFlushAll=0): global mappings survive an ASID-scoped sfence.vma.
-  logic ShouldFlush;
-  assign ShouldFlush = TLBFlush & (~PTE_G | TLBFlushAll);
-  flopenr #(1) validbitflop(clk, reset, WriteEnable | ShouldFlush, ~ShouldFlush, Valid);
+  // On a flush, zero the valid bit and leave the key unchanged.
+  flopenr #(1) validbitflop(clk, reset, WriteEnable | TLBFlush, ~TLBFlush, Valid);
   flopenr #(KEY_BITS) keyflop(clk, reset, WriteEnable, {SATP_ASID, VPN}, Key);
 endmodule

--- a/src/privileged/privdec.sv
+++ b/src/privileged/privdec.sv
@@ -40,8 +40,7 @@ module privdec import cvw::*;  #(parameter cvw_t P) (
   output logic         IllegalInstrFaultM,                  // Illegal instruction
   output logic         EcallFaultM, BreakpointFaultM,       // Ecall or breakpoint; must retire, so don't flush it when the trap occurs
   output logic         sretM, mretM, RetM,                  // return instructions
-  output logic         wfiM, wfiW, sfencevmaM,              // wfi / sfence.vma / sinval.vma instructions
-  output logic         sfencevmaAllM                        // sfence.vma with rs2=x0: flush all TLB entries including global
+  output logic         wfiM, wfiW, sfencevmaM               // wfi / sfence.vma / sinval.vma instructions
 );
 
   logic                rs1zeroM, rdzeroM;                   // rs1 / rd field = 0
@@ -82,11 +81,6 @@ module privdec import cvw::*;  #(parameter cvw_t P) (
   assign sfencevmaM = PrivilegedM & P.VIRTMEM_SUPPORTED &
                       ((PrivilegeModeW == P.M_MODE & (vmaM | fenceinvalM)) |
                        (PrivilegeModeW == P.S_MODE & (vmaM & ~STATUS_TVM  | fenceinvalM))); // sfence.w.inval & sfence.inval.ir not affected by TVM
-  // rs2 (InstrM[24:20]) = x0 means flush all ASIDs including global mappings; rs2 != x0 is ASID-specific
-  // and must preserve global (G=1) entries (RISC-V Privileged spec sfence.vma semantics).
-  // sfence.w.inval / sfence.inval.ir (fenceinvalM) have a fixed rs2 encoding that is not an ASID, so
-  // force the conservative full flush for them rather than interpreting rs2 as an ASID.
-  assign sfencevmaAllM = sfencevmaM & (fenceinvalM | ~|InstrM[24:20]);
 
   ///////////////////////////////////////////
   // WFI timeout Privileged Spec 3.1.6.5

--- a/src/privileged/privileged.sv
+++ b/src/privileged/privileged.sv
@@ -94,7 +94,6 @@ module privileged import cvw::*;  #(parameter cvw_t P) (
   // control outputs
   output logic              RetM, TrapM,                                    // return instruction, or trap
   output logic              sfencevmaM,                                     // sfence.vma instruction
-  output logic              sfencevmaAllM,                                  // sfence.vma with rs2=x0: flush all TLB entries including global
   input  logic              InvalidateICacheM,                              // fence instruction
   output logic              BigEndianM,                                     // Use big endian in current privilege mode
   // Fault outputs
@@ -131,7 +130,7 @@ module privileged import cvw::*;  #(parameter cvw_t P) (
   privdec #(P) pmd(.clk, .reset, .StallW, .FlushW, .InstrM(InstrM[31:7]),
     .PrivilegedM, .IllegalIEUFPUInstrM, .IllegalCSRAccessM,
     .PrivilegeModeW, .STATUS_TSR, .STATUS_TVM, .STATUS_TW, .IllegalInstrFaultM,
-    .EcallFaultM, .BreakpointFaultM, .sretM, .mretM, .RetM, .wfiM, .wfiW, .sfencevmaM, .sfencevmaAllM);
+    .EcallFaultM, .BreakpointFaultM, .sretM, .mretM, .RetM, .wfiM, .wfiW, .sfencevmaM);
 
   // Control and Status Registers
   csr #(P) csr(.clk, .reset, .FlushM, .FlushW, .StallE, .StallM, .StallW,

--- a/src/wally/wallypipelinedcore.sv
+++ b/src/wally/wallypipelinedcore.sv
@@ -112,7 +112,7 @@ module wallypipelinedcore import cvw::*; #(parameter cvw_t P) (
   logic [1:0]                    PrivilegeModeW;
   logic [P.XLEN-1:0]             PTE;
   logic [2:0]                    PageType;
-  logic                          sfencevmaM, sfencevmaAllM;
+  logic                          sfencevmaM;
   logic                          SelHPTW;
 
   // PMA checker signals
@@ -190,7 +190,7 @@ module wallypipelinedcore import cvw::*; #(parameter cvw_t P) (
     .IllegalBaseInstrD, .IllegalFPUInstrD, .InstrPageFaultF, .IllegalIEUFPUInstrD, .InstrMisalignedFaultM,
     // mmu management
     .PrivilegeModeW, .PTE, .PageType, .SATP_REGW, .STATUS_MXR, .STATUS_SUM, .STATUS_MPRV,
-    .STATUS_MPP, .ENVCFG_PBMTE, .ENVCFG_ADUE, .ITLBWriteF, .sfencevmaM, .sfencevmaAllM, .ITLBMissOrUpdateAF,
+    .STATUS_MPP, .ENVCFG_PBMTE, .ENVCFG_ADUE, .ITLBWriteF, .sfencevmaM, .ITLBMissOrUpdateAF,
     // pmp/pma (inside mmu) signals.
     .PMPCFG_ARRAY_REGW,  .PMPADDR_ARRAY_REGW, .InstrAccessFaultF);
 
@@ -241,7 +241,7 @@ module wallypipelinedcore import cvw::*; #(parameter cvw_t P) (
     .STATUS_MPP,                  // from csr
     .ENVCFG_PBMTE,                // from csr
     .ENVCFG_ADUE,                 // from csr
-    .sfencevmaM, .sfencevmaAllM,  // connects to privilege
+    .sfencevmaM,                  // connects to privilege
     .DCacheStallM,                // connects to privilege
     .IEUAdrxTvalM,                // connects to privilege
     .LoadPageFaultM,              // connects to privilege
@@ -291,7 +291,7 @@ module wallypipelinedcore import cvw::*; #(parameter cvw_t P) (
       .FlushD, .FlushE, .FlushM, .FlushW, .StallD, .StallE, .StallM, .StallW,
       .CSRReadM, .CSRWriteM, .SrcAM, .PCM, .PCSpillM,
       .InstrM, .InstrOrigM, .CSRReadValW, .EPCM, .TrapVectorM,
-      .RetM, .TrapM, .sfencevmaM, .sfencevmaAllM, .InvalidateICacheM, .DCacheStallM, .ICacheStallF,
+      .RetM, .TrapM, .sfencevmaM, .InvalidateICacheM, .DCacheStallM, .ICacheStallF,
       .InstrValidM, .CommittedM, .CommittedF,
       .FRegWriteM, .LoadStallD, .StoreStallD,
       .BPDirWrongM, .BTAWrongM, .BPWrongM,
@@ -313,7 +313,7 @@ module wallypipelinedcore import cvw::*; #(parameter cvw_t P) (
             // PMPCFG_ARRAY_REGW, PMPADDR_ARRAY_REGW,
             ENVCFG_CBE, ENVCFG_PBMTE, ENVCFG_ADUE,
             EPCM, TrapVectorM, RetM, TrapM,
-            sfencevmaM, sfencevmaAllM, BigEndianM, wfiM, IntPendingM} = '0;
+            sfencevmaM, BigEndianM, wfiM, IntPendingM} = '0;
   end
 
   // multiply/divide unit

--- a/testbench/testbench.sv
+++ b/testbench/testbench.sv
@@ -226,10 +226,6 @@ module testbench;
         "arch64pmp":     if (P.PMP_ENTRIES > 0)   tests = arch64pmp;
         "arch64vm_sv39": if (P.SV39_SUPPORTED)    tests = arch64vm_sv39;
         "arch64vm_sv48": if (P.SV48_SUPPORTED)    tests = arch64vm_sv48;
-        "arch64vm_sv48_a": if (P.SV48_SUPPORTED)    tests = arch64vm_sv48_a;
-        "arch64vm_sv48_b": if (P.SV48_SUPPORTED)    tests = arch64vm_sv48_b;
-        "arch64vm_sv39_isolate":     if (P.SV39_SUPPORTED) tests = arch64vm_sv39_isolate;
-        "arch64vm_sv48_mxr_isolate": if (P.SV48_SUPPORTED) tests = arch64vm_sv48_mxr_isolate;
         "arch64vm_sv57": if (P.SV57_SUPPORTED)    tests = arch64vm_sv57;
       endcase
     end else begin // RV32

--- a/testbench/tests.vh
+++ b/testbench/tests.vh
@@ -446,32 +446,10 @@ string arch64vm_sv48[] = '{
   "rv64i_m/vm_pmp/src/sv48/sv48_pmp_on_pte_U_mode.S"
 };
 
-string arch64vm_sv48_a[] = '{
-  `RISCVARCHTEST,
-  "rv64i_m/vm_sv48/src/sv48_res_global_pte_U_mode.S",
-  "rv64i_m/vm_sv48/src/sv48_pte_reserved_field_S_mode.S"
-};
-
-string arch64vm_sv48_b[] = '{
-  `RISCVARCHTEST,
-  "rv64i_m/vm_sv48/src/sv48_pte_reserved_field_S_mode.S",
-  "rv64i_m/vm_sv48/src/sv48_res_global_pte_U_mode.S"
-};
-
-string arch64vm_sv39_isolate[] = '{
-  `RISCVARCHTEST,
-  "rv64i_m/vm_sv39/src/vm_VA_all_zeros_S_mode.S"
-};
-
-string arch64vm_sv48_mxr_isolate[] = '{
-  `RISCVARCHTEST,
-  "rv64i_m/vm_sv48/src/sv48_mxr_S_mode.S"
-};
-
 string arch64vm_sv57[] = '{
   `RISCVARCHTEST,
-  "rv64i_m/vm_sv57/src/sv57_A_and_D_S_mode.S",         // Re-enabled: passes lockstep after Issue#1538 fix
-  "rv64i_m/vm_sv57/src/sv57_A_and_D_U_mode.S",         // Re-enabled: passes lockstep after Issue#1538 fix
+  //"rv64i_m/vm_sv57/src/sv57_A_and_D_S_mode.S",        // Disable until fixed; Might be due to Issue#1538 ***TODO: Zain
+  //"rv64i_m/vm_sv57/src/sv57_A_and_D_U_mode.S",        // Disable until fixed; Might be due to Issue#1538 ***TODO: Zain
   "rv64i_m/vm_sv57/src/sv57_VA_all_ones_S_mode.S",
   "rv64i_m/vm_sv57/src/sv57_VA_all_zeros_S_mode.S",
   "rv64i_m/vm_sv57/src/sv57_canonical_S_mode.S",


### PR DESCRIPTION
Reverts openhwgroup/cvw#1768

Breaks build root on the FPGA

```
[   29.384866] BUG: Bad page state in process kworker/u4:0  pfn:89a6e
[   29.393895] page: refcount:0 mapcount:0 mapping:(____ptrval____) index:0xf34 pfn:0x89a6e
[   29.403894] aops:0xffffffff84e15f80 ino:194 dentry name(?):"libstdc++.so.6.0.33"
[   29.413237] flags: 0x18(uptodate|dirty|zone=0)
[   29.420135] raw: 0000000000000018 0000000000000000 dead000000000000 ff60000005d6cd08
[   29.430090] raw: 0000000000000f34 0000000000000000 00000000ffffffff
[   29.438177] page dumped because: non-NULL mapping
```