### PR TITLE
Fix: WFI illegal-instruction trap on the next instruction when delegated to S-mode

### DIFF
--- a/src/privileged/privdec.sv
+++ b/src/privileged/privdec.sv
@@ -88,11 +88,11 @@ module privdec import cvw::*;  #(parameter cvw_t P) (
 
   if (P.U_SUPPORTED) begin : wfi
     logic [P.WFI_TIMEOUT_BIT:0] WFICount, WFICountPlus1;
-    assign WFICountPlus1 = (wfiM & (~WFICount[P.WFI_TIMEOUT_BIT])) ? WFICount + 1 : '0; // restart counting on WFI
+    assign WFICountPlus1 = wfiM ? WFICount + 1 : '0; // restart counting on WFI
     flopr #(P.WFI_TIMEOUT_BIT+1) wficountreg(clk, reset, WFICountPlus1, WFICount);  // count while in WFI
   // coverage off -item e 1 -fecexprrow 1
   // WFI Timeout trap will not occur when STATUS_TW is low while in supervisor mode, so the system gets stuck waiting for an interrupt and triggers a watchdog timeout.
-    assign WFITimeoutM = ((STATUS_TW & PrivilegeModeW != P.M_MODE) | (P.S_SUPPORTED & PrivilegeModeW == P.U_MODE)) & WFICount[P.WFI_TIMEOUT_BIT];
+    assign WFITimeoutM = wfiM & (((STATUS_TW & PrivilegeModeW != P.M_MODE) | (P.S_SUPPORTED & PrivilegeModeW == P.U_MODE)) & WFICount[P.WFI_TIMEOUT_BIT]);
   // coverage on
   end else assign WFITimeoutM = 1'b0;
 

--- a/src/privileged/privdec.sv
+++ b/src/privileged/privdec.sv
@@ -88,7 +88,7 @@ module privdec import cvw::*;  #(parameter cvw_t P) (
 
   if (P.U_SUPPORTED) begin : wfi
     logic [P.WFI_TIMEOUT_BIT:0] WFICount, WFICountPlus1;
-    assign WFICountPlus1 = wfiM ? WFICount + 1 : '0; // restart counting on WFI
+    assign WFICountPlus1 = (wfiM & (~WFICount[P.WFI_TIMEOUT_BIT])) ? WFICount + 1 : '0; // restart counting on WFI
     flopr #(P.WFI_TIMEOUT_BIT+1) wficountreg(clk, reset, WFICountPlus1, WFICount);  // count while in WFI
   // coverage off -item e 1 -fecexprrow 1
   // WFI Timeout trap will not occur when STATUS_TW is low while in supervisor mode, so the system gets stuck waiting for an interrupt and triggers a watchdog timeout.

--- a/src/privileged/privdec.sv
+++ b/src/privileged/privdec.sv
@@ -37,6 +37,7 @@ module privdec import cvw::*;  #(parameter cvw_t P) (
   input  logic         IllegalCSRAccessM,                   // Not a legal CSR access
   input  logic [1:0]   PrivilegeModeW,                      // current privilege level
   input  logic         STATUS_TSR, STATUS_TVM, STATUS_TW,   // status bits
+  input  logic         TrapM,                               // Trap is occurring
   output logic         IllegalInstrFaultM,                  // Illegal instruction
   output logic         EcallFaultM, BreakpointFaultM,       // Ecall or breakpoint; must retire, so don't flush it when the trap occurs
   output logic         sretM, mretM, RetM,                  // return instructions
@@ -88,11 +89,16 @@ module privdec import cvw::*;  #(parameter cvw_t P) (
 
   if (P.U_SUPPORTED) begin : wfi
     logic [P.WFI_TIMEOUT_BIT:0] WFICount, WFICountPlus1;
