### PR TITLE
Fix install issue with buildroot on Ubuntu 26.04

### DIFF
--- a/bin/installation/activate-tools.sh
+++ b/bin/installation/activate-tools.sh
@@ -60,4 +60,10 @@ elif (( UBUNTU_VERSION == 20 )); then
         done
     fi
     export PATH="$RISCV"/gcc-10/bin:$PATH
+elif (( UBUNTU_VERSION == 26 )); then
+    if [ ! -e "$RISCV"/gnuinstall/bin/install ]; then
+        mkdir -p "$RISCV"/gnuinstall/bin
+        ln -vsf "$(which gnuinstall)" $RISCV/gnuinstall/bin/install
+    fi
+    export PATH="$RISCV"/gnuinstall/bin:$PATH
 fi

--- a/bin/installation/buildroot-install.sh
+++ b/bin/installation/buildroot-install.sh
@@ -44,7 +44,18 @@ STATUS="buildroot"
 export LD_LIBRARY_PATH=$RISCV/lib:$RISCV/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}:$RISCV/riscv64-unknown-elf/lib:$RISCV/lib/x86_64-linux-gnu
 cd "$WALLY"/linux
 if [ ! -e "$RISCV"/buildroot ]; then
-    FORCE_UNSAFE_CONFIGURE=1 make 2>&1 | logger; [ "${PIPESTATUS[0]}" == 0 ] # FORCE_UNSAFE_CONFIGURE is needed to allow buildroot to compile when run as root
+    if [ "$FAMILY" == ubuntu ] && ((UBUNTU_VERSION == 26)); then
+        # Buildroot currently does not work with the default version of install: https://github.com/uutils/coreutils/issues/12166
+        # The update-alternatives fix will not work here because it makes a permanent change
+        TMP_BIN=/tmp/riscv-bin
+        mkdir -p TMP_BIN
+        ln -sf "$(which gnuinstall)" $TMP_BIN/install
+        # FORCE_UNSAFE_CONFIGURE is needed to allow buildroot to compile when run as root
+        env PATH="$TMP_BIN:$PATH" FORCE_UNSAFE_CONFIGURE=1 make 2>&1 | logger; [ "${PIPESTATUS[0]}" == 0 ]
+        rm -r TMP_BIN
+    else
+        FORCE_UNSAFE_CONFIGURE=1 make 2>&1 | logger; [ "${PIPESTATUS[0]}" == 0 ] # FORCE_UNSAFE_CONFIGURE is needed to allow buildroot to compile when run as root
+    fi
     echo -e "${SUCCESS_COLOR}Buildroot successfully installed and Linux testvectors created!${ENDC}"
 elif [ ! -e "$RISCV"/linux-testvectors ]; then
     echo -e "${OK_COLOR}Buildroot already exists, but Linux testvectors are missing. Generating them now.${ENDC}"

--- a/bin/installation/buildroot-install.sh
+++ b/bin/installation/buildroot-install.sh
@@ -34,6 +34,7 @@ if [ -z "$FAMILY" ]; then
     WALLY="$(dirname $(dirname "$dir"))"
     export WALLY
     source "${dir}"/../wally-environment-check.sh
+    source "${dir}"/activate-tools.sh
 fi
 
 # Buildroot and Linux testvectors
@@ -44,18 +45,7 @@ STATUS="buildroot"
 export LD_LIBRARY_PATH=$RISCV/lib:$RISCV/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}:$RISCV/riscv64-unknown-elf/lib:$RISCV/lib/x86_64-linux-gnu
 cd "$WALLY"/linux
 if [ ! -e "$RISCV"/buildroot ]; then
-    if [ "$FAMILY" == ubuntu ] && ((UBUNTU_VERSION == 26)); then
-        # Buildroot currently does not work with the default version of install: https://github.com/uutils/coreutils/issues/12166
-        # The update-alternatives fix will not work here because it makes a permanent change
-        TMP_BIN=/tmp/riscv-bin
-        mkdir -p TMP_BIN
-        ln -sf "$(which gnuinstall)" $TMP_BIN/install
-        # FORCE_UNSAFE_CONFIGURE is needed to allow buildroot to compile when run as root
-        env PATH="$TMP_BIN:$PATH" FORCE_UNSAFE_CONFIGURE=1 make 2>&1 | logger; [ "${PIPESTATUS[0]}" == 0 ]
-        rm -r TMP_BIN
-    else
-        FORCE_UNSAFE_CONFIGURE=1 make 2>&1 | logger; [ "${PIPESTATUS[0]}" == 0 ] # FORCE_UNSAFE_CONFIGURE is needed to allow buildroot to compile when run as root
-    fi
+    FORCE_UNSAFE_CONFIGURE=1 make 2>&1 | logger; [ "${PIPESTATUS[0]}" == 0 ] # FORCE_UNSAFE_CONFIGURE is needed to allow buildroot to compile when run as root
     echo -e "${SUCCESS_COLOR}Buildroot successfully installed and Linux testvectors created!${ENDC}"
 elif [ ! -e "$RISCV"/linux-testvectors ]; then
     echo -e "${OK_COLOR}Buildroot already exists, but Linux testvectors are missing. Generating them now.${ENDC}"


### PR DESCRIPTION
The buildroot installation was failing due to a problem with the version of `install` provided in Ubuntu 26.04. The suggested solution is to run `update-alternatives --install /usr/bin/install install /usr/bin/gnuinstall 100`, however I think that is not a suitable solution for our install scripts, as it replaces `install` with `gnuinstall` even after our install script finishes running. Instead, the solution here symlinks `gnuinstall` into a temporary directory that is placed into `PATH`  to make the buildroot installation works without having other side effects.