### PR TITLE
fix: Added many checks to flash-sd.sh to prevent regular files from being created accidentally where a block device was supposed to be.

### DIFF
--- a/linux/sdcard/flash-sd.sh
+++ b/linux/sdcard/flash-sd.sh
@@ -84,6 +84,15 @@ LINUX_KERNEL=$IMAGES/Image
 #DEVICE_TREE=$IMAGES/$DEVICE_TREE
 
 SDCARD=${ARGS[0]}
+
+# Resolve symlinks to the real device node (e.g. /dev/disk/by-id/... → /dev/mmcblk0)
+SDCARD_REAL="$(readlink -f -- "$SDCARD" 2>/dev/null || echo "$SDCARD")"
+
+if [ "$SDCARD_REAL" != "$SDCARD" ]; then
+    echo -e "$NAME Resolved symlink: $SDCARD → $SDCARD_REAL"
+fi
+
+SDCARD="$SDCARD_REAL"
 DEVNAME="$(basename "$SDCARD")"
 
 # User Error Checks ===================================================
@@ -92,9 +101,17 @@ if [ "$#" -eq "0" ] ; then
     usage
 fi
 
-# Check to make sure sd card device exists
-if [ ! -e "$SDCARD" ] ; then
-    echo -e "$NAME $ERRORTEXT SD card device does not exist."
+# Must be a real block device
+if [ ! -b "$SDCARD" ] ; then
+    echo -e "$NAME $ERRORTEXT '$SDCARD' is not a block device."
+    echo "       Check what type of file it is with 'ls -l $SDCARD'"
+    exit 1
+fi
+
+# Must be a whole disk, not a partition
+if [ "$(lsblk -dno TYPE "$SDCARD" 2>/dev/null)" != "disk" ]; then
+    echo -e "$NAME $ERRORTEXT '$SDCARD' must be a whole-disk block device"
+    echo "       (e.g. /dev/mmcblk0 or /dev/sdb), not a partition."
     exit 1
 fi
 
@@ -127,32 +144,28 @@ if [ ! -e $DEVICE_TREE ] ; then
     make -C ../ generate BUILDROOT=$BUILDROOT
 fi
 
-# Checks the block device
-if [ -b "$SDCARD" ] ; then
-    # Check the size of the card. If size is 0, then no card is inserted.
-    if [ ! "$(cat /sys/block/$DEVNAME/size 2>/dev/null || echo 0)" -gt 0 ] ; then
-        echo -e "$NAME $ERRORTEXT no SD card is inserted in '$SDCARD'."
-        exit 1
-    fi
+# Check the size of the card. If size is 0, then no card is inserted.
+if [ ! "$(cat /sys/block/$DEVNAME/size 2>/dev/null || echo 0)" -gt 0 ] ; then
+    echo -e "$NAME $ERRORTEXT no SD card is inserted in '$SDCARD'."
+    exit 1
+fi
 
-    # Checks to see if any partitions of the SDCARD are not device files
-    failed=0
-    for part in "${SDCARD}"*; do
-        if [ -e "$part" ] && [ ! -b "$part" ]; then
-            echo -e "$NAME $ERRORTEXT '$part' is not a block device."
-            echo "       It must be a real device node (e.g. /dev/sdb, /dev/mmcblk0, /dev/loop0, etc.)"
-            echo "       and cannot be a regular file, directory, or anything else inside /dev."
-            echo "       Run 'ls -l $SDCARD'* to see what type of file it actually is."
-            failed=1
-        fi
-    done
-
-    if [ "$failed" -eq 1 ]; then
-        exit 1
+# Checks to see if any partitions of the SDCARD are not device
+# files. Shouldn't happen now that the checks are more robust, but dd
+# has created regular files in place of partitions before. This alerts
+# the user to that scenario.
+failed=0
+for part in "${SDCARD}"*; do
+    if [ -e "$part" ] && [ ! -b "$part" ]; then
+        echo -e "$NAME $ERRORTEXT '$part' is not a block device."
+        echo "       It must be a real device node (e.g. /dev/sdb, /dev/mmcblk0, /dev/loop0, etc.)"
+        echo "       and cannot be a regular file, directory, or anything else inside /dev."
+        echo "       Run 'ls -l $SDCARD'* to see what type of file it actually is."
+        failed=1
     fi
-else
-    echo -e "$NAME $ERRORTEXT '$SDCARD' is not a block device."
-    echo "       Check what type of file it is with 'ls -l $SDCARD'"
+done
+
+if [ "$failed" -eq 1 ]; then
     exit 1
 fi
 