-    assign WFICountPlus1 = wfiM ? WFICount + 1 : '0; // restart counting on WFI
-    flopr #(P.WFI_TIMEOUT_BIT+1) wficountreg(clk, reset, WFICountPlus1, WFICount);  // count while in WFI
+    logic                       WFICountEn, WFICountRst;
+    // Clear counter when reset or when trap is taken
+    assign WFICountRst = reset | TrapM;
+    // Stop incrementing the counter once reach the timeout limit
+    assign WFICountEn = ~WFITimeoutM;
+    assign WFICountPlus1 = wfiM ? WFICount + 1 : '0; // Count while WFI
+    flopenr #(P.WFI_TIMEOUT_BIT+1) wficountreg(clk, WFICountRst, WFICountEn, WFICountPlus1, WFICount);
   // coverage off -item e 1 -fecexprrow 1
   // WFI Timeout trap will not occur when STATUS_TW is low while in supervisor mode, so the system gets stuck waiting for an interrupt and triggers a watchdog timeout.
-    assign WFITimeoutM = wfiM & (((STATUS_TW & PrivilegeModeW != P.M_MODE) | (P.S_SUPPORTED & PrivilegeModeW == P.U_MODE)) & WFICount[P.WFI_TIMEOUT_BIT]);
+    assign WFITimeoutM = ((STATUS_TW & PrivilegeModeW != P.M_MODE) | (P.S_SUPPORTED & PrivilegeModeW == P.U_MODE)) & WFICount[P.WFI_TIMEOUT_BIT];
   // coverage on
   end else assign WFITimeoutM = 1'b0;
 

--- a/src/privileged/privileged.sv
+++ b/src/privileged/privileged.sv
@@ -129,7 +129,7 @@ module privileged import cvw::*;  #(parameter cvw_t P) (
   // decode privileged instructions
   privdec #(P) pmd(.clk, .reset, .StallW, .FlushW, .InstrM(InstrM[31:7]),
     .PrivilegedM, .IllegalIEUFPUInstrM, .IllegalCSRAccessM,
-    .PrivilegeModeW, .STATUS_TSR, .STATUS_TVM, .STATUS_TW, .IllegalInstrFaultM,
+    .PrivilegeModeW, .STATUS_TSR, .STATUS_TVM, .STATUS_TW, .TrapM, .IllegalInstrFaultM,
     .EcallFaultM, .BreakpointFaultM, .sretM, .mretM, .RetM, .wfiM, .wfiW, .sfencevmaM);
 
   // Control and Status Registers

--- a/src/privileged/trap.sv
+++ b/src/privileged/trap.sv
@@ -99,9 +99,13 @@ module trap import cvw::*;  #(parameter cvw_t P) (
     else if (ValidIntsM[11])                                  CauseM = 5'd11; // Machine External Int
     else if (ValidIntsM[3])                                   CauseM = 5'd3;  // Machine Sw Int
     else if (ValidIntsM[7])                                   CauseM = 5'd7;  // Machine Timer Int
-    else if (ValidIntsM[9])                                   CauseM = 5'd9;  // Supervisor External Int
-    else if (ValidIntsM[1])                                   CauseM = 5'd1;  // Supervisor Sw Int
-    else if (ValidIntsM[5])                                   CauseM = 5'd5;  // Supervisor Timer Int
+    // if any of the interrupts are delegated to S mode they would be moved to lower priority than the undelegated ones
+    else if (~MIDELEG_REGW[9] & ValidIntsM[9])                CauseM = 5'd9;  // not delegated Supervisor External Int
+    else if (~MIDELEG_REGW[1] & ValidIntsM[1])                CauseM = 5'd1;  // not delegated Supervisor Sw Int
+    else if (~MIDELEG_REGW[5] & ValidIntsM[5])                CauseM = 5'd5;  // not delegated Supervisor Timer Int
+    else if (ValidIntsM[9])                                   CauseM = 5'd9;  // delegated Supervisor External Int
+    else if (ValidIntsM[1])                                   CauseM = 5'd1;  // delegated Supervisor Sw Int
+    else if (ValidIntsM[5])                                   CauseM = 5'd5;  // delegated Supervisor Timer Int
     else if (BothInstrPageFaultM)                             CauseM = 5'd12;
     else if (BothInstrAccessFaultM)                           CauseM = 5'd1;
     else if (IllegalInstrFaultM)                              CauseM = 5'd2;


### PR DESCRIPTION
Fix to [issue 1780](https://github.com/openhwgroup/cvw/issues/1780)

Root cause to the issue: WFITimeoutM remains high for another cycle after it hits the timeout limit. 

Added in logic to ensure that WFITimeoutM clears after the timeout limit is hit :)