### PR TITLE
Fix code coverage tooling

### DIFF
--- a/bin/regression-wally
+++ b/bin/regression-wally
@@ -386,6 +386,7 @@ def search_log_for_text(text, grepfile):
     with open(grepfile, errors="ignore") as file:
         content = file.readlines()
         passed = False
+        reported = False # whether any line identifying this test was printed
         success = any(text in line for line in content) # check if the success string is present in the log file
         # Even if the string is found, report warnings, errors, and failure, or PASSED
         for line in content:
@@ -393,6 +394,7 @@ def search_log_for_text(text, grepfile):
                 if "FAILED" in line:
                     print(f"{bcolors.FAIL}{grepfile}: {rvcp_summary} FAILED{bcolors.ENDC}")
                     success = False
+                    reported = True
                 elif "PASSED" in line:
                     print(f"{bcolors.OKGREEN}{grepfile}: {rvcp_summary} PASSED{bcolors.ENDC}")
                     passed = True
@@ -401,15 +403,22 @@ def search_log_for_text(text, grepfile):
             if "warning:" in line.lower():
                 print(f"{bcolors.WARNING}{grepfile}: {line.strip()}{bcolors.ENDC}")
                 success = False
+                reported = True
             if "error:" in line.lower():
                 print(f"{bcolors.FAIL}{grepfile}: {line.strip()}{bcolors.ENDC}")
                 success = False
+                reported = True
         nonrvcp_suites = ["buildroot", "all_lints"]
         if success and not passed:
             if not any(s in grepfile for s in nonrvcp_suites):
                 print(f"{bcolors.WARNING}{grepfile}: WARNING '{text}' found but no {rvcp_summary} PASSED{bcolors.ENDC}")
         if not success and passed:
             print(f"{bcolors.WARNING}{grepfile}: WARNING No success string '{text}' found in log file{bcolors.ENDC}")
+            reported = True
+        if not success and not reported:
+            # Otherwise-silent failure (e.g. lockstep mismatch: ImperasDV prints "Error (IDV)"
+            # without a colon, so the error: check above misses it); name the failing log
+            print(f"{bcolors.FAIL}{grepfile}: FAIL: success string '{text}' not found{bcolors.ENDC}")
         return 0 if success else 1
 
 

