### PR TITLE
Add a workaround for the latest imperas build

### DIFF
--- a/sim/questa/wally-compile.do
+++ b/sim/questa/wally-compile.do
@@ -64,7 +64,9 @@ if {[lcheck lst "--lockstep"]} {
     set IMPERAS_HOME $::env(IMPERAS_HOME)
     set lockstep 1
     set lockstepvlog "+incdir+${IMPERAS_HOME}/ImpPublic/include/host \
+                      +incdir+${IMPERAS_HOME}/ImpPublic/include/host/rvvi \
                       +incdir+${IMPERAS_HOME}/ImpProprietary/include/host \
+                      +incdir+${IMPERAS_HOME}/ImpProprietary/include/host/idv \
                       ${IMPERAS_HOME}/ImpPublic/source/host/rvvi/rvviApiPkg.sv \
                       ${IMPERAS_HOME}/ImpProprietary/source/host/idv/*.sv"
     if {$FCvlog eq ""} {append lockstepvlog " ${IMPERAS_HOME}/ImpPublic/source/host/rvvi/rvviTrace.sv"}

--- a/sim/vcs/run_vcs
+++ b/sim/vcs/run_vcs
@@ -55,7 +55,9 @@ def getCompileOptions(wkdir, args):
     compileOptions = []
     if args.lockstep:
         compileOptions.extend(["+incdir+$IMPERAS_HOME/ImpPublic/include/host",
+                                "+incdir+$IMPERAS_HOME/ImpPublic/include/host/rvvi",
                                 "+incdir+$IMPERAS_HOME/ImpProprietary/include/host",
+                                "+incdir+$IMPERAS_HOME/ImpProprietary/include/host/idv",
                                 "$IMPERAS_HOME/ImpPublic/source/host/rvvi/*.sv",
                                 "$IMPERAS_HOME/ImpProprietary/source/host/idv/*.sv"])
     if args.breker:


### PR DESCRIPTION
The way files are included changed in the latest imperas build. These changes are necessary to get it to run