--- a/linux/sdcard/flash-sd.sh
+++ b/linux/sdcard/flash-sd.sh
@@ -39,6 +39,11 @@ help() {
     exit 0;
 }
 
+abort() {
+    echo -e "$NAME $ERRORTEXT $*" >&2
+    exit 1
+}
+
 # Output colors
 GREEN="\e[32m"
 RED="\e[31m"
@@ -85,33 +90,15 @@ LINUX_KERNEL=$IMAGES/Image
 
 SDCARD=${ARGS[0]}
 
-# Resolve symlinks to the real device node (e.g. /dev/disk/by-id/... → /dev/mmcblk0)
-SDCARD_REAL="$(readlink -f -- "$SDCARD" 2>/dev/null || echo "$SDCARD")"
-
-if [ "$SDCARD_REAL" != "$SDCARD" ]; then
-    echo -e "$NAME Resolved symlink: $SDCARD → $SDCARD_REAL"
-fi
-
-SDCARD="$SDCARD_REAL"
-DEVNAME="$(basename "$SDCARD")"
-
 # User Error Checks ===================================================
 
 if [ "$#" -eq "0" ] ; then
     usage
 fi
 
-# Must be a real block device
-if [ ! -b "$SDCARD" ] ; then
-    echo -e "$NAME $ERRORTEXT '$SDCARD' is not a block device."
-    echo "       Check what type of file it is with 'ls -l $SDCARD'"
-    exit 1
-fi
-
-# Must be a whole disk, not a partition
-if [ "$(lsblk -dno TYPE "$SDCARD" 2>/dev/null)" != "disk" ]; then
-    echo -e "$NAME $ERRORTEXT '$SDCARD' must be a whole-disk block device"
-    echo "       (e.g. /dev/mmcblk0 or /dev/sdb), not a partition."
+# Check to make sure sd card device exists
+if [ ! -e "$SDCARD" ] ; then
+    echo -e "$NAME $ERRORTEXT SD card device does not exist."
     exit 1
 fi
 
@@ -131,7 +118,7 @@ if [ ! -d $IMAGES ] ; then
 else
     # If images are not built, exit
     if [ ! -e $FW_JUMP ] || [ ! -e $LINUX_KERNEL ] ; then
-        echo -e '$ERRORTEXT Missing images in buildroot output directory.'
+        echo -e "$ERRORTEXT Missing images in buildroot output directory."
         echo '       Build images before running this script.'
         exit 1
     fi
@@ -142,31 +129,6 @@ if [ ! -e $DEVICE_TREE ] ; then
     echo -e "$NAME $ERRORTEXT Missing device tree files"
     echo -e "$NAME generating all device tree files into buildroot"
     make -C ../ generate BUILDROOT=$BUILDROOT
-fi
-
-# Check the size of the card. If size is 0, then no card is inserted.
-if [ ! "$(cat /sys/block/$DEVNAME/size 2>/dev/null || echo 0)" -gt 0 ] ; then
-    echo -e "$NAME $ERRORTEXT no SD card is inserted in '$SDCARD'."
-    exit 1
-fi
-
-# Checks to see if any partitions of the SDCARD are not device
-# files. Shouldn't happen now that the checks are more robust, but dd
-# has created regular files in place of partitions before. This alerts
-# the user to that scenario.
-failed=0
-for part in "${SDCARD}"*; do
-    if [ -e "$part" ] && [ ! -b "$part" ]; then
-        echo -e "$NAME $ERRORTEXT '$part' is not a block device."
-        echo "       It must be a real device node (e.g. /dev/sdb, /dev/mmcblk0, /dev/loop0, etc.)"
-        echo "       and cannot be a regular file, directory, or anything else inside /dev."
-        echo "       Run 'ls -l $SDCARD'* to see what type of file it actually is."
-        failed=1
-    fi
-done
-
-if [ "$failed" -eq 1 ]; then
-    exit 1
 fi
 
 # Calculate partition information =====================================
@@ -189,17 +151,20 @@ echo -e "$NAME Kernel block size:          $KERNEL_SIZE"
 read -p $'\e[1;33mWarning:\e[0m Doing this will replace all data on this card. Continue? y/n: ' -n 1 -r
 echo
 if [[ $REPLY =~ ^[Yy]$ ]] ; then
+    # We need to make sure that the file system partition of the card
+    # is not mounted before re-flashing it.
     DEVBASENAME=$(basename $SDCARD)
     CHECKMOUNT=$(lsblk | grep "$DEVBASENAME"4 | tr -s ' ' | cut -d' ' -f 7)
 
     if [ ! -z $CHECKMOUNT ] ; then