--- a/bin/regression-wally
+++ b/bin/regression-wally
@@ -280,6 +280,7 @@ testfloatdivconfigs = [
 lockstepwaivers = [
     "WALLY-q-01.S_ref.elf",     # Q extension is not supported by ImperasDV
     "WALLY-cbom-01.S_ref.elf", #,  # cbom extension is not supported by ImperasDV because there is no cache model in ImperasDV
+    "Zicbom-cbo.inval-00.elf", # ImperasDV lacks cache model to match CVW on invalidation
 ]
 
 # tests for cache simulations on a rv64gc derived config - cache_rv64gc
@@ -370,7 +371,11 @@ def addTestsByDir(testDir, config, sim, coverStr, configs, lockstepMode=0, breke
                 fullfile = os.path.join(dirpath, file)
                 fields = fullfile.rsplit('/', 3)
                 shortelf = f"{fields[1]}_{fields[3]}" if fields[2] == "ref" else f"{fields[2]}_{fields[3]}"
-                if shortelf in lockstepwaivers: # skip tests that itch bugs in ImperasDV
+                # Waiver entries may be written either as the bare ELF filename (e.g.
+                # "Zicbom-cbo.inval-00.elf") or as the directory-prefixed shortelf used for the log
+                # name (e.g. "WALLY-cbom-01.S_ref.elf", where the file itself is just "ref.elf").
+                # Accept either form so tests in the list are honored regardless of naming.
+                if shortelf in lockstepwaivers or file in lockstepwaivers: # skip tests that itch bugs in ImperasDV
                     print(f"{bcolors.WARNING}Skipping waived test {shortelf}{bcolors.ENDC}")
                     continue
                 sim_log = f"{sim_logdir}{config}_{shortelf}.log"

--- a/config/rv64gc/imperasfpm.ic
+++ b/config/rv64gc/imperasfpm.ic
@@ -48,7 +48,7 @@
 --override iss/cpu0/Sstc=T
 
 # mcause and scause only have 4 lsbs of code and 1 msb of interrupt flag
---override iss/cpu0/ecode_mask=0x800000000000000F # for RV64
+--override iss/cpu0/ecode_mask=0x800000000000001F # for RV64
 
 # Misaligned access (Zicclsm) is supported
 --override iss/cpu0/unaligned=T

--- a/config/rv64gc/imperasfpm.ic
+++ b/config/rv64gc/imperasfpm.ic
@@ -47,7 +47,7 @@
 --override iss/cpu0/Zcb=T
 --override iss/cpu0/Sstc=T
 
-# mcause and scause only have 4 lsbs of code and 1 msb of interrupt flag
+# mcause and scause only have 5 lsbs of code and 1 msb of interrupt flag
 --override iss/cpu0/ecode_mask=0x800000000000001F # for RV64
 
 # Misaligned access (Zicclsm) is supported

--- a/sim/questa/coverage-exclusions-rv64gc.do
+++ b/sim/questa/coverage-exclusions-rv64gc.do
@@ -450,10 +450,6 @@ coverage exclude -scope /dut/core/lsu -linerange $line-$line -item c 1 -feccondr
 set line [GetLineNum ${SRC}/lsu/lsu.sv "assign CacheRWM"]
 coverage exclude -scope /dut/core/lsu -linerange $line-$line -item c 1 -feccondrow 4
 
-# Excluding reset and clear for impossible case in the wficountreg in privdec
-#set line [GetLineNum ${SRC}/generic/flop/floprc.sv "reset \\| clear"]
-#coverage exclude -scope /dut/core/priv/priv/pmd/wfi/wficountreg -linerange $line-$line -item c 1 -feccondrow 2
-
 # Exclude system reset case in ebu
 set line [GetLineNum ${SRC}/ebu/ebufsmarb.sv "BeatCounter\\("]
 coverage exclude -scope /dut/core/ebu/ebu/ebufsmarb -linerange $line-$line -item e 1 -fecexprrow 1

--- a/testbench/common/watchdog.sv
+++ b/testbench/common/watchdog.sv
@@ -24,7 +24,7 @@
 // and limitations under the License.
 ////////////////////////////////////////////////////////////////////////////////////////////////
 
-module watchdog #(parameter XLEN, WatchDogTimerThreshold)
+module watchdog #(parameter XLEN, WatchDogTimerThreshold, SameTrapPCThreshold = 100)
   (input clk,
    input reset,
    string TEST
@@ -44,11 +44,42 @@ module watchdog #(parameter XLEN, WatchDogTimerThreshold)
     else WatchDogTimerCount = 0;
   end
 
+  // Detect a recursive trap livelock.  When a faulting instruction's handler re-raises a fault at
+  // that same instruction (e.g. an S-mode handler that reads mcause, an M-mode CSR, so every pass
+  // takes an illegal-instruction trap) the core never wedges at one PC: the handler prologue
+  // retires instructions and the PC visits several addresses each pass.  So neither the stuck-PCW
+  // check above nor a minstret-frozen check would ever fire.  The invariant that *does* hold is
+  // that the trapping PC is identical every time.  Count consecutive traps that capture the same
+  // PCM; if the same instruction traps SameTrapPCThreshold times in a row, the core is livelocked.
+  logic [XLEN-1:0]      LastTrapPC;
+  integer               SameTrapPCCount;
+  logic                 TrapMD, TrapEvent;
+  logic                 SameTrapPCTimeOut;
+
+  assign TrapEvent = dut.core.TrapM & ~TrapMD; // one pulse per trap, even if M stalls while trapping
+
+  always_ff @(posedge clk) begin
+    if (reset) begin
+      TrapMD          <= 1'b0;
+      LastTrapPC      <= '0;
+      SameTrapPCCount <= 0;
+    end else begin
+      TrapMD <= dut.core.TrapM;
+      if (TrapEvent) begin
+        if (PCM == LastTrapPC) SameTrapPCCount <= SameTrapPCCount + 1;
+        else                   SameTrapPCCount <= 0;
+        LastTrapPC <= PCM;
+      end
+    end
+  end
+
   always_comb begin
     WatchDogTimeOut = WatchDogTimerCount >= WatchDogTimerThreshold;
-    if(WatchDogTimeOut) begin
-      if (TEST == "buildroot") $display("Watch Dog Time Out triggered.  This is a normal termination for a full buildroot boot.  Check sim/<simulator>/logs/buildroot_uart.log to check if the boot printed the login prompt.");
-      else $display("FAILURE: Watch Dog Time Out triggered. PCW stuck at %x for more than %d cycles", PCW, WatchDogTimerCount);
+    SameTrapPCTimeOut = SameTrapPCCount >= SameTrapPCThreshold;
+    if(WatchDogTimeOut | SameTrapPCTimeOut) begin
+      if (TEST == "buildroot" & WatchDogTimeOut) $display("Watch Dog Time Out triggered.  This is a normal termination for a full buildroot boot.  Check sim/<simulator>/logs/buildroot_uart.log to check if the boot printed the login prompt.");
+      else if (WatchDogTimeOut) $display("FAILURE: Watch Dog Time Out triggered. PCW stuck at %x for more than %d cycles", PCW, WatchDogTimerCount);
+      else $display("FAILURE: Watch Dog Time Out triggered. Instruction at PC %x trapped %d times in a row; the core is livelocked in a recursive trap", LastTrapPC, SameTrapPCCount);
       `ifdef QUESTA
         $stop;  // if this is changed to $finish for Questa, wally-batch.do does not go to the next step to run coverage, and wally.do terminates without allowing GUI debug
       `else

--- a/testbench/tests.vh
+++ b/testbench/tests.vh
@@ -80,7 +80,8 @@ string coverage64gc[] = '{
   "fpuReservedRM",
   "decompReserved",
   "pmpTOR7",
-  "cacheInval"
+  "cacheInval",
+  "wfitimeout"
 };
 
 string buildroot[] = '{

--- a/tests/coverage/wfitimeout.S
+++ b/tests/coverage/wfitimeout.S
@@ -1,0 +1,69 @@
+///////////////////////////////////////////
+// wfitimeout.S
+//
+// Written: David_Harris@hmc.edu 13 June 2026
+//
+// Purpose: Test coverage for the WFI watchdog-timeout logic in privdec.sv.
+//
+//   privdec.sv computes:
+//     WFITimeoutM = ((STATUS_TW & PrivilegeModeW != M_MODE) |
+//                    (S_SUPPORTED & PrivilegeModeW == U_MODE)) & WFICount[WFI_TIMEOUT_BIT];
+//
+//   The timeout-firing cases (S/U-mode) are already covered by the arch tests.
+//   This test covers the suppressed case: the watchdog counter saturates
+//   (WFICount[WFI_TIMEOUT_BIT] = 1) while the hart is in M-mode with mstatus.TW=1.
+//   WFI is always legal in M-mode regardless of TW, so WFITimeoutM must stay 0
+//   and no illegal instruction is raised; the hart simply waits for a real
+//   interrupt.  Saturating the counter in M-mode with TW=1 exercises the
+//   (PrivilegeModeW != M_MODE) and (PrivilegeModeW == U_MODE) FEC terms in their
+//   false (no-timeout) direction, which PR #1783 stopped covering incidentally
+//   when it made the counter reset on every trap.
+//
+//   WFI_TIMEOUT_BIT = 16, so the counter saturates after 2^16 = 65536 cycles of
+//   continuous WFI.  MTIME increments once per cycle, so a timer deadline of
+//   0x14000 (81920) cycles guarantees the counter saturates before the interrupt
+//   wakes WFI.
+//
+// A component of the CORE-V-WALLY configurable RISC-V project.
+// https://github.com/openhwgroup/cvw
+//
+// Copyright (C) 2021-23 Harvey Mudd College & Oklahoma State University
+//
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+//
+// Licensed under the Solderpad Hardware License v 2.1 (the “License”); you may not use this file
+// except in compliance with the License, or, at your option, the Apache License version 2.0. You
+// may obtain a copy of the License at
+//
+// https://solderpad.org/licenses/SHL-2.1/
+//
+// Unless required by applicable law or agreed to in writing, any work distributed under the
+// License is distributed on an “AS IS” BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+// either express or implied. See the License for the specific language governing permissions
+// and limitations under the License.
+////////////////////////////////////////////////////////////////////////////////////////////////
+
+// load code to initialize stack, handle interrupts, terminate
+#include "WALLY-init-lib.h"
+
+main:
+    # Set mstatus.TW (bit 21).  TW must not affect WFI legality in M-mode.
+    li t0, 0x200000
+    csrs mstatus, t0
+
+    # Schedule a machine timer interrupt well past the WFI watchdog timeout.
+    li t1, 0x0200BFF8       # MTIME register in CLINT
+    ld t2, 0(t1)            # read current MTIME
+    li t3, 0x14000          # deadline offset > 2^16 cycles so the watchdog counter saturates first
+    add t2, t2, t3          # MTIMECMP = MTIME + offset
+    li t1, 0x02004000       # MTIMECMP register in CLINT
+    sd t2, 0(t1)
+
+    # Wait in M-mode.  The watchdog counter saturates while WFI is still stalled,
+    # but WFITimeoutM stays 0 because we are in M-mode, so no illegal instruction
+    # is raised.  The hart wakes when the timer interrupt fires.
+    wfi
+    nop                     # slack for the interrupt-return mepc adjustment in WALLY-init-lib.h
+    nop
+
+    j done


### PR DESCRIPTION
Detect livelock of trap handler trapping back to itself forever
Report tests that were silently failing when Imperas mismatched

regression-wally --ccov now finishes and generates report rather than hanging