-        sudo umount -v $CHECKMOUNT
+        sudo umount -v $CHECKMOUNT || abort "Could not unmount $CHECKMOUNT. Aborting."
     fi
 
     #Make empty image
     if [ ! -z $WIPECARD ] ; then
         echo -e "$NAME Wiping SD card. This could take a while."
-        sudo dd if=/dev/zero of=$SDCARD bs=64k status=progress && sync
+        sudo dd if=/dev/zero of=$SDCARD bs=64k status=progress || abort "Failed to wipe card"
+        sync
     fi
 
     # GUID Partition Tables (GPT)
@@ -210,40 +175,47 @@ if [[ $REPLY =~ ^[Yy]$ ]] ; then
     # to 1 sector boundaries I think? This would normally be set to 2048
     # apparently.
 
-    sudo sgdisk -z $SDCARD
+    sudo sgdisk -z $SDCARD || abort "Failed to zap partition table."
 
     sleep 1
 
     echo -e "$NAME Creating GUID Partition Table"
     sudo sgdisk -g --clear --set-alignment=1 \
-         --new=1:34:+$DST_SIZE: --change-name=1:'fdt' \
-         --new=2:$FW_JUMP_START:+$FW_JUMP_SIZE --change-name=2:'opensbi' --typecode=1:2E54B353-1271-4842-806F-E436D6AF6985 \
+         --new=1:34:+$DST_SIZE --change-name=1:'fdt' \
+         --new=2:$FW_JUMP_START:+$FW_JUMP_SIZE --change-name=2:'opensbi' --typecode=2:2E54B353-1271-4842-806F-E436D6AF6985 \
          --new=3:$KERNEL_START:+$KERNEL_SIZE --change-name=3:'kernel' \
          --new=4:$FS_START:-0 --change-name=4:'filesystem' \
-         $SDCARD
+         $SDCARD || abort "Failed to create partition table on $SDCARD."
 
+    # Inform OS about the partition table change
     sudo partprobe $SDCARD
-
     sleep 3
 
     echo -e "$NAME Copying binaries into their partitions."
     DD_FLAGS="bs=4k iflag=direct,fullblock oflag=dsync conv=fsync status=progress"
 
     echo -e "$NAME Copying device tree"
-    sudo dd if=$DEVICE_TREE of="$SDCARD""$PART_PREFIX"1 $DD_FLAGS && sync
+    sudo dd if=$DEVICE_TREE of="$SDCARD""$PART_PREFIX"1 $DD_FLAGS && sync || \
+            abort "Failed to write device tree to ${SDCARD}${PART_PREFIX}1"
 
     echo -e "$NAME Copying OpenSBI"
-    sudo dd if=$FW_JUMP of="$SDCARD""$PART_PREFIX"2 $DD_FLAGS && sync
+    sudo dd if=$FW_JUMP of="$SDCARD""$PART_PREFIX"2 $DD_FLAGS && sync || \
+            abort "Failed to write OpenSBI to ${SDCARD}${PART_PREFIX}2"
 
     echo -e "$NAME Copying Kernel"
-    sudo dd if=$LINUX_KERNEL of="$SDCARD""$PART_PREFIX"3 $DD_FLAGS && sync
+    sudo dd if=$LINUX_KERNEL of="$SDCARD""$PART_PREFIX"3 $DD_FLAGS && sync || \
+            abort "Failed to write the Linux Kernel to ${SDCARD}${PART_PREFIX}3"
 
-    sudo mkfs.ext4 -E lazy_itable_init=0,lazy_journal_init=0 "$SDCARD""$PART_PREFIX"4
-    sudo fsck -fv "$SDCARD""$PART_PREFIX"4
+    # Initialize all inodes immediately. This avoids the case where
+    # the Kernel on the FPGA thinks the filesystem is corrupted.
+    sudo mkfs.ext4 -E lazy_itable_init=0,lazy_journal_init=0 "$SDCARD""$PART_PREFIX"4 || \
+        abort "Failed to initialize the filesystem on ${SDCARD}${PART_PREFIX}4."
+
+    # Fix any potential errors in the file system.
+    sudo fsck -fv "$SDCARD""$PART_PREFIX"4 || true
+
     sudo mkdir /mnt/$MNT_DIR
-
     sudo mount -o init_itable=0 -v "$SDCARD""$PART_PREFIX"4 /mnt/$MNT_DIR
-
     sudo umount -v /mnt/$MNT_DIR
 
     sudo rmdir /mnt/$MNT_DIR
@@ -251,9 +223,5 @@ if [[ $REPLY =~ ^[Yy]$ ]] ; then
 fi
 
 echo
-
-# Only print this part if there actually are partitions on the card
-if [ -b "${SDCARD}${PART_PREFIX}1" ]; then
-    echo "GPT Information for $SDCARD ==================================="
-    sudo sgdisk -p $SDCARD
-fi
+echo "GPT Information for $SDCARD ==================================="
+sudo sgdisk -p $SDCARD

--- a/linux/sdcard/flash-sd.sh
+++ b/linux/sdcard/flash-sd.sh
@@ -240,7 +240,7 @@ fi
 echo
 
 # Only print this part if there actually are partitions on the card
-if [ -e "$SDCARD""1" ]; then
+if [ -b "${SDCARD}${PART_PREFIX}1" ]; then
     echo "GPT Information for $SDCARD ==================================="
     sudo sgdisk -p $SDCARD
 fi

--- a/linux/sdcard/flash-sd.sh
+++ b/linux/sdcard/flash-sd.sh
@@ -84,6 +84,7 @@ LINUX_KERNEL=$IMAGES/Image
 #DEVICE_TREE=$IMAGES/$DEVICE_TREE
 
 SDCARD=${ARGS[0]}
+DEVNAME="$(basename "$SDCARD")"
 
 # User Error Checks ===================================================
 
@@ -92,7 +93,7 @@ if [ "$#" -eq "0" ] ; then
 fi
 
 # Check to make sure sd card device exists
-if [ ! -e "$SDCARD" ] ; then
+if [ ! -e "$SDCARD" ] && [ "$(cat /sys/block/$DEVNAME/size 2>/dev/null || echo 0)" -gt 0 ] ; then
     echo -e "$NAME $ERRORTEXT SD card device does not exist."
     exit 1
 fi
@@ -124,6 +125,35 @@ if [ ! -e $DEVICE_TREE ] ; then
     echo -e "$NAME $ERRORTEXT Missing device tree files"
     echo -e "$NAME generating all device tree files into buildroot"
     make -C ../ generate BUILDROOT=$BUILDROOT
+fi
+
+# Checks the block device
+if [ -b "$SDCARD" ] ; then
+    # Check the size of the card. If size is 0, then no card is inserted.
+    if [ ! "$(cat /sys/block/$DEVNAME/size 2>/dev/null || echo 0)" -gt 0 ] ; then
+        echo -e "$NAME $ERRORTEXT no SD card is inserted in '$SDCARD'."
+        exit 1
+    fi
+
+    # Checks to see if any partitions of the SDCARD are not device files
+    failed=0
+    for part in "${SDCARD}"*; do
+        if [ -e "$part" ] && [ ! -b "$part" ]; then
+            echo -e "$NAME $ERRORTEXT '$part' is not a block device."
+            echo "       It must be a real device node (e.g. /dev/sdb, /dev/mmcblk0, /dev/loop0, etc.)"
+            echo "       and cannot be a regular file, directory, or anything else inside /dev."
+            echo "       Run 'ls -l $SDCARD'* to see what type of file it actually is."
+            failed=1
+        fi
+    done
+
+    if [ "$failed" -eq 1 ]; then
+        exit 1
+    fi
+else
+    echo -e "$NAME $ERRORTEXT '$SDCARD' is not a block device."
+    echo "       Check what type of file it is with 'ls -l $SDCARD'"
+    exit 1
 fi
 
 # Calculate partition information =====================================
@@ -208,5 +238,9 @@ if [[ $REPLY =~ ^[Yy]$ ]] ; then
 fi
 
 echo
-echo "GPT Information for $SDCARD ==================================="
-sudo sgdisk -p $SDCARD
+
+# Only print this part if there actually are partitions on the card
+if [ -e "$SDCARD""1" ]; then
+    echo "GPT Information for $SDCARD ==================================="
+    sudo sgdisk -p $SDCARD
+fi

--- a/linux/sdcard/flash-sd.sh
+++ b/linux/sdcard/flash-sd.sh
@@ -93,7 +93,7 @@ if [ "$#" -eq "0" ] ; then
 fi
 
 # Check to make sure sd card device exists
-if [ ! -e "$SDCARD" ] && [ "$(cat /sys/block/$DEVNAME/size 2>/dev/null || echo 0)" -gt 0 ] ; then
+if [ ! -e "$SDCARD" ] ; then
     echo -e "$NAME $ERRORTEXT SD card device does not exist."
     exit 1
 fi


### PR DESCRIPTION
This PR resolves #1614 by adding extra checks for the block device. This will prevent accidentally creating regular files instead of block device partitions when an SD card is not inserted and present in the block device.